### PR TITLE
Convert control statement bodies to blocks

### DIFF
--- a/src/main/java/edu/isi/karma/cleaning/ANode.java
+++ b/src/main/java/edu/isi/karma/cleaning/ANode.java
@@ -47,13 +47,15 @@ public class ANode {
 	// all constant node and same content
 	public boolean isvalid()
 	{
-		if(orgPos.size()<= 1)
+		if(orgPos.size()<= 1){
 			return true;
+		}
 		for(int i=1; i<orgPos.size(); i++)
 		{
 			int value = orgPos.get(i)*orgPos.get(i-1);
-			if(value < 0)
+			if(value < 0){
 				return false;
+			}
 			if(orgPos.get(i) <0)
 			{
 				String sub = this.exps.get(i)[1].substring(tarPos.get(i), tarPos.get(i)+length.get(i));

--- a/src/main/java/edu/isi/karma/cleaning/DataCollection.java
+++ b/src/main/java/edu/isi/karma/cleaning/DataCollection.java
@@ -67,8 +67,9 @@ public class DataCollection {
 				stats.get(fname)[0] += f.learnTime;
 				stats.get(fname)[2] += f.genTime;
 				stats.get(fname)[4] += f.execTime;
-				if(stats.get(fname)[6] < f.exp_cnt)
+				if(stats.get(fname)[6] < f.exp_cnt){
 					stats.get(fname)[6] = (double) f.exp_cnt;
+				}
 				stats.get(fname)[7] += f.ruleNo;
 				stats.get(fname)[8] += f.checkedrow;
 			}

--- a/src/main/java/edu/isi/karma/cleaning/ExampleSelection.java
+++ b/src/main/java/edu/isi/karma/cleaning/ExampleSelection.java
@@ -156,8 +156,9 @@ public class ExampleSelection {
 		HashMap<String, Integer> d = new HashMap<String, Integer>();
 		int score = 0;
 		for (int i = 0; i < vec.size(); i++) {
-			if (d.containsKey(vec.get(i).text))
+			if (d.containsKey(vec.get(i).text)){
 				continue;
+			}
 			for (int j = 0; j < vec.size(); j++) {
 				if (vec.get(j).text.compareTo(vec.get(i).text) == 0 && i != j
 						&& vec.get(j).text.compareTo(" ") != 0) {

--- a/src/main/java/edu/isi/karma/cleaning/Feature1.java
+++ b/src/main/java/edu/isi/karma/cleaning/Feature1.java
@@ -35,12 +35,14 @@ public class Feature1 implements RecFeature{
 	public double computerScore()
 	{
 		double res = 0.0;
-		if(xNodes == null)
+		if(xNodes == null){
 			return 0.0;
+		}
 		for(TNode x:xNodes)
 		{
-			if(x.text.compareTo(target)==0)
+			if(x.text.compareTo(target)==0){
 				res += 1;
+			}
 		}
 		return res;
 	}

--- a/src/main/java/edu/isi/karma/cleaning/Feature2.java
+++ b/src/main/java/edu/isi/karma/cleaning/Feature2.java
@@ -36,12 +36,14 @@ public class Feature2 implements RecFeature {
 	public double computerScore()
 	{
 		double res = 0.0;
-		if(xNodes == null)
+		if(xNodes == null){
 			return 0.0;
+		}
 		for(TNode x:xNodes)
 		{
-			if(x.type == type)
+			if(x.type == type){
 				res += 1;
+			}
 		}
 		return res;
 	}

--- a/src/main/java/edu/isi/karma/cleaning/Loop.java
+++ b/src/main/java/edu/isi/karma/cleaning/Loop.java
@@ -29,8 +29,9 @@ public class Loop implements GrammarTreeNode {
 		if(this.looptype == a.looptype)
 		{
 			Segment segment = this.loopbody.mergewith(a.loopbody);
-			if(segment == null)
+			if(segment == null){
 				return null;
+			}
 			Loop l = new Loop(segment, looptype);
 			return l;
 		}
@@ -42,8 +43,9 @@ public class Loop implements GrammarTreeNode {
 	public Loop mergewith(Segment a)
 	{
 		Segment segment = this.loopbody.mergewith(a);
-		if(segment == null)
+		if(segment == null){
 			return null;
+		}
 		Loop l = new Loop(segment, looptype);
 		return l;
 	}
@@ -74,9 +76,9 @@ public class Loop implements GrammarTreeNode {
 		else if(a.getNodeType().compareTo("Segment")==0)
 		{
 			return this.mergewith((Segment)a);
-		}
-		else
+		}else{
 			return null;
+		}
 	}
 	public String getNodeType()
 	{

--- a/src/main/java/edu/isi/karma/cleaning/MultipleStringAlign.java
+++ b/src/main/java/edu/isi/karma/cleaning/MultipleStringAlign.java
@@ -65,16 +65,18 @@ public class MultipleStringAlign {
 				length.add(e[2]-e[1]);
 			}
 			ANode aNode = new ANode(orgPos, tarPos, length, a.exps);
-			if(aNode.isvalid())
+			if(aNode.isvalid()){
 				a.addChild(aNode);
+			}
 		}
 	}
 	// iteratively generate the combinations
 	public void getCrossIndex(Vector<Long> indexs,Vector<Vector<Integer>> configs) {
 	    int k = indexs.size();
 		int[] com = new int[k];
-	    for (int i = 0; i < k; i++) 
-	    		com[i] = 0;
+	    for (int i = 0; i < k; i++){
+			com[i] = 0;
+		}
 	    while (com[k - 1] < indexs.get(k-1)) {
 	    		Vector<Integer> res = new Vector<Integer>();
 	        for (int i = 0; i < k; i++)
@@ -84,15 +86,17 @@ public class MultipleStringAlign {
 	        }
 	        configs.add(res);
 	        int t = k - 1;
-	        while (t != 0 && com[t] == indexs.get(t)-1) 
-	        		t--;
+	        while (t != 0 && com[t] == indexs.get(t)-1){
+				t--;
+			}
 	        com[t]++;
 	        if(t==0 && com[t] >= indexs.get(0))
 	        {
 	        		break;
 	        }
-	        for (int i = t + 1; i < k; i++) 
-	        		com[i] = 0;
+	        for (int i = t + 1; i < k; i++){
+				com[i] = 0;
+			}
 	    }
 	}
 	//{[orgstartPos, orgendPos ], ...}
@@ -105,8 +109,9 @@ public class MultipleStringAlign {
 			segs.add(elem);
 			return segs;
 		}
-		if (pos >= tar.length())
+		if (pos >= tar.length()){
 			return segs;
+		}
 		String tmp = "";
 		tmp += tar.charAt(pos);
 		// identify the const string	 
@@ -118,8 +123,9 @@ public class MultipleStringAlign {
 				tvec+= tar.charAt(cnt);
 				cnt++;
 				tmp = "";
-				if(cnt >= tar.length())
+				if(cnt >= tar.length()){
 					break;
+				}
 				tmp += tar.charAt(cnt);
 				q = org.indexOf(tmp);
 			}

--- a/src/main/java/edu/isi/karma/cleaning/OutlierDetector.java
+++ b/src/main/java/edu/isi/karma/cleaning/OutlierDetector.java
@@ -39,8 +39,9 @@ public class OutlierDetector {
 	}
 	public double getDistance(double[] x,double[] y)
 	{
-		if(x.length != y.length)
+		if(x.length != y.length){
 			return Double.MAX_VALUE;
+		}
 		double value = 0.0;
 		for(int i = 0; i<x.length; i++)
 		{
@@ -80,8 +81,9 @@ public class OutlierDetector {
 	// pid: [{rawstring, code}]
 	public void buildMeanVector(HashMap<String,Vector<String[]>> data)
 	{
-		if(data == null)
+		if(data == null){
 			return;
+		}
 		for(String key:data.keySet())
 		{
 			Vector<String[]> vs = data.get(key);

--- a/src/main/java/edu/isi/karma/cleaning/Position.java
+++ b/src/main/java/edu/isi/karma/cleaning/Position.java
@@ -27,8 +27,9 @@ public class Position implements GrammarTreeNode {
 		this.absPosition = absPos;
 		this.orgStrings.addAll(orgStrings);
 		this.tarStrings.addAll(tarStrings);
-		if (itInterpretor == null)
+		if (itInterpretor == null){
 			itInterpretor = new Interpretor();
+		}
 		// occurance of a reg pattern
 		this.counters.add(-1);
 		this.counters.add(1);
@@ -56,7 +57,9 @@ public class Position implements GrammarTreeNode {
 			if (!smap.keySet().contains(path)) {
 				String res = UtilTools.escape(path);
 				if (!smap.containsKey(res) && res.length() != 0)
+				 {
 					smap.put(res, value); // store the string of all sizes
+				}
 			}
 		}
 		if (x == null || x.size() == 0) {
@@ -67,16 +70,18 @@ public class Position implements GrammarTreeNode {
 				if (!smap.keySet().contains(path)) {
 					String res = UtilTools.escape(path);
 					if (!smap.containsKey(res) && res.length() != 0)
+					 {
 						smap.put(res, value); // store the string of all sizes
+					}
 				}
 			}
 			return;
 		}
 		TNode t = x.get(cur);
 		if (t.text.compareTo("ANYTOK") != 0 && t.text.length() > 0) {
-			if (!isleft)
+			if (!isleft){
 				getString(x, cur + 1, path + t.text, value + 2, smap, false);
-			else {
+			}else {
 				getString(x, cur - 1, t.text + path, value + 2, smap, true);
 			}
 		}
@@ -102,9 +107,9 @@ public class Position implements GrammarTreeNode {
 		} else {
 			s += "" + t.getType();
 		}
-		if (!isleft)
+		if (!isleft){
 			getString(x, cur + 1, path + s, value + 1, smap, false);
-		else {
+		}else {
 			getString(x, cur - 1, s + path, value + 1, smap, true);
 		}
 	}
@@ -113,9 +118,9 @@ public class Position implements GrammarTreeNode {
 	public Vector<TNode> mergeCNXT(Vector<TNode> a, Vector<TNode> b,
 			String option) {
 		Vector<TNode> xNodes = new Vector<TNode>();
-		if (a == null || b == null)
+		if (a == null || b == null){
 			return null;
-		else {
+		}else {
 			int leng = Math.min(a.size(), b.size());
 			if (option.compareTo(Segment.LEFTPOS) == 0) {
 				for (int i = 1; i <= leng; i++) {
@@ -161,14 +166,16 @@ public class Position implements GrammarTreeNode {
 				}
 			}
 		}
-		if (xNodes.size() == 0)
+		if (xNodes.size() == 0){
 			return null;
+		}
 		return xNodes;
 	}
 
 	public Position mergewith(Position b) {
-		if (this == null || b == null)
+		if (this == null || b == null){
 			return null;
+		}
 		Vector<Integer> tmpIntegers = new Vector<Integer>();
 		tmpIntegers.addAll(this.absPosition);
 		tmpIntegers.retainAll(b.absPosition);
@@ -184,8 +191,9 @@ public class Position implements GrammarTreeNode {
 		// this.leftContextNodes = g_lcxtNodes;
 		// this.rightContextNodes = g_rcxtNodes;
 		if (tmpIntegers.size() == 0 && g_lcxtNodes == null
-				&& g_rcxtNodes == null)
+				&& g_rcxtNodes == null){
 			return null;
+		}
 		boolean loop = this.isinloop || b.isinloop;
 
 		Vector<String> aStrings = new Vector<String>();
@@ -251,9 +259,9 @@ public class Position implements GrammarTreeNode {
 		if (this.rightContextNodes != null) {
 			rsize = rightContextNodes.size();
 		}
-		if (lsize == 0 && rsize == 0)
+		if (lsize == 0 && rsize == 0){
 			return 1;
-		else {
+		}else {
 			for (int i = 0; i < lsize; i++) {
 				if (leftContextNodes.get(i).text.compareTo("ANYTOK") != 0
 						&& leftContextNodes.get(i).type != TNode.ANYTYP) {
@@ -277,21 +285,25 @@ public class Position implements GrammarTreeNode {
 	public Vector<String> rules = new Vector<String>();
 
 	public String toProgram() {
-		if (curState >= rules.size())
+		if (curState >= rules.size()){
 			return "null";
+		}
 		String rule = rules.get(curState);
-		if (!isinloop)
+		if (!isinloop){
 			rule = rule.replace("counter", counters.get(1) + "");
+		}
 		curState++;
 		return rule;
 	}
 
 	public String getRule(int index) {
-		if (index >= rules.size())
+		if (index >= rules.size()){
 			return "null";
+		}
 		String rule = rules.get(index);
-		if (!isinloop)
+		if (!isinloop){
 			rule = rule.replace("counter", counters.get(1) + "");
+		}
 		return rule;
 	}
 
@@ -322,23 +334,27 @@ public class Position implements GrammarTreeNode {
 						ProgramRule programRule = new ProgramRule(tmpRule);
 						String val = programRule.transform(this.orgStrings
 								.get(j));
-						if(val.indexOf("None")!= -1)
+						if(val.indexOf("None")!= -1){
 							break;
+						}
 						r += val+",";
 						cnt ++;
 					}
-					if(r.length()<=1)
+					if(r.length()<=1){
 						return "null";
+					}
 					if (this.tarStrings.get(j).compareTo(r.substring(0,r.length()-1)) != 0) {
 						isvalid = false;
 						break;
 					}
 				}
 				if (isvalid) {
-					if(itercnt == 0)
+					if(itercnt == 0){
 						return rule;
-					else
+					}
+					else {
 						itercnt--; // valid number - 1
+					}
 				}
 
 			} else {
@@ -353,10 +369,11 @@ public class Position implements GrammarTreeNode {
 					}
 				}
 				if (isValid) {
-					if(itercnt == 0)
+					if(itercnt == 0){
 						return rule;
-					else
+					}else{
 						itercnt--;
+					}
 				}
 			}
 		}
@@ -384,8 +401,9 @@ public class Position implements GrammarTreeNode {
 		String negString = "";
 		for (String a : lMap.keySet()) {
 			for (String b : rMap.keySet()) {
-				if (a.compareTo(b) == 0 && a.compareTo("ANY") == 0)
+				if (a.compareTo(b) == 0 && a.compareTo("ANY") == 0){
 					continue;
+				}
 				Double key = lMap.get(a) + rMap.get(b);
 				reString = String.format(
 						"indexOf(value,\'%s\',\'%s\',counter)", a, b);

--- a/src/main/java/edu/isi/karma/cleaning/ProgSynthesis.java
+++ b/src/main/java/edu/isi/karma/cleaning/ProgSynthesis.java
@@ -100,8 +100,9 @@ public class ProgSynthesis {
 				}
 			}
 		}
-		if (pos[0] != -1 && pos[1] != -1)
+		if (pos[0] != -1 && pos[1] != -1){
 			UpdatePartitions(pos[0], pos[1], pars);
+		}
 	}
 
 	public void UpdatePartitions(int i, int j, Vector<Partition> pars) {
@@ -136,8 +137,9 @@ public class ProgSynthesis {
 		long startTime = System.currentTimeMillis();
 		while (i < prog_cnt) {
 			ProgramRule r = prog.toProgram1();
-			if (r == null)
+			if (r == null){
 				return null;
+			}
 			String xString = "";
 			int termCnt = 0;
 			boolean findRule = true;
@@ -157,9 +159,10 @@ public class ProgSynthesis {
 				for (Partition p : prog.partitions) {
 					if (p.label.compareTo(xString) == 0) {
 						String newRule = p.toProgram();
-						if (ConfigParameters.debug == 1)
+						if (ConfigParameters.debug == 1){
 							System.out.println("updated Rule: " + p.label
 									+ ": " + newRule);
+						}
 						if (newRule.contains("null")) {
 							findRule = false;
 							break;
@@ -169,8 +172,9 @@ public class ProgSynthesis {
 				}
 				termCnt++;
 			}
-			if (findRule)
+			if (findRule){
 				rules.add(r);
+			}
 			this.ruleNo += termCnt; // accumulate the no of rules while the
 			i++;
 		}

--- a/src/main/java/edu/isi/karma/cleaning/Program.java
+++ b/src/main/java/edu/isi/karma/cleaning/Program.java
@@ -13,11 +13,13 @@ public class Program implements GrammarTreeNode {
 		for(int i=0;i<this.partitions.size();i++)
 		{
 			this.partitions.get(i).setLabel("attr_"+i);
-			if(ConfigParameters.debug == 1)
+			if(ConfigParameters.debug == 1){
 				System.out.println(this.partitions.get(i).toString());
+			}
 		}
-		if(partitions.size()>1)
+		if(partitions.size()>1){
 			this.learnClassifier();
+		}
 	}
 	public void learnClassifier()
 	{
@@ -73,11 +75,13 @@ public class Program implements GrammarTreeNode {
 					continue;
 				}
 				String rule = p.toProgram();
-				if(rule.contains("null"))
+				if(rule.contains("null")){
 					return null;
+				}
 				pr.addRule(p.label, rule);
-				if(ConfigParameters.debug == 1)
+				if(ConfigParameters.debug == 1){
 					System.out.println(pr.getStringRule(p.label));
+				}
 				score += p.getScore();
 			}
 			score = score/this.partitions.size();
@@ -96,10 +100,12 @@ public class Program implements GrammarTreeNode {
 				return pr;
 			}
 			String s = partitions.get(0).toProgram();
-			if(s.contains("null"))
+			if(s.contains("null")){
 				return null;
-			if(ConfigParameters.debug == 1)
+			}
+			if(ConfigParameters.debug == 1){
 				System.out.println(""+s);
+			}
 			score = this.partitions.get(0).getScore();
 			pr.addRule(partitions.get(0).label, s);
 			return pr;

--- a/src/main/java/edu/isi/karma/cleaning/ProgramRule.java
+++ b/src/main/java/edu/isi/karma/cleaning/ProgramRule.java
@@ -30,8 +30,9 @@ public class ProgramRule {
 	}
 	public void initInterpretor()
 	{
-		if(itInterpretor == null)
+		if(itInterpretor == null){
 			itInterpretor = new Interpretor();
+		}
 	}
 	public InterpreterType getRuleForValue(String value)
 	{
@@ -42,8 +43,9 @@ public class ProgramRule {
 	public String getClassForValue(String value)
 	{
 		String labelString = "attr_0";
-		if(value.length() == 0)
+		if(value.length() == 0){
 			return labelString;
+		}
 		if(pClassifier != null)
 		{
 			labelString = pClassifier.getLabel(value);

--- a/src/main/java/edu/isi/karma/cleaning/RecordDistiller.java
+++ b/src/main/java/edu/isi/karma/cleaning/RecordDistiller.java
@@ -216,8 +216,9 @@ public class RecordDistiller {
 					int id = 0;
 					HashMap<String, String> id2String = new HashMap<String, String>();
 					while ((pair = cr.readNext()) != null) {
-						if (pair == null || pair.length <= 1)
+						if (pair == null || pair.length <= 1){
 							break;
+						}
 						Ruler ruler = new Ruler();
 						ruler.setNewInput(pair[0]);
 						distiller.readRecord(""+id, ruler.vec);

--- a/src/main/java/edu/isi/karma/cleaning/Ruler.java
+++ b/src/main/java/edu/isi/karma/cleaning/Ruler.java
@@ -132,15 +132,16 @@ public class Ruler {
 			if(option.compareTo("from_beginning")==0)
 			{
 				int pos = Ruler.Search(vec,t, 0);
-				if(pos == -1)
+				if(pos == -1){
 					return -1;
+				}
 				if(incld)
 				{
 					return pos;
 				}
 				else
 				{
-					if(pos<vec.size())
+					if(pos<vec.size()){
 						if(pos>0)
 						{
 							return pos-1;
@@ -148,9 +149,9 @@ public class Ruler {
 						else {
 							return 0;
 						}
-						
-					else
+					}else{
 						return vec.size()-1;
+					}
 				}
 				
 			}
@@ -159,21 +160,24 @@ public class Ruler {
 				Vector<TNode> tmpvec = (Vector<TNode>)this.vec.clone();
 				Collections.reverse(tmpvec);
 				int pos = Ruler.Search(tmpvec,t, 0);
-				if(pos == -1)
+				if(pos == -1){
 					return -1;
+				}
 				if(incld)
 				{
-					if(this.vec.size()- pos-1>=0 && this.vec.size()- pos-1 <= vec.size())
+					if(this.vec.size()- pos-1>=0 && this.vec.size()- pos-1 <= vec.size()){
 						return this.vec.size()- pos-1;
-					else
+					}else{
 						return 0;
+					}
 				}
 				else
 				{
-					if(this.vec.size()- pos>=0 && this.vec.size()- pos <= vec.size())
+					if(this.vec.size()- pos>=0 && this.vec.size()- pos <= vec.size()){
 						return this.vec.size()- pos;
-					else
+					}else{
 						return 0;
+					}
 				}
 			}
 		}
@@ -282,16 +286,17 @@ public class Ruler {
 		for(int i =0;i<vec.size();i++)
 		{
 			String type = "";
-			if(vec.get(i).type==TNode.LWRDTYP)
+			if(vec.get(i).type==TNode.LWRDTYP){
 				type = "LWRD";
-			else if(vec.get(i).type==TNode.UWRDTYP)
+			}else if(vec.get(i).type==TNode.UWRDTYP){
 				type = "UWRD";
-			else if(vec.get(i).type==TNode.SYBSTYP)
+			}else if(vec.get(i).type==TNode.SYBSTYP){
 				type = "SYB";
-			else if(vec.get(i).type==TNode.NUMTYP)
+			}else if(vec.get(i).type==TNode.NUMTYP){
 				type = "NUM";
-			else if(vec.get(i).type==TNode.BNKTYP)
+			}else if(vec.get(i).type==TNode.BNKTYP){
 				type = "BNK";
+			}
 			res += vec.get(i).text+"<"+type+">";
 		}
 		return res;

--- a/src/main/java/edu/isi/karma/cleaning/Section.java
+++ b/src/main/java/edu/isi/karma/cleaning/Section.java
@@ -18,11 +18,12 @@ public class Section implements GrammarTreeNode {
 		pair = p;
 		this.orgStrings = orgStrings;
 		this.tarStrings = tarStrings;
-		if(itInterpretor==null)
+		if(itInterpretor==null){
 			itInterpretor =  new Interpretor();
-		if(supermode == 0)
+		}
+		if(supermode == 0){
 			this.createTotalOrderVector();
-		else
+		}else
 		{
 			this.reiniteRules();
 		}
@@ -65,9 +66,9 @@ public class Section implements GrammarTreeNode {
 		Section sec = (Section)a;
 		Position x = this.pair[0].mergewith(sec.pair[0]);
 		Position y = this.pair[1].mergewith(sec.pair[1]);
-		if(x== null || y == null)
+		if(x== null || y == null){
 			return null;
-		else
+		}else
 		{
 			Position[] pa = {x,y};
 			boolean loop = this.isinloop || sec.isinloop;
@@ -166,8 +167,9 @@ public class Section implements GrammarTreeNode {
 	}
 	public String getRule(long index)
 	{
-		if(index > this.rules.size())
+		if(index > this.rules.size()){
 			return "null";
+		}
 		String rule = "";
 		int[] loc = this.rules.get(((int)index));
 		pair[0].isinloop = this.isinloop;

--- a/src/main/java/edu/isi/karma/cleaning/Segment.java
+++ b/src/main/java/edu/isi/karma/cleaning/Segment.java
@@ -59,8 +59,9 @@ public class Segment implements GrammarTreeNode {
 		else
 		{
 			repString += tarNodes.get(this.start).getType();
-			if(end >start+1)
+			if(end >start+1){
 				repString += tarNodes.get(this.end-1).getType();
+			}
 		}
 		this.createTotalOrderVector();
 	}
@@ -97,8 +98,9 @@ public class Segment implements GrammarTreeNode {
 		Vector<TNode> res = new Vector<TNode>();
 		while(i<Segment.cxtsize_limit)
 		{
-			if((c+i)>=x.size())
+			if((c+i)>=x.size()){
 				break;
+			}
 			res.add(x.get(c+i));
 			i++;
 		}
@@ -248,8 +250,9 @@ public class Segment implements GrammarTreeNode {
 				}
 			}
 		}
-		if(newSections.size() ==0)
+		if(newSections.size() ==0){
 			return null;
+		}
 		boolean loop = this.isinloop || s.isinloop;
 		Segment res = new Segment(newSections,loop);
 		return res;
@@ -367,8 +370,9 @@ public class Segment implements GrammarTreeNode {
 		while(curState<rules.size() && s.contains("null"))
 		{
 			s = section.get(rules.get(curState)).toProgram();
-			if(s.contains("null"))
+			if(s.contains("null")){
 				curState ++;
+			}
 		}
 		return s;
 	}

--- a/src/main/java/edu/isi/karma/cleaning/TNode.java
+++ b/src/main/java/edu/isi/karma/cleaning/TNode.java
@@ -127,16 +127,18 @@ public class TNode{
 		{
 			return true;
 		}
-		if(this.type == t.type)
+		if(this.type == t.type){
 			return true;
+		}
 		return false;
 	}
 	public int mergableType(TNode t)
 	{
 		 
 		boolean res = this.sameType(t);
-		if(res)
+		if(res){
 			return this.type;
+		}
 		if((this.type == TNode.UWRDTYP || this.type == TNode.LWRDTYP || this.type == TNode.WORD) &&(t.type == TNode.LWRDTYP || t.type == TNode.UWRDTYP || t.type == TNode.WORD))
 		{
 			return TNode.WORD;

--- a/src/main/java/edu/isi/karma/cleaning/Template.java
+++ b/src/main/java/edu/isi/karma/cleaning/Template.java
@@ -61,8 +61,9 @@ public class Template implements GrammarTreeNode {
 	public void getCrossIndex(Vector<Long> indexs,Vector<Vector<Integer>> configs) {
 	    int k = indexs.size();
 		int[] com = new int[k];
-	    for (int i = 0; i < k; i++) 
-	    		com[i] = 0;
+	    for (int i = 0; i < k; i++){
+			com[i] = 0;
+		}
 	    while (com[k - 1] < indexs.get(k-1)) {
 	    		Vector<Integer> res = new Vector<Integer>();
 	        for (int i = 0; i < k; i++)
@@ -75,15 +76,17 @@ public class Template implements GrammarTreeNode {
 				return;
 			}
 	        int t = k - 1;
-	        while (t != 0 && com[t] == indexs.get(t)-1) 
-	        		t--;
+	        while (t != 0 && com[t] == indexs.get(t)-1){
+				t--;
+			}
 	        com[t]++;
 	        if(t==0 && com[t] >= indexs.get(0))
 	        {
 	        		break;
 	        }
-	        for (int i = t + 1; i < k; i++) 
-	        		com[i] = 0;
+	        for (int i = t + 1; i < k; i++){
+				com[i] = 0;
+			}
 	    }
 	}
 	public String prog1(){
@@ -94,14 +97,16 @@ public class Template implements GrammarTreeNode {
 			if (gt.getNodeType().compareTo("segment") == 0) {
 				Segment seg = (Segment)gt;
 				String s = seg.verifySpace();
-				if (s.indexOf("null")!= -1)
+				if (s.indexOf("null")!= -1){
 					return "null";
+				}
 				res += s+"+";
 			} else if (gt.getNodeType().compareTo("loop") == 0) {
 				Loop p = (Loop) gt;
 				String x = p.verifySpace();
-				if(x.indexOf("null")!= -1)
+				if(x.indexOf("null")!= -1){
 					return "null";
+				}
 				if (p.looptype == Loop.LOOP_START) {
 					res += "loop(value,r\"" + x + "+";
 				} else if (p.looptype == Loop.LOOP_END) {
@@ -138,8 +143,9 @@ public class Template implements GrammarTreeNode {
 	}
 	public String prog0() {
 		while (true) {
-			if (curState >= indexes.size())
+			if (curState >= indexes.size()){
 				return "null";
+			}
 			Vector<Integer> xIntegers = indexes.get(curState);
 			String res = "";
 			for (int i = 0; i < xIntegers.size(); i++) {

--- a/src/main/java/edu/isi/karma/cleaning/Test.java
+++ b/src/main/java/edu/isi/karma/cleaning/Test.java
@@ -51,15 +51,17 @@ public class Test {
 					String[] pair;
 					int index = 0;
 					while ((pair = cr.readNext()) != null) {
-						if (pair == null || pair.length <= 1)
+						if (pair == null || pair.length <= 1){
 							break;
+						}
 						entries.add(pair);
 						String[] line = {pair[0],pair[1],"","","wrong"}; // org, tar, tarcode, label
 						xHashMap.put(index + "", line);
 						index++;
 					}
-					if (entries.size() <= 1)
+					if (entries.size() <= 1){
 						continue;
+					}
 					ExampleSelection expsel = new ExampleSelection();
 					expsel.firsttime = true;
 					expsel.inite(xHashMap,null);
@@ -78,14 +80,15 @@ public class Test {
 						psProgSynthesis.inite(examples);
 						Vector<ProgramRule> pls = new Vector<ProgramRule>();
 						Collection<ProgramRule> ps = psProgSynthesis.run_main();
-						if (ps != null)
+						if (ps != null){
 							pls.addAll(ps);
-						else {
+						}else {
 							System.out.println("Cannot find any rule");
 						}
 						String[] wexam = null;
-						if (pls.size() == 0)
+						if (pls.size() == 0){
 							break;
+						}
 						long t1 = System.currentTimeMillis();
 						
 						for (int i = 0; i < pls.size(); i++) {
@@ -101,8 +104,9 @@ public class Test {
 								UtilTools.StringColorCode(entries.get(j)[0], tmps, dict);
 								String s = dict.get("Tar");
 								res += s+"\n";
-								if (ConfigParameters.debug == 1)
+								if (ConfigParameters.debug == 1){
 									System.out.println("result:   " + dict.get("Tardis"));
+								}
 								if (s == null || s.length() == 0) {
 									String[] ts = {"<_START>" + entries.get(j)[0] + "<_END>","",tmps,classlabel,"wrong"};
 									xHashMap.put(j + "", ts);
@@ -156,8 +160,9 @@ public class Test {
 									xHashMap.put(j + "", ts);			
 								}
 							}
-							if (wexam == null)
+							if (wexam == null){
 								break;
+							}
 							resultString.add(res);
 						}
 						records.put(f.getName()+examples.size(), resultString);
@@ -251,11 +256,13 @@ public class Test {
 			psProgSynthesis.inite(tmp);
 			Vector<ProgramRule> pls = new Vector<ProgramRule>();
 			Collection<ProgramRule> ps = psProgSynthesis.run_main();
-			if (ps != null)
+			if (ps != null){
 				pls.addAll(ps);
+			}
 			String[] wexam = null;
-			if (pls.size() == 0)
+			if (pls.size() == 0){
 				break;
+			}
 			for (int i = 0; i < pls.size(); i++) {
 				ProgramRule script = pls.get(i);
 				for (int j = 0; j < all.size(); j++) {
@@ -304,12 +311,14 @@ public class Test {
 							'\0');
 					String[] pair;
 					while ((pair = cr.readNext()) != null) {
-						if (pair == null || pair.length <= 1)
+						if (pair == null || pair.length <= 1){
 							break;
+						}
 						entries.add(pair);
 					}
-					if (entries.size() <= 1)
+					if (entries.size() <= 1){
 						continue;
+					}
 					int cnt = 0;
 					Vector<String[]> candStrings = new Vector<String[]>();
 					candStrings.addAll(entries);

--- a/src/main/java/edu/isi/karma/cleaning/TestJAVA.java
+++ b/src/main/java/edu/isi/karma/cleaning/TestJAVA.java
@@ -29,8 +29,9 @@ public class TestJAVA {
 	void generate_combos(Vector<Long> indexs,Vector<Vector<Integer>> configs) {
 	    int k = indexs.size();
 		int[] com = new int[k];
-	    for (int i = 0; i < k; i++) 
-	    		com[i] = 0;
+	    for (int i = 0; i < k; i++){
+			com[i] = 0;
+		}
 	    while (com[k - 1] < indexs.get(k-1)) {
 	    		Vector<Integer> res = new Vector<Integer>();
 	        for (int i = 0; i < k; i++)
@@ -41,15 +42,17 @@ public class TestJAVA {
 	        //System.out.println("");
 	        configs.add(res);
 	        int t = k - 1;
-	        while (t != 0 && com[t] == indexs.get(t)-1) 
-	        		t--;
+	        while (t != 0 && com[t] == indexs.get(t)-1){
+				t--;
+			}
 	        com[t]++;
 	        if(t==0 && com[t] >= indexs.get(0))
 	        {
 	        		break;
 	        }
-	        for (int i = t + 1; i < k; i++) 
-	        		com[i] = 0;
+	        for (int i = t + 1; i < k; i++){
+				com[i] = 0;
+			}
 	    }
 	}
 	public static void main(String[] args)

--- a/src/main/java/edu/isi/karma/cleaning/Tokenizer.java
+++ b/src/main/java/edu/isi/karma/cleaning/Tokenizer.java
@@ -135,7 +135,9 @@ public class Tokenizer extends Lexer {
             	    break;
 
             	default :
-            	    if ( cnt1 >= 1 ) break loop1;
+            	    if ( cnt1 >= 1 ){
+						break loop1;
+					}
                         EarlyExitException eee =
                             new EarlyExitException(1, input);
                         throw eee;
@@ -193,7 +195,9 @@ public class Tokenizer extends Lexer {
             	    break;
 
             	default :
-            	    if ( cnt2 >= 1 ) break loop2;
+            	    if ( cnt2 >= 1 ){
+						break loop2;
+					}
                         EarlyExitException eee =
                             new EarlyExitException(2, input);
                         throw eee;

--- a/src/main/java/edu/isi/karma/cleaning/Traces.java
+++ b/src/main/java/edu/isi/karma/cleaning/Traces.java
@@ -78,9 +78,9 @@ public class Traces implements GrammarTreeNode {
 				lines.add(segs);
 				break;
 			}
-			if (pos2Segs.containsKey(curPos))
+			if (pos2Segs.containsKey(curPos)){
 				children = pos2Segs.get(curPos);
-			else {
+			}else {
 				children = findSegs(curPos);
 			}
 			if (children == null || children.size() == 0) {
@@ -110,8 +110,9 @@ public class Traces implements GrammarTreeNode {
 				break; // otherwise takes too much time
 			}
 			Vector<Vector<GrammarTreeNode>> lLine = this.genLoop(vgt);
-			if (lLine != null)
+			if (lLine != null){
 				lSeg.addAll(lLine);
+			}
 		}
 		// consolidate
 		this.traceline = consolidateDiffSize(vSeg);
@@ -130,8 +131,9 @@ public class Traces implements GrammarTreeNode {
 			segs.add(s);
 			return segs;
 		}
-		if (pos >= tarNodes.size())
+		if (pos >= tarNodes.size()){
 			return segs;
+		}
 		Vector<TNode> tmp = new Vector<TNode>();
 		tmp.add(tarNodes.get(pos));
 		// identify the const string	
@@ -143,8 +145,9 @@ public class Traces implements GrammarTreeNode {
 				tvec.add(tarNodes.get(cnt));
 				cnt++;
 				tmp.clear();
-				if(cnt >= tarNodes.size())
+				if(cnt >= tarNodes.size()){
 					break;
+				}
 				tmp.add(tarNodes.get(cnt));
 				q = Ruler.Search(orgNodes, tmp, 0);
 			}
@@ -191,8 +194,9 @@ public class Traces implements GrammarTreeNode {
 					s = new Segment(pos, i + 1, corrm, orgNodes, tarNodes);
 					AllSegs.put(key, s);
 				}
-				if(s.section.size() >0)
+				if(s.section.size() >0){
 					segs.add(s);
+				}
 				continue;
 			} else if (mappings.size() == 1) {
 				Vector<int[]> corrm = new Vector<int[]>();
@@ -212,8 +216,9 @@ public class Traces implements GrammarTreeNode {
 						s = new Segment(pos, i + 1, corrm, orgNodes, tarNodes);
 						AllSegs.put(key, s);
 					}
-					if(s.section.size() >0)
+					if(s.section.size() >0){
 						segs.add(s);
+					}
 				} else {
 					tvec.add(tarNodes.get(i + 1));
 					int p = Ruler.Search(orgNodes, tvec, 0);
@@ -241,8 +246,9 @@ public class Traces implements GrammarTreeNode {
 							s = new Segment(pos, i + 1, corrm, orgNodes, tarNodes);
 							AllSegs.put(key, s);
 						}
-						if(s.section.size() > 0)
+						if(s.section.size() > 0){
 							segs.add(s);
+						}
 					} else {
 						continue;
 					}
@@ -266,8 +272,9 @@ public class Traces implements GrammarTreeNode {
 			//System.out.println(""+line1+"\n");
 			//System.out.println(""+line2+"\n");
 			Template nLine = (Template)line1.mergewith(line2);
-			if(nLine == null)
+			if(nLine == null){
 				continue;
+			}
 			boolean isfind = true;
 			nLines.put(index, nLine);
 		}
@@ -283,8 +290,9 @@ public class Traces implements GrammarTreeNode {
 				//System.out.println(""+line1+"\n");
 				//System.out.println(""+t.loopline.get(index).get(line2)+"\n");
 				Template nLine = (Template)line1.mergewith(t.loopline.get(index).get(line2));
-				if(nLine == null)
+				if(nLine == null){
 					continue;
+				}
 				if (allLoops.containsKey(index)) {
 					if(allLoops.get(index).containsKey(line2))
 					{
@@ -316,8 +324,9 @@ public class Traces implements GrammarTreeNode {
 				//System.out.println(""+line1+"\n");
 				//System.out.println(""+this.loopline.get(index).get(line2)+"\n");
 				Template nLine = (Template)line1.mergewith(this.loopline.get(index).get(line2));
-				if(nLine == null)
+				if(nLine == null){
 					continue;
+				}
 				if (allLoops.containsKey(index)) {
 					if(allLoops.get(index).containsKey(line2))
 					{
@@ -355,8 +364,9 @@ public class Traces implements GrammarTreeNode {
 					//System.out.println(""+this.loopline.get(index).get(line1)+"\n");
 					//System.out.println(""+t.loopline.get(index).get(line2)+"\n");
 					Template nLine = (Template) this.loopline.get(index).get(line1).mergewith(t.loopline.get(index).get(line2));
-					if(nLine == null)
+					if(nLine == null){
 						continue;
+					}
 					if (allLoops.containsKey(index)) {
 						if(allLoops.get(index).containsKey(line2))
 						{
@@ -395,8 +405,9 @@ public class Traces implements GrammarTreeNode {
 				
 			}
 		}
-		if (lLines.keySet().size() == 0 && nLines.keySet().size() == 0)
+		if (lLines.keySet().size() == 0 && nLines.keySet().size() == 0){
 			return null;
+		}
 		Traces rTraces = new Traces(nLines, lLines);
 		return rTraces;
 	}
@@ -436,10 +447,11 @@ public class Traces implements GrammarTreeNode {
 			}
 			boolean loop = s.isinloop || t.isinloop;
 			Segment r;
-			if(s.isConstSegment() && t.isConstSegment())
+			if(s.isConstSegment() && t.isConstSegment()){
 				r = new Segment(sec,loop);
-			else
+			}else{
 				r = s;
+			}
 			return r;
 		}
 		if (x.getNodeType().compareTo("loop") == 0
@@ -478,9 +490,9 @@ public class Traces implements GrammarTreeNode {
 			if (s.looptype == t.looptype)
 			{
 				Segment loopbody;
-				if(s.loopbody.isConstSegment() && t.loopbody.isConstSegment())
+				if(s.loopbody.isConstSegment() && t.loopbody.isConstSegment()){
 					loopbody= s.loopbody;
-				else {
+				}else {
 					loopbody = new Segment(sec,true);
 				}
 				r = new Loop(loopbody, t.looptype);
@@ -516,8 +528,9 @@ public class Traces implements GrammarTreeNode {
 				}
 			} else {
 				Vector<Template> xVector = new Vector<Template>();
-				if(!isLegalVS(vg))
+				if(!isLegalVS(vg)){
 					continue;
+				}
 				xVector.add(new Template(vg));
 				HashMap<String, Vector<Template>> xHashMap = new HashMap<String, Vector<Template>>();
 				xHashMap.put(subkey, xVector);
@@ -558,8 +571,9 @@ public class Traces implements GrammarTreeNode {
 				tmpStore.get(key).add(new Template(vg));
 			} else {
 				Vector<Template> xVector = new Vector<Template>();
-				if(!isLegalVS(vg))
+				if(!isLegalVS(vg)){
 					continue;
+				}
 				xVector.add(new Template(vg));
 				tmpStore.put(key, xVector);
 			}
@@ -576,8 +590,9 @@ public class Traces implements GrammarTreeNode {
 	{
 		for(GrammarTreeNode t:x)
 		{
-			if(t.size()<=0)
+			if(t.size()<=0){
 				return false;
+			}
 		}
 		return true;
 	}
@@ -615,17 +630,19 @@ public class Traces implements GrammarTreeNode {
 		}
 		for (String key : map.keySet()) {
 			Vector<Integer> v = map.get(key);
-			if (v.size() <= 1 || !this.verfiyLoop(v, curPath))
+			if (v.size() <= 1 || !this.verfiyLoop(v, curPath)){
 				continue;
+			}
 			Vector<Vector<GrammarTreeNode>> vtn = this.detectLoop(v, curPath);
 			if (vtn != null && vtn.size() > 0) {
 				res.addAll(vtn);
 			}
 		}
-		if(res.size() ==0)
+		if(res.size() ==0){
 			return null;
-		else
+		}else{
 			return res;
+		}
 	}
 	//if there is a cross of the mapping. the loop doesn't exist
 	public boolean verfiyLoop(Vector<Integer> vx,Vector<Segment> segs)
@@ -666,8 +683,9 @@ public class Traces implements GrammarTreeNode {
 	
 	public Vector<GrammarTreeNode> subVector(Vector<Segment> nodes, int start, int end)
 	{
-		if(start>=end || start <0 || end>nodes.size())
+		if(start>=end || start <0 || end>nodes.size()){
 			return null;
+		}
 		Vector<GrammarTreeNode> vgt = new Vector<GrammarTreeNode>();
 		for(int i = start; i< end; i++)
 		{
@@ -710,8 +728,9 @@ public class Traces implements GrammarTreeNode {
 				Vector<GrammarTreeNode> elem = new Vector<GrammarTreeNode>();
 				Vector<GrammarTreeNode> mx = gt.get(j);
 				Vector<GrammarTreeNode> nx = gt.get(j+1);
-				if(mx.size() != nx.size())
+				if(mx.size() != nx.size()){
 					return null;
+				}
 				
 				for(int r = 0; r< mx.size(); r++)
 				{
@@ -733,7 +752,9 @@ public class Traces implements GrammarTreeNode {
 				}
 			}
 			if(!isLegal)
+			 {
 				return null; // nothing merged in this iteration;
+			}
 			gt = tmp_gt;
 			itercnt ++;
 			if(gt.size() == presize)
@@ -746,8 +767,9 @@ public class Traces implements GrammarTreeNode {
 			}
 		}
 		//only detect one loop
-		if(gt.size() >1)
+		if(gt.size() >1){
 			return null;
+		}
 		//
 		for(int i = 0; i<nodes.size(); i++)
 		{
@@ -805,8 +827,9 @@ public class Traces implements GrammarTreeNode {
 					nodelist.add(curPath.get(i));
 				} else if ( i == endpos) {
 					Vector<GrammarTreeNode> sublist = this.createLoop(subVector(curPath, startpos, endpos+1), 1);
-					if(sublist == null)
+					if(sublist == null){
 						return null;
+					}
 					nodelist.addAll(sublist);
 				} else if (i > endpos) {
 					nodelist.add(curPath.get(i));
@@ -824,8 +847,9 @@ public class Traces implements GrammarTreeNode {
 					}
 					if (i == endpos + span - 1) {
 						Vector<GrammarTreeNode> sublist = this.createLoop(subVector(curPath, startpos, endpos+span), span);
-						if(sublist == null)
+						if(sublist == null){
 							return null;
+						}
 						nodelist.addAll(sublist);
 					} else if (i >= endpos + span) {
 						nodelist.add(curPath.get(i));
@@ -842,8 +866,9 @@ public class Traces implements GrammarTreeNode {
 					}
 					if (i == endpos) {						
 						Vector<GrammarTreeNode> sublist = this.createLoop(subVector(curPath, startpos-span+1, endpos+1), span);
-						if(sublist == null)
+						if(sublist == null){
 							return null;
+						}
 						nodelist.addAll(sublist);
 					} else if (i > endpos) {
 						nodelist.add(curPath.get(i));
@@ -931,8 +956,9 @@ public class Traces implements GrammarTreeNode {
 						nodelist1.add(curPath.get(i));
 					}
 				}
-				if(nodelist1.size()>0)
+				if(nodelist1.size()>0){
 					resVector.add(nodelist1);
+				}
 			}
 		}
 		if(nodelist.size()!=0)

--- a/src/main/java/edu/isi/karma/cleaning/UtilTools.java
+++ b/src/main/java/edu/isi/karma/cleaning/UtilTools.java
@@ -11,8 +11,9 @@ public class UtilTools {
 	public static Vector<Integer> getStringPos(int tokenpos,Vector<TNode> example)
 	{
 		Vector<Integer> poss = new Vector<Integer>();
-		if(tokenpos < 0)
+		if(tokenpos < 0){
 			return poss;
+		}
 		int pos = 0;
 		int strleng = 0;
 		for(int i=0;i<example.size();i++)
@@ -59,19 +60,23 @@ public class UtilTools {
 
 	public static String print(Vector<TNode> x) {
 		String str = "";
-		if(x == null)
+		if(x == null){
 			return "null";
-		for (TNode t : x)
-			if(t.text.compareTo("ANYTOK")==0)
+		}
+		for (TNode t : x){
+			if(t.text.compareTo("ANYTOK")==0){
 				str += t.getType();
-			else
+			}else{
 				str += t.text;
+			}
+		}
 		return str;
 	}
 
 	public static boolean samesteplength(Vector<Integer> s) {
-		if (s.size() <= 1)
+		if (s.size() <= 1){
 			return false;
+		}
 		if (s.size() == 2) {
 			if (s.get(1) - s.get(0) >= 1) {
 				return true;
@@ -81,8 +86,9 @@ public class UtilTools {
 		}
 		int span = s.get(1) - s.get(0);
 		for (int i = 2; i < s.size(); i++) {
-			if ((s.get(i) - s.get(i - 1)) != span)
+			if ((s.get(i) - s.get(i - 1)) != span){
 				return false;
+			}
 		}
 		return true;
 	}
@@ -151,13 +157,15 @@ public class UtilTools {
 				{
 					tardis += String.format("{%s}",str);
 					tar += str;
-					if(!inloop)
+					if(!inloop){
 						segmentCnt ++;
+					}
 				}
 			}
 		}
-		if(pre<org.length())
+		if(pre<org.length()){
 			orgdis += org.substring(pre);
+		}
 		dict.put("Org", org);
 		dict.put("Tar",tar );
 		dict.put("Orgdis", orgdis);
@@ -423,7 +431,8 @@ class DoubleCompare implements Comparator {
 			return -1;
 		} else if (a1.score < a2.score) {
 			return 1;
-		} else
+		}else{
 			return 0;
+		}
 	}
 }

--- a/src/main/java/edu/isi/karma/cleaning/features/CntFeature.java
+++ b/src/main/java/edu/isi/karma/cleaning/features/CntFeature.java
@@ -37,16 +37,18 @@ public class CntFeature implements Feature{
 				while (p!=-1)
 				{
 					p = Ruler.Search(z, pa, bpos);
-					if(p==-1)
+					if(p==-1){
 						break;
+					}
 					bpos = p+1;
 					cnt++;
 				}
 				while (p1!=-1)
 				{
 					p1 = Ruler.Search(z1, pa, bpos1);
-					if(p1==-1)
+					if(p1==-1){
 						break;
+					}
 					bpos1 = p1+1;
 					cnt1++;
 				}

--- a/src/main/java/edu/isi/karma/cleaning/features/Main.java
+++ b/src/main/java/edu/isi/karma/cleaning/features/Main.java
@@ -42,8 +42,9 @@ public class Main {
 				Vector<String> row = new Vector<String>();
 				Vector<String> examples = new Vector<String>();
 				Vector<String> oexamples = new Vector<String>();
-				if(!flist[i].getName().contains(".csv"))
+				if(!flist[i].getName().contains(".csv")){
 					continue;
+				}
 				CSVReader re = new CSVReader(new FileReader(flist[i]), '\t');
 				String[] line = null;
 				re.readNext();//discard the first line

--- a/src/main/java/edu/isi/karma/cleaning/features/MovFeature.java
+++ b/src/main/java/edu/isi/karma/cleaning/features/MovFeature.java
@@ -33,16 +33,18 @@ public class MovFeature implements Feature {
 			while (p!=-1)
 			{
 				p = Ruler.Search(z, pa, bpos);
-				if(p==-1)
+				if(p==-1){
 					break;
+				}
 				bpos = p+1;
 				cnt++;
 			}
 			while (p1!=-1)
 			{
 				p1 = Ruler.Search(z1, pa, bpos1);
-				if(p1==-1)
+				if(p1==-1){
 					break;
+				}
 				bpos1 = p1+1;
 				cnt1++;
 			}

--- a/src/main/java/edu/isi/karma/cleaning/features/RecordClassifier2.java
+++ b/src/main/java/edu/isi/karma/cleaning/features/RecordClassifier2.java
@@ -156,9 +156,9 @@ public class RecordClassifier2 implements PartitionClassifierType {
 	public String getLabel(String value) {
 		try {
 			String label = this.Classify(value);
-			if (label.length() > 0)
+			if (label.length() > 0){
 				return label;
-			else {
+			}else {
 				return "null_in_classification";
 			}
 		} catch (Exception e) {

--- a/src/main/java/edu/isi/karma/cleaning/features/RegularityFeatureSet.java
+++ b/src/main/java/edu/isi/karma/cleaning/features/RegularityFeatureSet.java
@@ -199,13 +199,16 @@ public class RegularityFeatureSet implements FeatureSet {
 			cnt += c;
 		}
 		if(cnt==0)
+		 {
 			return Math.log(10);//
+		}
 		double entropy = 0.0;
 		for(int i=0;i<a.length;i++)
 		{
 			double freq = a[i]*1.0/cnt;
-			if(freq==0)
+			if(freq==0){
 				continue;
+			}
 			entropy -= freq*Math.log(freq);
 		}
 		return entropy;

--- a/src/main/java/edu/isi/karma/controller/command/AddColumnCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/AddColumnCommand.java
@@ -115,8 +115,9 @@ public class AddColumnCommand extends WorksheetCommand {
 		try{
 			if(hTableId==null || hTableId.isEmpty()){
 				//get table id based on the hNodeId
-				if(hNodeId==null)
+				if(hNodeId==null){
 					throw new KarmaException("TableId and NodeId are empty. Can't add column.");
+				}
 				hTableId = vWorkspace.getRepFactory().getHNode(hNodeId).getHTableId();
 			}
 						

--- a/src/main/java/edu/isi/karma/controller/command/EditCellCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/EditCellCommand.java
@@ -95,9 +95,10 @@ public class EditCellCommand extends WorksheetCommand {
 	@Override
 	public String getDescription() {
 		if (isExecuted()) {
-			if (newValueArg.asString().length() > 20)
+			if (newValueArg.asString().length() > 20){
 				return "Set value to "
 						+ newValueArg.asString().substring(0, 19) + "...";
+			}
 			return "Set value to " + newValueArg.asString();
 		}
 		return "";

--- a/src/main/java/edu/isi/karma/controller/command/ImportCSVFileCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/ImportCSVFileCommand.java
@@ -156,13 +156,13 @@ public class ImportCSVFileCommand extends CommandWithPreview {
 	public UpdateContainer handleUserActions(HttpServletRequest request) {
 		/** Set the parameters **/
 		// Set the delimiter
-		if (request.getParameter("delimiter").equals("comma"))
+		if (request.getParameter("delimiter").equals("comma")){
 			setDelimiter(',');
-		else if (request.getParameter("delimiter").equals("tab"))
+		}else if (request.getParameter("delimiter").equals("tab")){
 			setDelimiter('\t');
-		else if (request.getParameter("delimiter").equals("space"))
+		}else if (request.getParameter("delimiter").equals("space")){
 			setDelimiter(' ');
-		else {
+		}else {
 			// TODO What to do with manual text delimiter
 		}
 
@@ -177,8 +177,9 @@ public class ImportCSVFileCommand extends CommandWithPreview {
 				logger.error("Wrong user input for CSV Header line index");
 				return null;
 			}
-		} else
+		}else{
 			setHeaderRowIndex(0);
+		}
 
 		// Set the data start row index
 		String dataIndex = request.getParameter("startRowIndex");
@@ -190,8 +191,9 @@ public class ImportCSVFileCommand extends CommandWithPreview {
 				logger.error("Wrong user input for Data start line index");
 				return null;
 			}
-		} else
+		}else{
 			setDataStartRowIndex(2);
+		}
 
 		/** Send response based on the interaction type **/
 		UpdateContainer c = null;

--- a/src/main/java/edu/isi/karma/controller/command/ImportDatabaseTableCommandFactory.java
+++ b/src/main/java/edu/isi/karma/controller/command/ImportDatabaseTableCommandFactory.java
@@ -38,8 +38,9 @@ public class ImportDatabaseTableCommandFactory extends CommandFactory{
 
 		ImportDatabaseTableCommand comm = new ImportDatabaseTableCommand(getNewId(vWorkspace), vWorkspace);
 		
-		if(interactionType.equals(ImportDatabaseTableCommand.InteractionType.getPreferencesValues.name()))
+		if(interactionType.equals(ImportDatabaseTableCommand.InteractionType.getPreferencesValues.name())){
 			comm.setRequestedInteractionType(ImportDatabaseTableCommand.InteractionType.getPreferencesValues);
+		}
 		return comm;
 	}
 }

--- a/src/main/java/edu/isi/karma/controller/command/ImportServiceCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/ImportServiceCommand.java
@@ -69,10 +69,11 @@ public class ImportServiceCommand extends Command {
 
 	@Override
 	public String getDescription() {
-		if (serviceUrl.length() > 50)
+		if (serviceUrl.length() > 50){
 			return serviceUrl.substring(0, 50);
-		else
+		}else{
 			return serviceUrl;
+		}
 	}
 
 	@Override

--- a/src/main/java/edu/isi/karma/controller/command/RenameColumnCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/RenameColumnCommand.java
@@ -61,8 +61,9 @@ public class RenameColumnCommand extends Command {
 	
 	@Override
 	public String getDescription() {
-		if (newColumnName.length() > 20)
+		if (newColumnName.length() > 20){
 			return newColumnName.substring(0, 19) + "...";
+		}
 		return newColumnName;
 	}
 

--- a/src/main/java/edu/isi/karma/controller/command/ResetKarmaCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/ResetKarmaCommand.java
@@ -58,14 +58,15 @@ public class ResetKarmaCommand extends Command {
 
 	@Override
 	public String getDescription() {
-		if (forgetSemanticTypes && forgetModels)
+		if (forgetSemanticTypes && forgetModels){
 			return "Semantic Types and Models";
-		else if (forgetModels)
+		}else if (forgetModels){
 			return "Models";
-		else if(forgetSemanticTypes)
+		}else if(forgetSemanticTypes){
 			return "Semantic Types";
-		else
+		}else{
 			return "";
+		}
 	}
 
 	@Override
@@ -77,10 +78,11 @@ public class ResetKarmaCommand extends Command {
 	public UpdateContainer doIt(VWorkspace vWorkspace) throws CommandException {
 		if (forgetSemanticTypes) {
 			boolean deletTypes = vWorkspace.getWorkspace().getCrfModelHandler().removeAllLabels();
-			if (!deletTypes && forgetModels)
+			if (!deletTypes && forgetModels){
 				return new UpdateContainer(new ErrorUpdate("Error occured while removing semantic types. Models have also not been reset."));
-			else if (!deletTypes)
+			}else if (!deletTypes){
 				return new UpdateContainer(new ErrorUpdate("Error occured while removing semantic types."));
+			}
 		}
 		
 		if (forgetModels) {
@@ -89,9 +91,10 @@ public class ResetKarmaCommand extends Command {
 			File historyDir = new File(ServletContextParameterMap.getParameterValue(ContextParameter.USER_DIRECTORY_PATH) + "publish/History/");
 			if (!historyDir.exists() || !historyDir.isDirectory()) {
 				logger.error("Directory not found where the model histories are stored.");
-				if (forgetSemanticTypes)
+				if (forgetSemanticTypes){
 					return new UpdateContainer(new ErrorUpdate("Error occured while removing model histories." +
 							" Learned Semantic types have been reset."));
+				}
 				return new UpdateContainer(new ErrorUpdate("Error occured while removing model histories."));
 			}
 			

--- a/src/main/java/edu/isi/karma/controller/command/SplitColumnByDelimiter.java
+++ b/src/main/java/edu/isi/karma/controller/command/SplitColumnByDelimiter.java
@@ -69,11 +69,11 @@ public class SplitColumnByDelimiter {
 
 		// Convert the delimiter into character primitive type
 		char delimiterChar = ',';
-		if (delimiter.equalsIgnoreCase("space"))
+		if (delimiter.equalsIgnoreCase("space")){
 			delimiterChar = ' ';
-		else if (delimiter.equalsIgnoreCase("tab"))
+		}else if (delimiter.equalsIgnoreCase("tab")){
 			delimiterChar = '\t';
-		else {
+		}else {
 			delimiterChar = new Character(delimiter.charAt(0));
 		}
 
@@ -84,10 +84,12 @@ public class SplitColumnByDelimiter {
 		// Need to save and clear the values before adding the nested table.
 		// Otherwise we have both a value and a nested table, which is not legal.
 		for (Node node : nodes) {
-			if (oldNodeValueMap != null)
+			if (oldNodeValueMap != null){
 				oldNodeValueMap.put(node, node.getValue());
-			if (oldNodeStatusMap != null)
+			}
+			if (oldNodeStatusMap != null){
 				oldNodeStatusMap.put(node, node.getStatus());
+			}
 			
 			node.clearValue(NodeStatus.edited);
 		}
@@ -111,8 +113,9 @@ public class SplitColumnByDelimiter {
 						delimiterChar);
 				try {
 					String[] rowValues = reader.readNext();
-					if (rowValues == null || rowValues.length == 0)
+					if (rowValues == null || rowValues.length == 0){
 						continue;
+					}
 
 					// Get the nested table for the node
 					Table table = node.getNestedTable();

--- a/src/main/java/edu/isi/karma/controller/command/alignment/GetAlternativeLinksCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/alignment/GetAlternativeLinksCommand.java
@@ -104,8 +104,9 @@ public class GetAlternativeLinksCommand extends Command {
 								alignment.getNodeById(LinkIdFactory.getLinkSourceId(link.getId()));
 						String edgeSourceLabel = edgeSource.getDisplayId();
 						Label nodeLabel = edgeSource.getLabel();
-						if (nodeLabel.getUri() !=null && nodeLabel.getNs() != null && nodeLabel.getUri().equalsIgnoreCase(nodeLabel.getNs()))
+						if (nodeLabel.getUri() !=null && nodeLabel.getNs() != null && nodeLabel.getUri().equalsIgnoreCase(nodeLabel.getNs())){
 							edgeSourceLabel = edgeSource.getId();
+						}
 						
 						
 						JSONObject edgeObj = new JSONObject();

--- a/src/main/java/edu/isi/karma/controller/command/alignment/GetDataPropertiesForClassCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/alignment/GetDataPropertiesForClassCommand.java
@@ -93,8 +93,9 @@ public class GetDataPropertiesForClassCommand extends Command {
 						JSONObject classObject = new JSONObject();
 
 						Label domainURI = ontMgr.getUriLabel(domain);
-						if (domainURI == null)
+						if (domainURI == null){
 							continue;
+						}
 						
 						classObject.put(JsonKeys.data.name(), domainURI.getDisplayName());
 						JSONObject metadataObject = new JSONObject();

--- a/src/main/java/edu/isi/karma/controller/command/alignment/GetDomainsForDataPropertyCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/alignment/GetDomainsForDataPropertyCommand.java
@@ -118,8 +118,9 @@ public class GetDomainsForDataPropertyCommand extends Command {
 						JSONObject classObject = new JSONObject();
 
 						Label domainURI = ontMgr.getUriLabel(domain);
-						if(domainURI == null)
+						if(domainURI == null){
 							continue;
+						}
 						classObject.put(JsonKeys.data.name(), domainURI.getDisplayName());
 
 						JSONObject metadataObject = new JSONObject();

--- a/src/main/java/edu/isi/karma/controller/command/alignment/SetMetaPropertyCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/alignment/SetMetaPropertyCommand.java
@@ -137,8 +137,9 @@ public class SetMetaPropertyCommand extends Command {
 			columnNodeAlreadyExisted = true;
 			oldIncomingLinkToColumnNode = alignment.getCurrentLinksToNode(existingColumnNode.getId()).iterator().next();
 			oldDomainNode = oldIncomingLinkToColumnNode.getSource();
-			if (!rdfLiteralType.equals(existingColumnNode.getRdfLiteralType()))
+			if (!rdfLiteralType.equals(existingColumnNode.getRdfLiteralType())){
 				existingColumnNode.setRdfLiteralType(rdfLiteralType);
+			}
 		}
 		
 		if (metaPropertyName.equals(METAPROPERTY_NAME.isUriOfClass)) {
@@ -147,8 +148,9 @@ public class SetMetaPropertyCommand extends Command {
 			if (columnNodeAlreadyExisted) {
 				clearOldSemanticTypeLink(oldIncomingLinkToColumnNode, oldDomainNode, alignment, classNode);
 				columnNode = existingColumnNode;
-			} else
-				columnNode = getColumnNode(alignment, vWorkspace.getRepFactory().getHNode(hNodeId)); 
+			}else{
+				columnNode = getColumnNode(alignment, vWorkspace.getRepFactory().getHNode(hNodeId));
+			} 
 			
 			if (classNode == null) {
 				Label classNodeLabel = ontMgr.getUriLabel(metaPropertyValue);
@@ -200,8 +202,9 @@ public class SetMetaPropertyCommand extends Command {
 			if (columnNodeAlreadyExisted) {
 				clearOldSemanticTypeLink(oldIncomingLinkToColumnNode, oldDomainNode, alignment, classNode);
 				columnNode = existingColumnNode;
-			} else
-				columnNode = getColumnNode(alignment, vWorkspace.getRepFactory().getHNode(hNodeId)); 
+			}else{
+				columnNode = getColumnNode(alignment, vWorkspace.getRepFactory().getHNode(hNodeId));
+			} 
 			
 			if (classNode == null) {
 				Label classNodeLabel = ontMgr.getUriLabel(metaPropertyValue);
@@ -252,8 +255,9 @@ public class SetMetaPropertyCommand extends Command {
 	private void clearOldSemanticTypeLink(Link oldIncomingLinkToColumnNode,
 			Node oldDomainNode, Alignment alignment, Node newDomainNode) {
 		alignment.removeLink(oldIncomingLinkToColumnNode.getId());
-		if (oldDomainNode != newDomainNode)
+		if (oldDomainNode != newDomainNode){
 			alignment.removeNode(oldDomainNode.getId());
+		}
 	}
 
 	@Override

--- a/src/main/java/edu/isi/karma/controller/command/alignment/SetSemanticTypeCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/alignment/SetSemanticTypeCommand.java
@@ -145,8 +145,9 @@ public class SetSemanticTypeCommand extends Command {
 					domainValueExists = true;
 					// Check if the new domain is an existing instance
 					newDomainNode = alignment.getNodeById(domainValue);
-					if (newDomainNode != null)
+					if (newDomainNode != null){
 						domainNodeAlreadyExistsInGraph = true;
+					}
 				}
 					
 				if (type.getBoolean(ClientJsonKeys.isPrimary.name())) {
@@ -159,8 +160,9 @@ public class SetSemanticTypeCommand extends Command {
 						columnNodeAlreadyExisted = true;
 						oldIncomingLinkToColumnNode = alignment.getCurrentLinksToNode(existingColumnNode.getId()).iterator().next();
 						oldDomainNode = oldIncomingLinkToColumnNode.getSource();
-						if (!rdfLiteralType.equals(existingColumnNode.getRdfLiteralType()))
+						if (!rdfLiteralType.equals(existingColumnNode.getRdfLiteralType())){
 							existingColumnNode.setRdfLiteralType(rdfLiteralType);
+						}
 					}
 					
 					// Add a class link if the domain is null

--- a/src/main/java/edu/isi/karma/controller/command/alignment/ShowAutoModelCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/alignment/ShowAutoModelCommand.java
@@ -101,8 +101,10 @@ public class ShowAutoModelCommand extends WorksheetCommand {
 		// Generate the semantic types for the worksheet
 		OntologyManager ontMgr = vWorkspace.getWorkspace().getOntologyManager();
 		if(ontMgr.isEmpty())
+		 {
 			return new UpdateContainer(new ErrorUpdate("No ontology loaded."));
 //SemanticTypeUtil.computeSemanticTypesForAutoModel(worksheet, vWorkspace.getWorkspace().getCrfModelHandler(), ontMgr);
+		}
 
 		String alignmentId = AlignmentManager.Instance().constructAlignmentId(vWorkspace.getWorkspace().getId(), vWorksheetId);
 		Alignment alignment = AlignmentManager.Instance().getAlignment(alignmentId);

--- a/src/main/java/edu/isi/karma/controller/command/alignment/ShowAutoModelCommandFactory.java
+++ b/src/main/java/edu/isi/karma/controller/command/alignment/ShowAutoModelCommandFactory.java
@@ -140,8 +140,9 @@ public class ShowAutoModelCommandFactory extends CommandFactory implements
 
 			Label typeName = ontMgr.getUriLabel(fullType);
 			Label domainName = null;
-			if (domain != null && !domain.trim().equals(""))
+			if (domain != null && !domain.trim().equals("")){
 				domainName = ontMgr.getUriLabel(domain);
+			}
 
 			if (typeName != null) {
 				type = new SemanticType(hNodeId, typeName, domainName,

--- a/src/main/java/edu/isi/karma/controller/command/alignment/ShowModelCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/alignment/ShowModelCommand.java
@@ -99,8 +99,10 @@ public class ShowModelCommand extends WorksheetCommand {
 		// Generate the semantic types for the worksheet
 		OntologyManager ontMgr = vWorkspace.getWorkspace().getOntologyManager();
 		if(ontMgr.isEmpty())
+		 {
 			return new UpdateContainer(new ErrorUpdate("No ontology loaded."));
 //		SemanticTypeUtil.populateSemanticTypesUsingCRF(worksheet, outlierTag, vWorkspace.getWorkspace().getCrfModelHandler(), ontMgr);
+		}
 		
 		String alignmentId = AlignmentManager.Instance().constructAlignmentId(vWorkspace.getWorkspace().getId(), vWorksheetId);
 		Alignment alignment = AlignmentManager.Instance().getAlignment(alignmentId);

--- a/src/main/java/edu/isi/karma/controller/command/alignment/ShowModelCommandFactory.java
+++ b/src/main/java/edu/isi/karma/controller/command/alignment/ShowModelCommandFactory.java
@@ -107,8 +107,9 @@ public class ShowModelCommandFactory extends CommandFactory implements JSONInput
 			
 			Label typeName = ontMgr.getUriLabel(fullType);
 			Label domainName = null;
-			if (domain != null && !domain.trim().equals(""))
+			if (domain != null && !domain.trim().equals("")){
 				domainName = ontMgr.getUriLabel(domain);
+			}
 			
 			if(typeName != null) {
 				type = new SemanticType(hNodeId, typeName, domainName, Origin.User, 1.00, isPrimary);

--- a/src/main/java/edu/isi/karma/controller/command/alignment/UnassignSemanticTypeCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/alignment/UnassignSemanticTypeCommand.java
@@ -164,8 +164,9 @@ public class UnassignSemanticTypeCommand extends Command {
 
 		// Add the old SemanticType object if it is not null
 		SemanticTypes types = worksheet.getSemanticTypes();
-		if (oldSemanticType != null)
+		if (oldSemanticType != null){
 			types.addType(oldSemanticType);
+		}
 
 		// Update the container
 		UpdateContainer c = new UpdateContainer();

--- a/src/main/java/edu/isi/karma/controller/command/cleaning/GenerateCleaningRulesCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/cleaning/GenerateCleaningRulesCommand.java
@@ -261,8 +261,9 @@ public class GenerateCleaningRulesCommand extends WorksheetCommand {
 				pre = update[1];
 			}
 		}
-		if(org.length() > pre)
+		if(org.length() > pre){
 			orgdis += org.substring(pre);
+		}
 		dict.put("Org", org);
 		dict.put("Tar", tar);
 		dict.put("Orgdis", orgdis);
@@ -289,8 +290,9 @@ public class GenerateCleaningRulesCommand extends WorksheetCommand {
 		wk.getDataTable().collectNodes(selectedPath, nodes);
 		for (Node node : nodes) {
 			String id = node.getId();
-			if (!this.nodeIds.contains(id))
+			if (!this.nodeIds.contains(id)){
 				continue;
+			}
 			String originalVal = node.getValue().asString();
 			rows.put(id, originalVal);
 			this.compResultString += originalVal + "\n";
@@ -323,8 +325,9 @@ public class GenerateCleaningRulesCommand extends WorksheetCommand {
 			long _time5 = System.currentTimeMillis();
 			String tpid = iter.next();
 			ValueCollection rvco = rtf.getTransformedValues_debug(tpid);
-			if (rvco == null)
+			if (rvco == null){
 				continue;
+			}
 			long _time6 = System.currentTimeMillis();
 			// constructing displaying data
 			HashMap<String, String[]> xyzHashMap = new HashMap<String, String[]>();
@@ -363,8 +366,9 @@ public class GenerateCleaningRulesCommand extends WorksheetCommand {
 				}
 				resdata.put(key, dict);
 			}
-			if(!rtf.nullRule)
+			if(!rtf.nullRule){
 				keys.add(getBestExample(xyzHashMap, expFeData));
+			}
 			long _time7 = System.currentTimeMillis();
 			time6 += _time6 - _time5;
 			time7 = _time7 - _time6;
@@ -403,8 +407,9 @@ public class GenerateCleaningRulesCommand extends WorksheetCommand {
 			for (String key : values.keySet()) {
 				JSONArray jsonArray = new JSONArray();
 				HashSet<String> vs = values.get(key);
-				for (String v : vs)
+				for (String v : vs){
 					jsonArray.put(v);
+				}
 				jsobj.put(key, jsonArray);
 			}
 		} catch (Exception e) {
@@ -419,8 +424,9 @@ public class GenerateCleaningRulesCommand extends WorksheetCommand {
 		Vector<TNode> tNodes = ruler.vec;
 		int tcnt = 1;
 		for (int i = 0; i < tNodes.size(); i++) {
-			if (tNodes.get(i).text.compareTo(" ") == 0)
+			if (tNodes.get(i).text.compareTo(" ") == 0){
 				continue;
+			}
 			for (int j = 0; j > i && j < tNodes.size(); j++) {
 				if (tNodes.get(j).sameNode(tNodes.get(i))) {
 					tcnt++;
@@ -456,8 +462,9 @@ public class GenerateCleaningRulesCommand extends WorksheetCommand {
 			HashMap<String, HashMap<String, Integer>> values, boolean sw) {
 
 		int topKsize = 1;
-		if (sw)
+		if (sw){
 			topKsize = Integer.MAX_VALUE;
+		}
 		HashMap<String, Double> topK = new HashMap<String, Double>();
 		Iterator<String> iditer = dicts.keySet().iterator();
 		while (iditer.hasNext()) {

--- a/src/main/java/edu/isi/karma/controller/command/cleaning/SubmitCleaningCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/cleaning/SubmitCleaningCommand.java
@@ -183,8 +183,9 @@ public class SubmitCleaningCommand extends Command {
 			for (Node node : nodes) {
 				String id = node.getBelongsToRow().getId();
 				String originalVal = node.getValue().asString();
-				if(!rows.containsKey(id))
+				if(!rows.containsKey(id)){
 					rows.put(id, originalVal);
+				}
 			}
 			RamblerValueCollection vc = new RamblerValueCollection(rows);
 			RamblerTransformationInputs inputs = new RamblerTransformationInputs(examples, vc);

--- a/src/main/java/edu/isi/karma/controller/command/publish/PublishCSVCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/publish/PublishCSVCommand.java
@@ -85,9 +85,10 @@ public class PublishCSVCommand extends Command {
 		try {
 
 			final String fileName = csvFileExport.publishCSV();
-			if(fileName == null)
+			if(fileName == null){
 				return new UpdateContainer(new ErrorUpdate(
 						"No data to export! Have you aligned the worksheet?"));
+			}
 			return new UpdateContainer(new AbstractUpdate() {
 				@Override
 				public void generateJson(String prefix, PrintWriter pw,

--- a/src/main/java/edu/isi/karma/controller/command/publish/PublishDatabaseCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/publish/PublishDatabaseCommand.java
@@ -149,8 +149,9 @@ public class PublishDatabaseCommand extends Command {
 			//see if table exists
 			if (dbUtil.tableExists(tableName, conn)) {
 				if(!overwrite && !insert){
-					if(conn!=null)
+					if(conn!=null){
 						conn.close();
+					}
 					return new UpdateContainer(new ErrorUpdate(
 					"Table exists! Please check one of \"Overwrite Table\" or \"Insert in Table\"."));					
 				}
@@ -174,8 +175,9 @@ public class PublishDatabaseCommand extends Command {
 				numRowsNotInserted=insertInTable(worksheet, tableName, colNamesMap,conn);
 			}
 
-			if(conn!=null)
+			if(conn!=null){
 				conn.close();
+			}
 			
 			return new UpdateContainer(new AbstractUpdate() {
 				@Override
@@ -197,8 +199,9 @@ public class PublishDatabaseCommand extends Command {
 			});
 		} catch (Exception e) {
 			try{
-			if(conn!=null)
+			if(conn!=null){
 				conn.close();
+			}
 			}catch(SQLException ex){}
 			e.printStackTrace();
 			return new UpdateContainer(new ErrorUpdate(e.getMessage()));
@@ -222,8 +225,9 @@ public class PublishDatabaseCommand extends Command {
 		for(String semType: colNames){
 			//for now always VARCHAR
 			String dbType = getDbType(semType);
-			if (i++ > 0)
+			if (i++ > 0){
 				createQ += ",";
+			}
 			createQ += dbUtil.prepareName(semType) + " " + dbType;
 		}
 		createQ += ")";
@@ -251,8 +255,9 @@ public class PublishDatabaseCommand extends Command {
 			for(String semType: colNames){
 				//for now always VARCHAR
 				String dbType = getDbType(semType);
-				if (i++ > 0)
+				if (i++ > 0){
 					createQ += ",";
+				}
 				createQ += dbUtil.prepareName(semType) + " " + dbType;
 			}
 			createQ += ")";
@@ -315,9 +320,11 @@ public class PublishDatabaseCommand extends Command {
 			String insertRow = insertInTableRow(r, tableName, addTheseColumns, addTheseTypes);
 			//returns null if that particular row could not be inserted
 			//because there is a number column for which the values are not numbers
-			if(insertRow!=null)
+			if(insertRow!=null){
 				dbUtil.executeUpdate(conn, insertRow);
-			else numOfRowsNotInserted++;
+			}else{
+				numOfRowsNotInserted++;
+			}
 		}
 		return numOfRowsNotInserted;
 	}
@@ -354,17 +361,18 @@ public class PublishDatabaseCommand extends Command {
 				}
 				colNames += dbUtil.prepareName(colName);
 				//handle null vaules in worksheets
-				if(val==null)
+				if(val==null){
 					val="";
+				}
 				//escape string
 				val = val.replaceAll("'", "''");
 				if (isDbTypeString(colTypesMap.get(hNodeId))) {
 					val = "'" + val + "'";
 				} else {
 					// it's a number
-					if (val.trim().equals(""))
+					if (val.trim().equals("")){
 						val = null;
-					else{
+					}else{
 						//check that it is really a number
 						try{
 							Double.valueOf(val);
@@ -402,8 +410,9 @@ public class PublishDatabaseCommand extends Command {
 	 * @return
 	 */
 	private boolean isDbTypeString(String type){
-		if(type.toLowerCase().contains("varchar") || type.toLowerCase().contains("bit"))
+		if(type.toLowerCase().contains("varchar") || type.toLowerCase().contains("bit")){
 			return true;
+		}
 		return false;
 	}
 	

--- a/src/main/java/edu/isi/karma/controller/command/publish/PublishKMLLayerCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/publish/PublishKMLLayerCommand.java
@@ -206,8 +206,9 @@ public class PublishKMLLayerCommand extends Command {
 					logger.info("Transfer complete.");
 					inStream.close();
 					return true;
-				} else
+				}else{
 					return false;
+				}
 			}
 			inStream.close();
 			return false;

--- a/src/main/java/edu/isi/karma/controller/command/publish/PublishMDBCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/publish/PublishMDBCommand.java
@@ -84,9 +84,10 @@ public class PublishMDBCommand extends Command {
 
 		try {
 			final String csvFileName = csvFileExport.publishCSV();
-			if(csvFileName == null)
+			if(csvFileName == null){
 				return new UpdateContainer(new ErrorUpdate(
 						"No data to export! Have you aligned the worksheet?"));
+			}
 			final String fileName = mdbFileExport.publishMDB(csvFileName);
 
 			return new UpdateContainer(new AbstractUpdate() {

--- a/src/main/java/edu/isi/karma/controller/command/publish/PublishRDFCellCommandFactory.java
+++ b/src/main/java/edu/isi/karma/controller/command/publish/PublishRDFCellCommandFactory.java
@@ -48,8 +48,9 @@ public class PublishRDFCellCommandFactory extends CommandFactory {
 		if(prefObject!=null){
 			rdfPrefix = prefObject.optString("rdfPrefix");
 		}
-		if(rdfPrefix==null || rdfPrefix.trim().isEmpty())
-			rdfPrefix = "http://localhost/source/"; 
+		if(rdfPrefix==null || rdfPrefix.trim().isEmpty()){
+			rdfPrefix = "http://localhost/source/";
+		} 
 		String nodeId = request.getParameter(Arguments.nodeId.name());
 		return new PublishRDFCellCommand(getNewId(vWorkspace), vWorksheetId, nodeId,
 				rdfPrefix,rdfNamespace);

--- a/src/main/java/edu/isi/karma/controller/command/publish/PublishRDFCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/publish/PublishRDFCommand.java
@@ -88,10 +88,11 @@ public class PublishRDFCommand extends Command {
 		this.dbName=dbName;
 		this.userName=userName;
 		this.password=password;
-		if(modelName==null || modelName.trim().isEmpty())
+		if(modelName==null || modelName.trim().isEmpty()){
 			this.modelName="karma";
-		else
+		}else{
 			this.modelName=modelName;
+		}
 	}
 
 	@Override

--- a/src/main/java/edu/isi/karma/controller/command/service/InvokeServiceCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/service/InvokeServiceCommand.java
@@ -147,8 +147,9 @@ public class InvokeServiceCommand extends WorksheetCommand {
 	
 	public Worksheet generateWorksheet(Workspace workspace, String title) throws KarmaException, IOException {
 
-		if (workspace == null)
+		if (workspace == null){
 			throw new KarmaException("Workspace is null.");
+		}
 		
 		Worksheet worksheet = workspace.getFactory().createWorksheet(title, workspace);
 		

--- a/src/main/java/edu/isi/karma/controller/command/service/PublishModelCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/service/PublishModelCommand.java
@@ -99,8 +99,9 @@ public class PublishModelCommand extends Command{
 			logger.info("The worksheet does not have a service object.");
 //			return new UpdateContainer(new ErrorUpdate(
 //				"Error occured while publishing the model. The worksheet does not have a service object."));
-		} else
+		}else{
 			service = wk.getMetadataContainer().getService();
+		}
 		
 		AlignmentManager mgr = AlignmentManager.Instance();
 		String alignmentId = mgr.constructAlignmentId(ws.getId(), vWorksheetId);
@@ -121,24 +122,28 @@ public class PublishModelCommand extends Command{
 		
 		if (al == null) { 
 			logger.error("The alignment model is null.");
-			if (service == null)
+			if (service == null){
 				return new UpdateContainer(new ErrorUpdate(
 					"Error occured while publishing the source. The alignment model is null."));
+			}
 		} 
 		
 		DirectedWeightedMultigraph<Node, Link> tree = null;
-		if (al != null) 
+		if (al != null){
 			tree = al.getSteinerTree();
+		}
 		
 		if (tree == null) { 
 			logger.error("The alignment tree is null.");
-			if (service == null)
+			if (service == null){
 				return new UpdateContainer(new ErrorUpdate(
 					"Error occured while publishing the source. The alignment tree is null."));
+			}
 		}
 		
-		if (service != null) service.updateModel(tree);
-		else {
+		if (service != null){
+			service.updateModel(tree);
+		}else {
 			source = new DataSource(wk.getTitle(), tree);
 			MetadataContainer metaData = wk.getMetadataContainer();
 			if (metaData == null) {
@@ -167,10 +172,12 @@ public class PublishModelCommand extends Command{
 				sourcePrefix = "s";
 				addInverseProperties = "true";
 			}
-			if(sourceNamespace.trim().isEmpty())
+			if(sourceNamespace.trim().isEmpty()){
 				sourceNamespace = "http://localhost/";
-			if(sourcePrefix.trim().isEmpty())
+			}
+			if(sourcePrefix.trim().isEmpty()){
 				sourcePrefix = "s";
+			}
 
 			SourceDescription desc = new SourceDescription(ws, al, wk,
 					sourcePrefix, sourceNamespace,Boolean.valueOf(addInverseProperties),false);
@@ -219,15 +226,17 @@ public class PublishModelCommand extends Command{
 			logger.error("The worksheet does not have a service object.");
 //			return new UpdateContainer(new ErrorUpdate(
 //				"Error occured while deleting the model. The worksheet does not have a service object."));
-		} else
+		}else{
 			service = wk.getMetadataContainer().getService();
+		}
 		
 		if (!wk.containSource()) { 
 			logger.error("The worksheet does not have a source object.");
 //			return new UpdateContainer(new ErrorUpdate(
 //				"Error occured while deleting the model. The worksheet does not have a source object."));
-		} else
+		}else{
 			source = wk.getMetadataContainer().getSource();
+		}
 		
 		try {
 

--- a/src/main/java/edu/isi/karma/controller/command/service/ServiceTableUtil.java
+++ b/src/main/java/edu/isi/karma/controller/command/service/ServiceTableUtil.java
@@ -87,11 +87,13 @@ public class ServiceTableUtil {
 			List<String> hNodeIdList, edu.isi.karma.rep.Table dataTable) {
 		
 		for (List<String> rowValues : tableValues) {
-			if (rowValues == null || rowValues.size() == 0)
+			if (rowValues == null || rowValues.size() == 0){
 				continue;
+			}
 			Row row = dataTable.addRow(factory);
-			for (int i = 0; i < rowValues.size(); i++) 
+			for (int i = 0; i < rowValues.size(); i++){
 				row.setValue(hNodeIdList.get(i), rowValues.get(i), factory);
+			}
 		}
 		
 	}
@@ -125,8 +127,9 @@ public class ServiceTableUtil {
 			
 			for (int k = 0; k < tableValues.size(); k++) {
 				List<String> rowValues = tableValues.get(k);
-				if (rowValues == null || rowValues.size() == 0)
+				if (rowValues == null || rowValues.size() == 0){
 					continue;
+				}
 				
 				String tableRowId = tableRowIds.get(k);
 				if (tableRowId == null || !tableRowId.trim().equalsIgnoreCase(currentRowId.trim())) {
@@ -136,10 +139,11 @@ public class ServiceTableUtil {
 				addedRowsCount ++;
 				
 				Row row = null;
-				if (addedRowsCount <= rowsCount)
+				if (addedRowsCount <= rowsCount){
 					row = dataTable.getRows(addedRowsCount - 1, 1).get(0);
-				else 
+				}else{
 					row = dataTable.addRow(factory);
+				}
 				
 //				System.out.println(hNodeIdList.size());
 				for (int j = 0; j < hNodeIdList.size(); j++) {

--- a/src/main/java/edu/isi/karma/controller/command/transformation/PreviewPythonTransformationResultsCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/transformation/PreviewPythonTransformationResultsCommand.java
@@ -117,8 +117,9 @@ public class PreviewPythonTransformationResultsCommand extends Command {
 				int counter = 0;
 				for (String hNodeId:hNodeIds) {
 					String nodeVal = row.getNode(hNodeId).getValue().asString();
-					if (counter++ != 0)
+					if (counter++ != 0){
 						objectCreationStmt.append(",");
+					}
 					if (nodeVal == null || nodeVal.equals("")) {
 						objectCreationStmt.append("\"\"");
 					} else {

--- a/src/main/java/edu/isi/karma/controller/command/transformation/SubmitPythonTransformationCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/transformation/SubmitPythonTransformationCommand.java
@@ -124,8 +124,9 @@ public class SubmitPythonTransformationCommand extends Command {
 				int counter = 0;
 				for (String hNodeId:hNodeIds) {
 					String nodeVal = row.getNode(hNodeId).getValue().asString();
-					if (counter++ != 0)
+					if (counter++ != 0){
 						objectCreationStmt.append(",");
+					}
 					if (nodeVal == null || nodeVal.equals("")) {
 						objectCreationStmt.append("\"\"");
 					} else {

--- a/src/main/java/edu/isi/karma/controller/history/CommandHistory.java
+++ b/src/main/java/edu/isi/karma/controller/history/CommandHistory.java
@@ -274,16 +274,18 @@ public class CommandHistory {
 			Command redoComm = redoStack.get(i);
 			redoComm.generateJson(prefix, pw, vWorkspace,
 					Command.HistoryType.redo);
-			if(i != 0)
+			if(i != 0){
 				pw.println(prefix + ",");
+			}
 		}
 	}
 
 	public void removeCommands(CommandTag tag) {
 		List<Command> commandsToBeRemoved = new ArrayList<Command>();
 		for(Command command: history) {
-			if(command.hasTag(tag))
+			if(command.hasTag(tag)){
 				commandsToBeRemoved.add(command);
+			}
 		}
 		history.removeAll(commandsToBeRemoved);
 	}

--- a/src/main/java/edu/isi/karma/controller/history/CommandHistoryWriter.java
+++ b/src/main/java/edu/isi/karma/controller/history/CommandHistoryWriter.java
@@ -36,8 +36,9 @@ public class CommandHistoryWriter {
 				JSONArray json = new JSONArray(command.getInputParameterJson());
 				String vWorksheetId = HistoryJsonUtil.getStringValue(HistoryArguments.vWorksheetId.name(), json);
 				String worksheetName = vWorkspace.getViewFactory().getVWorksheet(vWorksheetId).getWorksheet().getTitle(); 
-				if(comMap.get(worksheetName) == null)
+				if(comMap.get(worksheetName) == null){
 					comMap.put(worksheetName, new ArrayList<Command>());
+				}
 				comMap.get(worksheetName).add(command);
 			}
 		}
@@ -51,8 +52,9 @@ public class CommandHistoryWriter {
 				
 				// Populate the tags
 				JSONArray tagsArr = new JSONArray();
-				for (CommandTag tag : comm.getTags())
+				for (CommandTag tag : comm.getTags()){
 					tagsArr.put(tag.name());
+				}
 				commObj.put(HistoryArguments.tags.name(), tagsArr);
 				
 				JSONArray inputArr = new JSONArray(comm.getInputParameterJson());
@@ -73,8 +75,9 @@ public class CommandHistoryWriter {
 					}
 				}
 				commObj.put(HistoryArguments.inputParameters.name(), inputArr);
-				 if(!commandAlreadyexists(commArr, commObj))
+				 if(!commandAlreadyexists(commArr, commObj)){
 					commArr.put(commObj);
+				}
 			}
 //			System.out.println(commArr.toString(4));
 			JSONUtil.writeJsonFile(commArr, HistoryJsonUtil.constructWorksheetHistoryJsonFilePath(wkName, 

--- a/src/main/java/edu/isi/karma/controller/history/WorksheetCommandHistoryReader.java
+++ b/src/main/java/edu/isi/karma/controller/history/WorksheetCommandHistoryReader.java
@@ -107,10 +107,10 @@ public class WorksheetCommandHistoryReader {
 				if(comm != null){
 //					logger.info("Executing command: " + commObject.get(HistoryArguments.commandName.name()));
 					vWorkspace.getWorkspace().getCommandHistory().doCommand(comm, vWorkspace);
-				}
-				else
+				}else{
 					logger.error("Error occured while creating command (Could not create Command object): " 
 							+ commObject.get(HistoryArguments.commandName.name()));
+				}
 			}
 		}
 	}
@@ -128,8 +128,9 @@ public class WorksheetCommandHistoryReader {
 				JSONArray tags = commObject.getJSONArray(HistoryArguments.tags.name());
 				for (int j=0; j< tags.length(); j++) {
 					String tag2 = tags.getString(j);
-					if(tag2.equals(tag.name()))
+					if(tag2.equals(tag.name())){
 						commandsJSON.add(commObject.toString());
+					}
 				}
 			}
 		} catch (FileNotFoundException e) {

--- a/src/main/java/edu/isi/karma/controller/update/CSVImportPreviewUpdate.java
+++ b/src/main/java/edu/isi/karma/controller/update/CSVImportPreviewUpdate.java
@@ -141,8 +141,9 @@ public class CSVImportPreviewUpdate extends AbstractUpdate {
 						for (String val : rowValues) {
 							vals.add(val);
 						}
-					} else 
+					}else{
 						vals.add("");
+					}
 					// Add the row index
 					vals.add(0, Integer.toString(rowCount + 1));
 

--- a/src/main/java/edu/isi/karma/controller/update/OntologyClassHierarchyUpdate.java
+++ b/src/main/java/edu/isi/karma/controller/update/OntologyClassHierarchyUpdate.java
@@ -83,8 +83,9 @@ public class OntologyClassHierarchyUpdate extends AbstractUpdate {
 							while (superClasses.hasNext()) {
 								OntClass clss = superClasses.next();
 								System.out.println("Superclass" + clss.getURI());
-								if (!clss.isAnon() && !clss.getURI().equals("http://www.w3.org/2000/01/rdf-schema#Resource"))
+								if (!clss.isAnon() && !clss.getURI().equals("http://www.w3.org/2000/01/rdf-schema#Resource")){
 									flag = true;
+								}
 							}
 						} catch (ConversionException e) {
 							logger.debug(e.getMessage());
@@ -105,8 +106,9 @@ public class OntologyClassHierarchyUpdate extends AbstractUpdate {
 	
 					String pr = prefixMap.get(cls.getNameSpace());
 					String classLabel = cls.getLocalName();
-					if (cls.getLabel(null) != null && !cls.getLabel(null).equals(""))
+					if (cls.getLabel(null) != null && !cls.getLabel(null).equals("")){
 						classLabel = cls.getLabel(null);
+					}
 					
 					if(pr != null && !pr.equals("")) {
 						classObject.put(JsonKeys.data.name(), pr + ":" + classLabel);
@@ -150,12 +152,14 @@ public class OntologyClassHierarchyUpdate extends AbstractUpdate {
 			JSONObject classObject = new JSONObject();
 			String pr = prefixMap.get(subclass.getNameSpace());
 			String subClassLabel = subclass.getLocalName();
-			if (subclass.getLabel(null) != null && !subclass.getLabel(null).equals(""))
+			if (subclass.getLabel(null) != null && !subclass.getLabel(null).equals("")){
 				subClassLabel = subclass.getLabel(null);
-			if (pr != null && !pr.equals(""))
+			}
+			if (pr != null && !pr.equals("")){
 				classObject.put(JsonKeys.data.name(), pr + ":" + subClassLabel);
-			else
+			}else{
 				classObject.put(JsonKeys.data.name(), subClassLabel);
+			}
 			JSONObject metadataObject = new JSONObject();
 			metadataObject.put(JsonKeys.URI.name(), subclass.getURI());
 			classObject.put(JsonKeys.metadata.name(), metadataObject);

--- a/src/main/java/edu/isi/karma/controller/update/OntologyHierarchyUpdate.java
+++ b/src/main/java/edu/isi/karma/controller/update/OntologyHierarchyUpdate.java
@@ -84,8 +84,9 @@ public class OntologyHierarchyUpdate extends AbstractUpdate {
 					addChildren(node, childrenArray, steinerTreeNodeIds);
 				}
 				// Add the graph nodes
-				if (addSteinerTreeNodesAsChildren && alignment!=null)
+				if (addSteinerTreeNodesAsChildren && alignment!=null){
 					addSteinerTreeNodes(node, childrenArray, steinerTreeNodeIds);
+				}
 
 				resourceObject = getResourceObject(node, childrenArray, steinerTreeNodeIds);
 				dataArray.put(resourceObject);

--- a/src/main/java/edu/isi/karma/controller/update/SVGAlignmentUpdate_ForceKarmaLayout.java
+++ b/src/main/java/edu/isi/karma/controller/update/SVGAlignmentUpdate_ForceKarmaLayout.java
@@ -61,8 +61,9 @@ public class SVGAlignmentUpdate_ForceKarmaLayout extends AbstractUpdate {
 			VWorkspace vWorkspace) {
 		List<String> hNodeIdList = new ArrayList<String>();
 		List<HNodePath> columns = vWorksheet.getColumns();
-		for(HNodePath path:columns)
+		for(HNodePath path:columns){
 			hNodeIdList.add(path.getLeaf().getId());
+		}
 		String alignmentId = AlignmentManager.Instance().constructAlignmentId(vWorkspace.getWorkspace().getId(), 
 				vWorksheet.getId());
 		
@@ -150,8 +151,9 @@ public class SVGAlignmentUpdate_ForceKarmaLayout extends AbstractUpdate {
 
 					if(target.getType() == NodeType.ColumnNode && outEdges.isEmpty()) {
 						linkObj.put(JsonKeys.linkType.name(), JsonValues.holderLink.name());
-						if(link.getKeyType() == LinkKeyInfo.PartOfKey)
+						if(link.getKeyType() == LinkKeyInfo.PartOfKey){
 							linkObj.put(JsonKeys.label.name(), link.getLabel().getLocalName()+"*");
+						}
 					}
 
 					linksArr.put(linkObj);
@@ -308,8 +310,9 @@ public class SVGAlignmentUpdate_ForceKarmaLayout extends AbstractUpdate {
 		nodeObj.put(JsonKeys.nodeType.name(), nodeType);
 		nodeObj.put(JsonKeys.height.name(), height);
 		nodeObj.put(JsonKeys.hNodesCovered.name(), hNodeIdsCoveredByVertex);
-		if (!hNodeId.equals(""))
+		if (!hNodeId.equals("")){
 			nodeObj.put(JsonKeys.hNodeId.name(), hNodeId);
+		}
 		return nodeObj;
 	}
 	
@@ -321,12 +324,15 @@ public class SVGAlignmentUpdate_ForceKarmaLayout extends AbstractUpdate {
 		linkObj.put(JsonKeys.source.name(), sourceIndex);
 		linkObj.put(JsonKeys.target.name(), targetIndex);
 		linkObj.put(JsonKeys.linkType.name(), linkType);
-		if (!sourceNodeId.equals(""))
+		if (!sourceNodeId.equals("")){
 			linkObj.put(JsonKeys.sourceNodeId.name(), sourceNodeId);
-		if (!targetNodeId.equals(""))
+		}
+		if (!targetNodeId.equals("")){
 			linkObj.put(JsonKeys.targetNodeId.name(), targetNodeId);
-		if (!linkStatus.equals(""))
+		}
+		if (!linkStatus.equals("")){
 			linkObj.put(JsonKeys.linkStatus.name(), linkStatus);
+		}
 		return linkObj;
 	}
 	

--- a/src/main/java/edu/isi/karma/controller/update/SemanticTypesUpdate.java
+++ b/src/main/java/edu/isi/karma/controller/update/SemanticTypesUpdate.java
@@ -222,14 +222,16 @@ public class SemanticTypesUpdate extends AbstractUpdate {
 		// Check for the case of DataPropertyOfColumnLink and ColumnSubClassLink
 		boolean case1 =  (type.getUri().equals(DataPropertyOfColumnLink.getFixedLabel().getUri()) 
 				|| type.getUri().equals(ColumnSubClassLink.getFixedLabel().getUri()));
-		if (case1)
+		if (case1){
 			return true;
+		}
 		Set<Link> incomingLinks = alignment.getCurrentLinksToNode(alignmentColumnNode.getId());
 		if (incomingLinks != null && !incomingLinks.isEmpty()) {
 			Link incomingLink = incomingLinks.iterator().next();
 			if (incomingLink != null && (incomingLink instanceof ClassInstanceLink) 
-					&& incomingLink.getKeyType().equals(LinkKeyInfo.UriOfInstance))
+					&& incomingLink.getKeyType().equals(LinkKeyInfo.UriOfInstance)){
 				return true;
+			}
 		}
 		return false;
 	}
@@ -237,8 +239,9 @@ public class SemanticTypesUpdate extends AbstractUpdate {
 	private Map<String, InternalNode> createDomainNodeMap() {
 		Map<String, InternalNode> hNodeIdToDomainNodeMap = new HashMap<String, InternalNode>();
 		List<Node> alignmentColumnNodes = alignment.getNodesByType(NodeType.ColumnNode);
-		if (alignmentColumnNodes == null)
+		if (alignmentColumnNodes == null){
 			return hNodeIdToDomainNodeMap;
+		}
 		for (Node cNode : alignmentColumnNodes) {
 			Set<Link> incomingLinks = alignment.getCurrentLinksToNode(cNode.getId());
 			if (incomingLinks != null && !incomingLinks.isEmpty()) {
@@ -256,8 +259,9 @@ public class SemanticTypesUpdate extends AbstractUpdate {
 	private Map<String, ColumnNode> createColumnNodeMap() {
 		List<Node> alignmentColumnNodes = alignment.getNodesByType(NodeType.ColumnNode);
 		Map<String, ColumnNode> hNodeIdToColumnNodeMap = new HashMap<String, ColumnNode>();
-		if (alignmentColumnNodes == null)
+		if (alignmentColumnNodes == null){
 			return hNodeIdToColumnNodeMap;
+		}
 		for (Node cNode : alignmentColumnNodes) {
 			ColumnNode columnNode = (ColumnNode) cNode;
 			hNodeIdToColumnNodeMap.put(columnNode.getHNodeId(), columnNode);

--- a/src/main/java/edu/isi/karma/er/aggregator/impl/RatioWeightAggregator.java
+++ b/src/main/java/edu/isi/karma/er/aggregator/impl/RatioWeightAggregator.java
@@ -101,8 +101,9 @@ public class RatioWeightAggregator implements Aggregator {
 	 */
 	private double calcRatio(List<Score> sList) {
 		double finalScore = 0;
-		if (sList == null || sList.size() <= 0)
+		if (sList == null || sList.size() <= 0){
 			return finalScore;
+		}
 		
 		double sim, ratio, weight, totalSim = 0, totalWeight = 0;
 		for (Score s : sList) {

--- a/src/main/java/edu/isi/karma/er/compare/impl/NumberEqualityComparatorImpl.java
+++ b/src/main/java/edu/isi/karma/er/compare/impl/NumberEqualityComparatorImpl.java
@@ -13,8 +13,9 @@ public class NumberEqualityComparatorImpl implements NumberComparator {
 	}
 	
 	public double getSimilarity(Number a, Number b) {
-		if (a.intValue() == b.intValue()) 
+		if (a.intValue() == b.intValue()){
 			return 1;
+		}
 		return 0; 
 	}
 

--- a/src/main/java/edu/isi/karma/er/compare/impl/StringEqualComparatorImpl.java
+++ b/src/main/java/edu/isi/karma/er/compare/impl/StringEqualComparatorImpl.java
@@ -5,8 +5,9 @@ import edu.isi.karma.er.compare.StringComparator;
 public class StringEqualComparatorImpl implements StringComparator {
 
 	public float getSimilarity(String str1, String str2) {
-		if (str1 == null || str2 == null)
+		if (str1 == null || str2 == null){
 			return 0f;
+		}
 		
 		return (str1.equalsIgnoreCase(str2) ? 1f : 0f);
 	}

--- a/src/main/java/edu/isi/karma/er/compare/impl/StringQGramComparatorImpl.java
+++ b/src/main/java/edu/isi/karma/er/compare/impl/StringQGramComparatorImpl.java
@@ -21,8 +21,9 @@ public class StringQGramComparatorImpl implements StringComparator {
 		str2 = trim(str2);
 
 		int s1 = str1.length(), s2 = str2.length();
-		if (s1 < 2 || s2 < 2) 
+		if (s1 < 2 || s2 < 2){
 			return 0;
+		}
 
 		char[][] a = new char[s1 - q + 1][q];
 		char[][] b = new char[s2 - q + 1][q];
@@ -40,17 +41,19 @@ public class StringQGramComparatorImpl implements StringComparator {
 		}
 
 		int k, count = 0;
-		for (int i = 0; i < s1 - q + 1; i++) 
+		for (int i = 0; i < s1 - q + 1; i++){
 			for (int j = 0; j < s2 -q + 1; j++) {
 				for (k = 0; k < q; k++) {
-					if (a[i][k] != b[j][k])
+					if (a[i][k] != b[j][k]){
 						break;
+					}
 				}
 				if (k >= q) {
 					count ++;
 					break;
 				}
 			}
+		}
 		degree = count * 2f / (s1 + s2 -2*q + 2);
 
 		degree = degree + (1 - degree) * calcWeight(str1, str2);
@@ -64,8 +67,12 @@ public class StringQGramComparatorImpl implements StringComparator {
 		char[] strch = new char[str.length()];
 		for (int i = 0; i < strch.length; i++) {
 			char ch = str.charAt(i);
-			if (ch == '(') break;
-			if (ch == ',' || ch == '.') ch = ' ';
+			if (ch == '('){
+				break;
+			}
+			if (ch == ',' || ch == '.'){
+				ch = ' ';
+			}
 			if (ch == ' ' && last == ' ') {
 				
 			} else {
@@ -125,21 +132,29 @@ public class StringQGramComparatorImpl implements StringComparator {
 						break;
 					}
 				}
-				while (ch2[j++] != ' ' && j < len2) ;
+				while (ch2[j++] != ' ' && j < len2){
+					;
+				}
 
 				
 			}
-			while (ch1[i++] != ' ' && i < len1); 
+			while (ch1[i++] != ' ' && i < len1){
+				;
+			} 
 
 		}
 		
 		count = 0;
-		for (i = 0; i < len1; i++)
-			if (ch1[i] == ' ')
+		for (i = 0; i < len1; i++){
+			if (ch1[i] == ' '){
 				count ++;
-		for (j = 0; j < len2; j++) 
-			if (ch2[j] == ' ')
+			}
+		}
+		for (j = 0; j < len2; j++){
+			if (ch2[j] == ' '){
 				count ++;
+			}
+		}
 		return weight * 0.5f / (count + 2);
 	}
 

--- a/src/main/java/edu/isi/karma/er/helper/PairPropertyUtil.java
+++ b/src/main/java/edu/isi/karma/er/helper/PairPropertyUtil.java
@@ -48,8 +48,9 @@ public class PairPropertyUtil {
 	
 	public double getPairCount(Map<String, Map<String, Double>> map, String s1, String s2) {
 		double count = 0;
-		if (map.containsKey(s1) && map.get(s1).containsKey(s2))
+		if (map.containsKey(s1) && map.get(s1).containsKey(s2)){
 			count = map.get(s1).get(s2);
+		}
 		return count;
 	}
 	

--- a/src/main/java/edu/isi/karma/er/helper/RatioFileUtil.java
+++ b/src/main/java/edu/isi/karma/er/helper/RatioFileUtil.java
@@ -220,16 +220,18 @@ public class RatioFileUtil {
 		Map<String, List<SimilarityFrequency>> map = loadDefaultFrequency();
 		List<SimilarityFrequency> list = map.get(predicate);
 		int i = 0; 
-		if (list == null) 
+		if (list == null){
 			return freq;
+		}
 		for (i = 0; i < list.size(); i++) {
 			SimilarityFrequency f = list.get(i);
 			if (similarity >= f.getSimilarity()) {
 				break;
 			}
 		}
-		if (i < list.size())
+		if (i < list.size()){
 			freq = list.get(i).getFrequency();
+		}
 		
 		return freq;
 	}

--- a/src/main/java/edu/isi/karma/er/helper/ScoreBoardFileUtil.java
+++ b/src/main/java/edu/isi/karma/er/helper/ScoreBoardFileUtil.java
@@ -103,8 +103,9 @@ public class ScoreBoardFileUtil {
 			for (int j = 0; j < len; j++) {
 				
 				ScoreBoard s = list.get(j); 
-				if (s.getDbpediaUri().trim().length() > 0)
+				if (s.getDbpediaUri().trim().length() > 0){
 					i ++;
+				}
 				if (s.getKarmaUri() != null && s.getKarmaUri().length() > 0) {
 					count++;
 					StringBuffer sb = new StringBuffer();
@@ -264,8 +265,9 @@ public class ScoreBoardFileUtil {
 			int i;
 			for (i = 0; i < list.size() ; i++) {
 				rec = list.get(i);
-				if (s.getFound() > rec.getFound())
+				if (s.getFound() > rec.getFound()){
 					break;
+				}
 			}
 			list.add(i, s);
 		}
@@ -328,8 +330,9 @@ public class ScoreBoardFileUtil {
 	 */
 	public Vector<ScoreBoard> loadScoreBoardFile(String filename) {
 		File file = new File(Constants.PATH_SCORE_BOARD_FILE + filename);
-		if (!file.exists())
+		if (!file.exists()){
 			throw new IllegalArgumentException("file " + file.getAbsolutePath() + " not exists.");
+		}
 		
 		RandomAccessFile raf = null;
 		Vector<ScoreBoard> list = new Vector<ScoreBoard>();
@@ -411,8 +414,9 @@ public class ScoreBoardFileUtil {
 		} else {
 			file = new File(Constants.PATH_SCORE_BOARD_FILE + filename);
 		}
-		if (!file.exists())
+		if (!file.exists()){
 			throw new IllegalArgumentException("file " + file.getAbsolutePath() + " not exists.");
+		}
 		
 		RandomAccessFile raf = null;
 		Vector<ScoreBoard> list = new Vector<ScoreBoard>();
@@ -531,8 +535,9 @@ public class ScoreBoardFileUtil {
 		FilenameFilter filter = new FilenameFilter() {
 
 			public boolean accept(File dir, String name) {
-				if (name.toLowerCase().endsWith(".csv")) 
+				if (name.toLowerCase().endsWith(".csv")){
 					return true;
+				}
 				return false;
 			}};
 		File[] files = file.listFiles(filter);

--- a/src/main/java/edu/isi/karma/er/helper/entity/NYTimes.java
+++ b/src/main/java/edu/isi/karma/er/helper/entity/NYTimes.java
@@ -73,8 +73,9 @@ public class NYTimes {
 			ent.setSubject(subj.getURI());
 			ent.setName(subj.getProperty(NameSpace.SKOS_PREF_LABEL).getObject().asLiteral().getString());
 			stmt = subj.getProperty(NameSpace.NYTIMES_TOPIC_PAGE);
-			if (stmt != null)
+			if (stmt != null){
 				ent.setTopicPage(stmt.getObject().asResource().getURI());
+			}
 			ent.setSearchLink(subj.getProperty(NameSpace.NYTIMES_SEARCH_API_QUERY).getObject().asLiteral().getString());
 			
 			StmtIterator sit = subj.listProperties(NameSpace.OWL_SAME_AS);
@@ -112,8 +113,9 @@ public class NYTimes {
 			ent.setSubject(subj.getURI());
 			ent.setName(subj.getProperty(NameSpace.SKOS_PREF_LABEL).getObject().asLiteral().getString());
 			stmt = subj.getProperty(NameSpace.NYTIMES_TOPIC_PAGE);
-			if (stmt != null)
+			if (stmt != null){
 				ent.setTopicPage(stmt.getObject().asResource().getURI());
+			}
 			ent.setSearchLink(subj.getProperty(NameSpace.NYTIMES_SEARCH_API_QUERY).getObject().asLiteral().getString());
 			
 			StmtIterator sit = subj.listProperties(NameSpace.OWL_SAME_AS);

--- a/src/main/java/edu/isi/karma/er/helper/ontology/MatchOntologyUtil.java
+++ b/src/main/java/edu/isi/karma/er/helper/ontology/MatchOntologyUtil.java
@@ -276,8 +276,9 @@ public class MatchOntologyUtil {
 			}
 			
 			Resource res = this.createMatchOntology(model, finalScore, matched, generatedTime, srcURI, dstURI, creator, comment, srcAttr, srcVal, dstAttr, dstVal, onto.getNytimes());
-			if (res == null)
+			if (res == null){
 				return null;
+			}
 			onto.setResId(res.getURI());
 		}
 		model.commit();
@@ -1200,7 +1201,9 @@ public class MatchOntologyUtil {
 			e.printStackTrace();
 		} finally {
 			try {
-				if (raf != null) raf.close();
+				if (raf != null){
+					raf.close();
+				}
 			} catch (IOException e) {
 				e.printStackTrace();
 			}

--- a/src/main/java/edu/isi/karma/er/matcher/impl/NumberMatcher.java
+++ b/src/main/java/edu/isi/karma/er/matcher/impl/NumberMatcher.java
@@ -111,10 +111,11 @@ public class NumberMatcher implements Matcher {
 			}
 		}
 
-		if (i >= ch.length)
+		if (i >= ch.length){
 			return true;
-		else
+		}else{
 			return false;
+		}
 	}
 
 

--- a/src/main/java/edu/isi/karma/er/matcher/impl/NumberSetMatcher.java
+++ b/src/main/java/edu/isi/karma/er/matcher/impl/NumberSetMatcher.java
@@ -134,10 +134,11 @@ public class NumberSetMatcher implements Matcher {
 			}
 		}
 
-		if (i >= ch.length)
+		if (i >= ch.length){
 			return true;
-		else
+		}else{
 			return false;
+		}
 	}
 
 	public double getMin() {

--- a/src/main/java/edu/isi/karma/er/test/TestPairMatchMain.java
+++ b/src/main/java/edu/isi/karma/er/test/TestPairMatchMain.java
@@ -150,8 +150,9 @@ public class TestPairMatchMain {
 				ScoreBoard sb = map.get(rec.getRes().getSubject());
 				//System.out.println(rec.getRes().getURI());
 				String res = null;
-				if (rec.getRankList().size() > 0)
+				if (rec.getRankList().size() > 0){
 					res = rec.getRankList().get(0).getDstSubj().getSubject();
+				}
 				sb.setRankList(rec.getRankList());
 				sb.setKarmaUri(res);
 				sb.setFound(rec.getCurrentMaxScore()); 			// count means valid results with similarity greater than threshold 0.9

--- a/src/main/java/edu/isi/karma/er/test/old/CreateOntologyRepositoryUsingJena.java
+++ b/src/main/java/edu/isi/karma/er/test/old/CreateOntologyRepositoryUsingJena.java
@@ -261,8 +261,9 @@ public class CreateOntologyRepositoryUsingJena {
 		List<MatchResultOntology> mlist = new Vector<MatchResultOntology>();
 		String filename = "BuildingMatchResult.csv";
 		File file = new File(Constants.PATH_SCORE_BOARD_FILE + filename);
-		if (!file.exists())
+		if (!file.exists()){
 			throw new IllegalArgumentException("file " + file.getAbsolutePath() + " not exists.");
+		}
 		
 		RandomAccessFile raf = null;
 		

--- a/src/main/java/edu/isi/karma/er/test/old/DrawDiagramFromScoreBoard.java
+++ b/src/main/java/edu/isi/karma/er/test/old/DrawDiagramFromScoreBoard.java
@@ -30,8 +30,9 @@ public class DrawDiagramFromScoreBoard {
 				if (s.getKarmaUri().equals(s.getDbpediaUri())) {
 					found ++;
 				}
-				if (lastResult - s.getFound() > 1e-8)
+				if (lastResult - s.getFound() > 1e-8){
 					System.out.println(s.getFound() + "\t" + df.format(found / count)  + "\t" + df.format(found / total) + "\t" + df.format(2*found/(count + total)));
+				}
 				lastResult = s.getFound();
 			}
 		}

--- a/src/main/java/edu/isi/karma/er/test/old/TestRandomFrequency.java
+++ b/src/main/java/edu/isi/karma/er/test/old/TestRandomFrequency.java
@@ -82,8 +82,9 @@ public class TestRandomFrequency {
 			}
 		}
 		File file = new File(Constants.PATH_BASE + "qgram-string-example.csv");
-		if (file.exists())
+		if (file.exists()){
 			file.delete();
+		}
 		RandomAccessFile raf = null;
 		try {
 			file.createNewFile();
@@ -128,8 +129,9 @@ public class TestRandomFrequency {
 		int[] timesArr = {100000000};//, 200000000 ,300000000};//, 40000000, 50000000};//, 60000000, 70000000, 80000000, 90000000};
 		//int[] timesArr = {80000000, 90000000, 100000000};
 		for (int times : timesArr) {
-			for (int i = 0; i < N; i++) 
+			for (int i = 0; i < N; i++){
 				counts[i] = 0;
+			}
 			System.out.println("times:" + times);
 			for (int i = 0; i < times; ) {
 				n1 = r.nextInt(len);
@@ -157,8 +159,10 @@ public class TestRandomFrequency {
 									}
 								}
 								if (j < N)
+								 {
 									counts[j] ++;
 							//} catch (NumberFormatException e) {
+								}
 								
 							//}
 						}
@@ -172,8 +176,9 @@ public class TestRandomFrequency {
 			}
 		}
 		File file = new File(Constants.PATH_BASE + "jw_random_frequency.result");
-		if (file.exists())
+		if (file.exists()){
 			file.delete();
+		}
 		RandomAccessFile raf = null;
 		try {
 			file.createNewFile();
@@ -311,8 +316,9 @@ public class TestRandomFrequency {
 		}
 		
 		File file = new File(Constants.PATH_BASE + "frequency.result");
-		if (file.exists())
+		if (file.exists()){
 			file.delete();
+		}
 		RandomAccessFile raf = null;
 		try {
 			file.createNewFile();
@@ -422,10 +428,11 @@ public class TestRandomFrequency {
 				//if (i % 500000 == 0)
 				//	break;
 			}
-			if (sp.getFullName() != null && sp.getFullName().getValue().size() > 0)
+			if (sp.getFullName() != null && sp.getFullName().getValue().size() > 0){
 				s2 = sp.getFullName().getValue().get(0);
-			else 
+			}else{
 				continue;
+			}
 			for (String s1 : srcList) {
 				
 				/*	

--- a/src/main/java/edu/isi/karma/er/web/service/ResultService.java
+++ b/src/main/java/edu/isi/karma/er/web/service/ResultService.java
@@ -137,8 +137,9 @@ public class ResultService {
 		for (int j = 0; j < resultList.size() ; j++) {
 			ScoreBoard sb = resultList.get(j);
 			onto = util.createMatchOntology(sb, map);
-			if (onto != null)
+			if (onto != null){
 				count ++;
+			}
 			
 		}
 

--- a/src/main/java/edu/isi/karma/geospatial/SpatialReferenceSystemTransformationUtil.java
+++ b/src/main/java/edu/isi/karma/geospatial/SpatialReferenceSystemTransformationUtil.java
@@ -52,8 +52,9 @@ public class SpatialReferenceSystemTransformationUtil {
 		Hints.putSystemDefault(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER,
 				Boolean.TRUE);
 
-		if(sourceCRS.equals(targetCRS))
+		if(sourceCRS.equals(targetCRS)){
 			return inGeom;
+		}
 		
 		MathTransform transform = null;
 		
@@ -85,8 +86,9 @@ public class SpatialReferenceSystemTransformationUtil {
 		Hints.putSystemDefault(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER,
 				Boolean.TRUE);
 		
-		if(fromSRID.equals(toSRID))
+		if(fromSRID.equals(toSRID)){
 			return inGeomWKT;
+		}
 		
 		WKTReader reader = new WKTReader();
 		Geometry JTSGeometry;
@@ -97,10 +99,12 @@ public class SpatialReferenceSystemTransformationUtil {
 			return inGeomWKT;
 		}
 
-		if (!fromSRID.contains(":"))
+		if (!fromSRID.contains(":")){
 			fromSRID = "EPSG:" + fromSRID;
-		if (!toSRID.contains(":"))
+		}
+		if (!toSRID.contains(":")){
 			toSRID = "EPSG:" + toSRID;
+		}
 
 		CoordinateReferenceSystem sourceCRS = null;
 		CoordinateReferenceSystem targetCRS = null;

--- a/src/main/java/edu/isi/karma/geospatial/WorksheetGeospatialContent.java
+++ b/src/main/java/edu/isi/karma/geospatial/WorksheetGeospatialContent.java
@@ -177,7 +177,9 @@ public class WorksheetGeospatialContent {
 						.getValue().asString();
 		        WKTReader reader = new WKTReader();
 		        Polygon JTSPolygon = (Polygon)reader.read(posList);
-		        if(JTSPolygon == null) continue;
+		        if(JTSPolygon == null){
+					continue;
+				}
 		        polygons.add(JTSPolygon);
 				FeatureTable featureTable = new FeatureTable();
 				Collection<Node> nodes = row.getNodes();
@@ -205,7 +207,9 @@ public class WorksheetGeospatialContent {
 		        WKTReader reader = new WKTReader();
 		        
 		        LineString JTSLine = (LineString)reader.read(posList);
-		        if(JTSLine == null) continue;
+		        if(JTSLine == null){
+					continue;
+				}
 		        int lineLength = JTSLine.getNumPoints();
 				List<Coordinate> coordsList = new ArrayList<Coordinate>();
 				for (int i=0;i<lineLength;i++) {
@@ -214,8 +218,9 @@ public class WorksheetGeospatialContent {
 					coordsList.add(coord);
 				}
 
-				if (coordsList.size() == 0)
+				if (coordsList.size() == 0){
 					continue;
+				}
 
 				edu.isi.karma.geospatial.LineString line = new edu.isi.karma.geospatial.LineString(coordsList);
 				Collection<Node> nodes = row.getNodes();
@@ -265,7 +270,9 @@ public class WorksheetGeospatialContent {
 					//	lat = coordinateSplit[1];
 						WKTReader reader = new WKTReader();
 						Point JTSPoint = (Point)reader.read(coordinate);
-						if(JTSPoint == null) continue;
+						if(JTSPoint == null){
+							continue;
+						}
 						lng = Double.toString(JTSPoint.getX());
 						lat = Double.toString(JTSPoint.getY());
 					} catch (Exception e) {
@@ -285,8 +292,9 @@ public class WorksheetGeospatialContent {
 				}
 
 				if (lng == null || lng.trim().equals("") || lat == null
-						|| lat.trim().equals(""))
+						|| lat.trim().equals("")){
 					continue;
+				}
 
 				double lngF = Double.parseDouble(lng.trim());
 				double latF = Double.parseDouble(lat.trim());
@@ -334,10 +342,11 @@ public class WorksheetGeospatialContent {
 
 		Style style = folder.createAndAddStyle().withId("karma");
 		
-		if(randomCounter++%2 == 0)
+		if(randomCounter++%2 == 0){
 			style.createAndSetIconStyle().withScale(1.399999976158142).withIcon(new Icon().withHref("http://maps.google.com/mapfiles/ms/icons/blue-pushpin.png"));
-		else
+		}else{
 			style.createAndSetIconStyle().withScale(1.399999976158142).withIcon(new Icon().withHref("http://maps.google.com/mapfiles/ms/icons/red-pushpin.png"));
+		}
 
 		for (edu.isi.karma.geospatial.Point point : points) {
 			folder.createAndAddPlacemark()
@@ -396,8 +405,9 @@ public class WorksheetGeospatialContent {
 				List<Coordinate> innercoord = new ArrayList<Coordinate>();
 				innerlinearring.setCoordinates(innercoord);
 				int numOfPoints = polygon.getInteriorRingN(i).getNumPoints();
-				for(int j=0;j<numOfPoints;j++)
+				for(int j=0;j<numOfPoints;j++){
 					innercoord.add(new Coordinate(polygon.getInteriorRingN(i).getPointN(j).getX(),polygon.getInteriorRingN(i).getPointN(j).getY()));
+				}
 				
 			}
 			
@@ -410,8 +420,9 @@ public class WorksheetGeospatialContent {
 	}
 
 	public boolean hasNoGeospatialData() {
-		if (points.size() == 0 && lines.size() == 0 && polygons.size()==0)
+		if (points.size() == 0 && lines.size() == 0 && polygons.size()==0){
 			return true;
+		}
 		return false;
 	}
 }

--- a/src/main/java/edu/isi/karma/geospatial/WorksheetToFeatureCollection.java
+++ b/src/main/java/edu/isi/karma/geospatial/WorksheetToFeatureCollection.java
@@ -192,27 +192,32 @@ public class WorksheetToFeatureCollection {
 		String domainURI = type.getDomain().getUri();
 		if ((typeURI.equals(property) && domainURI.equals(domain))
 				|| (isSubPropertyOf(typeURI, property, true) && isSubClassOf(
-						domainURI, domain, true)))
+						domainURI, domain, true))){
 			return true;
-		else
+		}else{
 			return false;
+		}
 	}
 
 	private void Go() {
 		prepareFeatureSchema();
-		if (pointFeatureHNodeId != "")
+		if (pointFeatureHNodeId != ""){
 			populateSimpleFeatures(pointFeatureHNodeId,
 					"", getRows(), pointFeatureList, Point.class);
-		if (pointFeatureLatHNodeId != "" && pointFeatureLonHNodeId != "")
+		}
+		if (pointFeatureLatHNodeId != "" && pointFeatureLonHNodeId != ""){
 			populateSimpleFeatures(pointFeatureLonHNodeId,
 					pointFeatureLatHNodeId, getRows(), pointFeatureList,
 					Point.class);
-		if (lineFeatureHNodeId != "")
+		}
+		if (lineFeatureHNodeId != ""){
 			populateSimpleFeatures(lineFeatureHNodeId, "",
 					getRows(), lineFeatureList, LineString.class);
-		if (polygonFeatureHNodeId != "")
+		}
+		if (polygonFeatureHNodeId != ""){
 			populateSimpleFeatures(polygonFeatureHNodeId,
 					"", getRows(), polygonFeatureList, Polygon.class);
+		}
 	}
 	private void prepareFeatureSchema() {
 		List<String> spatialHNodeIds = new ArrayList<String>();
@@ -256,8 +261,9 @@ public class WorksheetToFeatureCollection {
 							.getSynonymTypesForHNodeId(kmlCategoryHNodeId)
 							.getSynonyms()) {
 						if (hasType(synonymType, KML_LABEL_PROPERTY,
-								KML_CUSTOMIZATION_CLASS))
+								KML_CUSTOMIZATION_CLASS)){
 							kmlLabelHNodeId = kmlCategoryHNodeId;
+						}
 					}
 				}
 			} else if (hasType(type, KML_LABEL_PROPERTY,
@@ -269,8 +275,9 @@ public class WorksheetToFeatureCollection {
 							.getSynonymTypesForHNodeId(kmlLabelHNodeId)
 							.getSynonyms()) {
 						if (hasType(synonymType, KML_CATEGORY_PROPERTY,
-								KML_CUSTOMIZATION_CLASS))
+								KML_CUSTOMIZATION_CLASS)){
 							kmlCategoryHNodeId = kmlLabelHNodeId;
+						}
 					}
 				}
 			}
@@ -293,10 +300,12 @@ public class WorksheetToFeatureCollection {
 					featureSchema.add(descriptor);
 					geomHNodeIdList.add(hNode.getId());
 
-					if (hNode.getId().equals(kmlCategoryHNodeId))
+					if (hNode.getId().equals(kmlCategoryHNodeId)){
 						kmlCategoryColumnName = hNode.getColumnName();
-					if (hNode.getId().equals(kmlLabelHNodeId))
+					}
+					if (hNode.getId().equals(kmlLabelHNodeId)){
 						kmlLabelColumnName = hNode.getColumnName();
+					}
 				}
 			}
 		}
@@ -322,31 +331,36 @@ public class WorksheetToFeatureCollection {
 							.asString();
 					String lat = row.getNode(geometry2HNodeId).getValue()
 							.asString();
-					if (lon.trim().length() == 0 || lat.trim().length() == 0)
+					if (lon.trim().length() == 0 || lat.trim().length() == 0){
 						continue;
+					}
 					posList = "POINT(" + lon + " " + lat + ")";
 				}
 
-				if (posList == null) // no spatial data
+				if (posList == null){
 					continue;
-				else if(!posList.contains("(")) { // assuming the lon, lat case ... we might need to handle additional cases
+				}else if(!posList.contains("(")) { // assuming the lon, lat case ... we might need to handle additional cases
 					posList = "POINT(" + posList.replace(","," ")+")";
 				}
 				posList = posList.toUpperCase();
 				WKTReader reader = new WKTReader();
 				JTSGeometry = reader.read(posList);
 
-				if (JTSGeometry == null) 
+				if (JTSGeometry == null){
 					continue;
+				}
 
 				String srid = "";
-				if (SRIDHNodeId != "")
+				if (SRIDHNodeId != ""){
 					srid = row.getNode(SRIDHNodeId).getValue().asString();
-				else
+				}
+				else {
 					srid = "4326"; // default to WGS84
+				}
 
-				if (!srid.contains(":"))
+				if (!srid.contains(":")){
 					srid = "EPSG:" + srid;
+				}
 				CoordinateReferenceSystem sourceCRS = null;
 
 				try {
@@ -369,9 +383,9 @@ public class WorksheetToFeatureCollection {
 
 				for (String hNodeId : geomHNodeIdList) {
 					Node node = row.getNode(hNodeId);
-					if (node.hasNestedTable())
+					if (node.hasNestedTable()){
 						featureBuilder.add("Nested table");
-					else {
+					}else {
 						String colValue = node.getValue().asString();
 						featureBuilder.add(colValue);
 					}
@@ -408,15 +422,18 @@ public class WorksheetToFeatureCollection {
 
 		File kml = publishKML(spatialDataFolder, fileName);
 		if (pointFeatureHNodeId != ""
-				|| (pointFeatureLatHNodeId != "" && pointFeatureLonHNodeId != ""))
+				|| (pointFeatureLatHNodeId != "" && pointFeatureLonHNodeId != "")){
 			saveShapefile(pointFeatureList, spatialDataFolder, fileName
 					+ "_point");
-		if (lineFeatureHNodeId != "")
+		}
+		if (lineFeatureHNodeId != ""){
 			saveShapefile(lineFeatureList, spatialDataFolder, fileName
 					+ "_line");
-		if (polygonFeatureHNodeId != "")
+		}
+		if (polygonFeatureHNodeId != ""){
 			saveShapefile(polygonFeatureList, spatialDataFolder, fileName
 					+ "_polygon");
+		}
 
 		saveSpatialDataToZip(spatialDataFolder, fileName);
 		return fileToString(kml);
@@ -456,15 +473,18 @@ public class WorksheetToFeatureCollection {
 
 		File kml = publishKML(spatialDataFolder, fileName);
 		if (pointFeatureHNodeId != ""
-				|| (pointFeatureLatHNodeId != "" && pointFeatureLonHNodeId != ""))
+				|| (pointFeatureLatHNodeId != "" && pointFeatureLonHNodeId != "")){
 			saveShapefile(pointFeatureList, spatialDataFolder, fileName
 					+ "_point");
-		if (lineFeatureHNodeId != "")
+		}
+		if (lineFeatureHNodeId != ""){
 			saveShapefile(lineFeatureList, spatialDataFolder, fileName
 					+ "_line");
-		if (polygonFeatureHNodeId != "")
+		}
+		if (polygonFeatureHNodeId != ""){
 			saveShapefile(polygonFeatureList, spatialDataFolder, fileName
 					+ "_polygon");
+		}
 
 		saveSpatialDataToZip(spatialDataFolder, fileName);
 		return kml;
@@ -499,8 +519,9 @@ public class WorksheetToFeatureCollection {
 			 */
 			CoordinateReferenceSystem crs = features.get(0).getFeatureType()
 					.getCoordinateReferenceSystem();
-			if (crs == null)
+			if (crs == null){
 				newDataStore.forceSchemaCRS(DefaultGeographicCRS.WGS84);
+			}
 			
 			for (int i=1;i<features.size();i++) {
 				
@@ -509,8 +530,9 @@ public class WorksheetToFeatureCollection {
 				CoordinateReferenceSystem crs2 = feature.getFeatureType()
 				.getCoordinateReferenceSystem();
 				
-				if(crs2==null)
+				if(crs2==null){
 					continue;
+				}
 				
 				if(!crs.equals(crs2)) {
 					remainingFeatures.add(feature);
@@ -556,9 +578,10 @@ public class WorksheetToFeatureCollection {
 		} catch (Exception e) {
 			logger.error("Shapefile file published failed! Do you have multiple SRID in a single worksheet?");
 		}
-		if(!remainingFeatures.isEmpty())
+		if(!remainingFeatures.isEmpty()){
 			saveShapefile(remainingFeatures,
 				spatialDataFolder, fileName+"_");
+		}
 				
 		logger.info("Shapefile file published. Location:"
 				+ outputFile.getAbsolutePath());
@@ -566,8 +589,9 @@ public class WorksheetToFeatureCollection {
 	}
 
 	public String getKMLStyle(String label, Folder folder) {
-		if (kmlStyles.containsKey(label))
+		if (kmlStyles.containsKey(label)){
 			return (String) kmlStyles.get(label);
+		}
 
 		int pushpingLinkCounter = kmlStylesCounter % kmlPushPings.length;
 		int colorCounter = kmlStylesCounter % kmlColors.length;
@@ -813,10 +837,11 @@ public class WorksheetToFeatureCollection {
 		for (Property property : simpleFeature.getProperties()) {
 			if (property.getName().toString() != GEOM) {
 				str.append("<b>" + property.getName() + "</b>: ");
-				if (property.getValue() != null)
+				if (property.getValue() != null){
 					str.append(property.getValue().toString() + " <br />");
-				else
+				}else{
 					str.append(" <br />");
+				}
 			}
 		}
 		return str.toString();
@@ -840,15 +865,16 @@ public class WorksheetToFeatureCollection {
 			File dir = new File(sourceDirectory);
 
 			// check to see if this directory exists
-			if (!dir.isDirectory())
+			if (!dir.isDirectory()){
 				System.out.println(sourceDirectory + " is not a directory");
-			else {
+			}else {
 				File[] files = dir.listFiles();
 
 				for (int i = 0; i < files.length; i++) {
 					System.out.println("Adding " + files[i].getName());
-					if (files[i].getName().contains(".zip"))
+					if (files[i].getName().contains(".zip")){
 						continue;
+					}
 					// create object of FileInputStream for source file
 					FileInputStream fin = new FileInputStream(files[i]);
 
@@ -897,8 +923,9 @@ public class WorksheetToFeatureCollection {
 
 	public boolean hasNoGeospatialData() {
 		if (pointFeatureList.size() == 0 && lineFeatureList.size() == 0
-				&& polygonFeatureList.size() == 0)
+				&& polygonFeatureList.size() == 0){
 			return true;
+		}
 		return false;
 	}
 

--- a/src/main/java/edu/isi/karma/imp/csv/CSVFileExport.java
+++ b/src/main/java/edu/isi/karma/imp/csv/CSVFileExport.java
@@ -57,10 +57,13 @@ public class CSVFileExport {
 		for (SemanticType type : worksheet.getSemanticTypes().getListOfTypes()) {
 			modeledColumnTable.put(type.getHNodeId(),"");
 		}
-		if(modeledColumnTable.size()==0) return null;
+		if(modeledColumnTable.size()==0){
+			return null;
+		}
 		int numRows = worksheet.getDataTable().getNumRows();
-		if(numRows==0) 
+		if(numRows==0){
 			return "";
+		}
 		StringBuilder sb = new StringBuilder();
 		ArrayList<Row> rows =  worksheet.getDataTable().getRows(0, numRows);
 		List<HNode> sortedLeafHNodes = new ArrayList<HNode>();
@@ -68,8 +71,9 @@ public class CSVFileExport {
 		worksheet.getHeaders().getSortedLeafHNodes(sortedLeafHNodes);
 		for (HNode hNode : sortedLeafHNodes) {
 			if(modeledColumnTable.containsKey(hNode.getId())) {
-				if (sb.length() != 0)
+				if (sb.length() != 0){
 					sb.append(",");
+				}
 				sb.append(hNode.getColumnName());
 				hNodeIdList.add(hNode.getId());
 			}
@@ -79,10 +83,11 @@ public class CSVFileExport {
 			boolean newRow = true;
 			try {
 				for(String hNodeId : hNodeIdList) {
-					if(!newRow) 
+					if(!newRow){
 						sb.append(",");
-					else
+					}else{
 						newRow = false;
+					}
 					String colValue =row.getNode(hNodeId).getValue().asString();
 					sb.append("\"");
 					sb.append(colValue);

--- a/src/main/java/edu/isi/karma/imp/csv/CSVFileImport.java
+++ b/src/main/java/edu/isi/karma/imp/csv/CSVFileImport.java
@@ -125,10 +125,11 @@ public class CSVFileImport {
 			
 		for (int i = 0; i < rowValues.length; i++) {
 			HNode hNode = null;
-			if (headerRowIndex == 0)
+			if (headerRowIndex == 0){
 				hNode = headers.addHNode("Column_" + (i + 1), worksheet, fac);
-			else
+			}else{
 				hNode = headers.addHNode(rowValues[i], worksheet, fac);
+			}
 			headersList.add(hNode.getId());
 		}
 		reader.close();
@@ -148,9 +149,9 @@ public class CSVFileImport {
 			
 		Row row = dataTable.addRow(fac);
 		for (int i = 0; i < rowValues.length; i++) {
-			if (i < hNodeIdList.size())
+			if (i < hNodeIdList.size()){
 				row.setValue(hNodeIdList.get(i), rowValues[i], fac);
-			else {
+			}else {
 				// TODO Our model does not allow a value to be added to a row
 				// without its associated HNode. In CSVs, there could be case
 				// where values in rows are greater than number of column names.
@@ -190,8 +191,9 @@ public class CSVFileImport {
 				break;
 			}
 			rowCount++;
-			if(scanner.hasNext())
+			if(scanner.hasNext()){
 				scanner.nextLine();
+			}
 		}
 		return headersList;
 	}

--- a/src/main/java/edu/isi/karma/imp/json/JsonImport.java
+++ b/src/main/java/edu/isi/karma/imp/json/JsonImport.java
@@ -203,15 +203,15 @@ public class JsonImport {
 			Row row = dataTable.addRow(factory);
 			// TODO, conserve the types of the primitive types.
 			String value = "";
-			if (listValue instanceof String || listValue instanceof Boolean)
+			if (listValue instanceof String || listValue instanceof Boolean){
 				value = (String) listValue;
-			else if (listValue instanceof Double)
+			}else if (listValue instanceof Double){
 				value = Double.toString((Double) listValue);
-			else if (listValue instanceof Integer)
+			}else if (listValue instanceof Integer){
 				value = Integer.toString((Integer) listValue);
-			else if (listValue instanceof Long)
+			}else if (listValue instanceof Long){
 				value = Long.toString((Long) listValue);
-			else {
+			}else {
 				// Pedro 2012/09/14
 				logger.error("Unexpected value in JSON array:"
 						+ listValue.toString());

--- a/src/main/java/edu/isi/karma/imp/mdb/MDBFileExport.java
+++ b/src/main/java/edu/isi/karma/imp/mdb/MDBFileExport.java
@@ -62,8 +62,9 @@ public class MDBFileExport {
 			modeledColumnTable.put(type.getHNodeId(),"");
 		}
 		int numRows = worksheet.getDataTable().getNumRows();
-		if(numRows==0) 
+		if(numRows==0){
 			return "";
+		}
 		
 		Database db;
 		try {
@@ -77,8 +78,9 @@ public class MDBFileExport {
 			for (HNode hNode : sortedLeafHNodes) {
 				if (modeledColumnTable.containsKey(hNode.getId())) {
 					String columnName = hNode.getColumnName();
-					if (columnName.equals(""))
+					if (columnName.equals("")){
 						columnName = "NA";
+					}
 					tb.addColumn(new ColumnBuilder(columnName).setType(
 							DataType.MEMO).toColumn());
 					hNodeIdList.add(hNode.getId());

--- a/src/main/java/edu/isi/karma/kr2rml/KR2RMLMappingGenerator.java
+++ b/src/main/java/edu/isi/karma/kr2rml/KR2RMLMappingGenerator.java
@@ -127,8 +127,9 @@ public class KR2RMLMappingGenerator {
 			if (subjMap.getTemplate().getAllTerms().size() == 1 &&
 					(subjMap.getTemplate().getAllTerms().get(0) instanceof StringTemplateTerm)) {
 				String str = subjMap.getTemplate().getAllTerms().get(0).getTemplateTermValue();
-				if (str.equals(sourceNamespace)) 
+				if (str.equals(sourceNamespace)){
 					subjMap.setAsBlankNode(true);
+				}
 			}
 		}
 	}
@@ -179,8 +180,9 @@ public class KR2RMLMappingGenerator {
 			if (node instanceof InternalNode) {
 				SubjectMap subj = new SubjectMap(node.getId());
 				
-				if (node.getId().equals(steinerTreeRoot.getId()))
+				if (node.getId().equals(steinerTreeRoot.getId())){
 					subj.setAsSteinerTreeRootNode(true);
+				}
 				
 				// Add the user provided namespace as the first template term
 				subj.getTemplate().addTemplateTermToSet(new StringTemplateTerm(sourceNamespace));
@@ -243,8 +245,9 @@ public class KR2RMLMappingGenerator {
 					if (olink instanceof ObjectPropertySpecializationLink 
 							|| olink instanceof DataPropertyOfColumnLink 
 							|| olink instanceof ClassInstanceLink 
-							|| olink instanceof ColumnSubClassLink)
+							|| olink instanceof ColumnSubClassLink){
 						continue;
+					}
 					
 					PredicateObjectMap poMap = new PredicateObjectMap(subjTrMap);
 					Node target = olink.getTarget();
@@ -275,8 +278,9 @@ public class KR2RMLMappingGenerator {
 									new StringTemplateTerm(olink.getLabel().getUri(), true));
 						}
 						poMap.setPredicate(pred);
-						if (generateInverse)
+						if (generateInverse){
 							addInversePropertyIfExists(subjMap, poMap, olink, subjTrMap);
+						}
 						
 						// Add the links in the graph links data structure
 						TriplesMapLink link = new TriplesMapLink(subjTrMap, objTrMap, poMap);  
@@ -320,8 +324,9 @@ public class KR2RMLMappingGenerator {
 						addSynonymTypesPredicateObjectMaps(subjTrMap, hNodeId);
 					}
 					// Add the predicateobjectmap to the triples map after a sanity check
-					if (poMap.getObject() != null && poMap.getPredicate() != null)
+					if (poMap.getObject() != null && poMap.getPredicate() != null){
 						subjTrMap.addPredicateObjectMap(poMap);
+					}
 				}
 			}
 		}
@@ -378,8 +383,9 @@ public class KR2RMLMappingGenerator {
 			PredicateObjectMap poMap, Link olink, TriplesMap subjTrMap) {
 		String propUri = olink.getLabel().getUri();
 		//this can happen if propertyName is not an Object property; it could be a subclass
-		if (!ontMgr.isObjectProperty(propUri))
+		if (!ontMgr.isObjectProperty(propUri)){
 			return;
+		}
 		
 		Label inversePropLabel = ontMgr.getInverseProperty(propUri);
 		Label inverseOfPropLabel = ontMgr.getInverseOfProperty(propUri);
@@ -428,8 +434,9 @@ public class KR2RMLMappingGenerator {
 			// Check for the object property specialization
 			if (olink instanceof ObjectPropertySpecializationLink ) {
 				ObjectPropertySpecializationLink splLink = (ObjectPropertySpecializationLink) olink;
-				if (splLink.getSpecializedLink().getId().equals(link.getId()))
+				if (splLink.getSpecializedLink().getId().equals(link.getId())){
 					return olink;
+				}
 			}
 			// Check for the data property specialization
 			else if (olink instanceof DataPropertyOfColumnLink) {
@@ -437,8 +444,9 @@ public class KR2RMLMappingGenerator {
 				Node target = link.getTarget();
 				if (target instanceof ColumnNode) {
 					ColumnNode cnode = (ColumnNode) target;
-					if (dlink.getSpecializedColumnHNodeId().equals(cnode.getId()))
+					if (dlink.getSpecializedColumnHNodeId().equals(cnode.getId())){
 						return dlink;
+					}
 				}
 			}
 		}

--- a/src/main/java/edu/isi/karma/kr2rml/KR2RMLWorksheetRDFGenerator.java
+++ b/src/main/java/edu/isi/karma/kr2rml/KR2RMLWorksheetRDFGenerator.java
@@ -115,8 +115,9 @@ public class KR2RMLWorksheetRDFGenerator {
 				Map<String, ReportMessage> predicatesFailed = new HashMap<String,ReportMessage>();
 				generateTriplesForRow(row, rowTriplesSet, rowPredicatesCovered, predicatesFailed);
 				outWriter.println();
-				if (i++%2000 == 0)
+				if (i++%2000 == 0){
 					logger.info("Done processing " + i + " rows");
+				}
 				for (ReportMessage errMsg:predicatesFailed.values()){
 					this.errorReport.addReportMessage(errMsg);
 				}
@@ -157,8 +158,9 @@ public class KR2RMLWorksheetRDFGenerator {
 			Map<String, ReportMessage> predicatesFailed) {
 		Map<String, String> columnValues = node.getColumnValues();
 		List<PredicateObjectMap> pomList = this.auxInfo.getHNodeIdToPredObjLinks().get(hNodeId);
-		if (pomList == null || pomList.isEmpty())
+		if (pomList == null || pomList.isEmpty()){
 			return;
+		}
 		
 		List<TriplesMap> toBeProcessedTriplesMap = new LinkedList<TriplesMap>();
 		for (PredicateObjectMap pom:pomList) {
@@ -187,8 +189,9 @@ public class KR2RMLWorksheetRDFGenerator {
 					.getAllNeighboringTriplesMap(trMap.getId());
 			
 			for (TriplesMapLink trMapLink:neighboringLinks) {
-				if (predicatesCovered.contains(trMapLink.getPredicateObjectMapLink().getPredicate().getId()))
+				if (predicatesCovered.contains(trMapLink.getPredicateObjectMapLink().getPredicate().getId())){
 					continue;
+				}
 				
 				// Add the other triplesMap in queue to be processed later
 				if (!alreadyProcessedTriplesMapIds.contains(trMapLink.getSourceMap().getId())
@@ -277,8 +280,9 @@ public class KR2RMLWorksheetRDFGenerator {
 			String value = "";
 			try {
 				value = getTemplateTermSetPopulatedWithValues(columnValues, pom.getObject().getTemplate());
-				if (value == null || value.trim().equals(""))
+				if (value == null || value.trim().equals("")){
 					return;
+				}
 			} catch (ValueNotFoundKarmaException ve) {
 				ReportMessage msg = createReportMessage("Could not retrieve value for the <i>predicate:" + 
 						pom.getPredicate().getTemplate().toString().replaceAll("<", "{").replaceAll(">", "}") +
@@ -296,8 +300,9 @@ public class KR2RMLWorksheetRDFGenerator {
 			}
 		}
 		predicatesCovered.add(pom.getPredicate().getId());
-		if (predicatesFailed.containsKey(pom.getPredicate().getId()))
+		if (predicatesFailed.containsKey(pom.getPredicate().getId())){
 			predicatesFailed.remove(pom.getPredicate().getId());
+		}
 	}
 
 	private ReportMessage createReportMessage(String title, ValueNotFoundKarmaException ve, 
@@ -314,9 +319,10 @@ public class KR2RMLWorksheetRDFGenerator {
 		if (subjMap.isBlankNode()) {
 			uri = getBlankNodeUri(subjMap.getId(), columnValues).replaceAll(" ", "")
 					.replaceAll("[,`']", "_");
-		} else 
+		}else{
 			uri = getTemplateTermSetPopulatedWithValues(columnValues, subjMap.getTemplate())
 				.replaceAll(" ", "").replaceAll("[,`']", "_");
+		}
 		
 		// Generate triples for specifying the types
 		for (TemplateTermSet typeTerm:subjMap.getRdfsType()) {
@@ -331,11 +337,13 @@ public class KR2RMLWorksheetRDFGenerator {
 	}
 	
 	private String constructTripleWithURIObject(String subjUri, String predicateUri, String objectUri) {
-		if (!subjUri.startsWith(BLANK_NODE_PREFIX))
+		if (!subjUri.startsWith(BLANK_NODE_PREFIX)){
 			subjUri = "<" + subjUri + ">";
+		}
 		
-		if (!objectUri.startsWith(BLANK_NODE_PREFIX))
+		if (!objectUri.startsWith(BLANK_NODE_PREFIX)){
 			objectUri = "<" + objectUri + ">";
+		}
 		
 		return subjUri + " " 
 				+ getNormalizedPredicateUri(predicateUri) + " " 
@@ -344,8 +352,9 @@ public class KR2RMLWorksheetRDFGenerator {
 	
 	private String constructTripleWithLiteralObject(String subjUri, String predicateUri, String value, 
 			String literalType) {
-		if (!subjUri.startsWith(BLANK_NODE_PREFIX))
+		if (!subjUri.startsWith(BLANK_NODE_PREFIX)){
 			subjUri = "<" + subjUri + ">";
+		}
 		
 		// Escaping the quotes
 		value = value.replaceAll("\\\\", "\\\\\\\\");

--- a/src/main/java/edu/isi/karma/kr2rml/ObjectMap.java
+++ b/src/main/java/edu/isi/karma/kr2rml/ObjectMap.java
@@ -39,11 +39,13 @@ public class ObjectMap extends TermMap {
 
 	@Override
 	public String toString() {
-		if (template != null)
+		if (template != null){
 			return "ObjectMap [template=" + template + "]";
-		else if (refObjectMap != null)
+		}else if (refObjectMap != null){
 			return "RefObjectMap [" + refObjectMap.getParentTriplesMap().getId() + "]";
-		else return "<No ObjectMap or RefObjectMap found for the ObjectMap!>";
+		}else{
+			return "<No ObjectMap or RefObjectMap found for the ObjectMap!>";
+		}
 	}
 	
 	public boolean hasRefObjectMap() {

--- a/src/main/java/edu/isi/karma/kr2rml/R2RMLMapping.java
+++ b/src/main/java/edu/isi/karma/kr2rml/R2RMLMapping.java
@@ -48,8 +48,9 @@ public class R2RMLMapping {
 	public String toString() {
 		StringBuilder str = new StringBuilder();
 		str.append("R2RMLMapping [triplesMapSet=\n");
-		for (TriplesMap trMap:triplesMapList)
+		for (TriplesMap trMap:triplesMapList){
 			str.append("\t" + trMap.toString() + "\n");
+		}
 		str.append("]");
 		return str.toString();
 	}

--- a/src/main/java/edu/isi/karma/kr2rml/ReportMessage.java
+++ b/src/main/java/edu/isi/karma/kr2rml/ReportMessage.java
@@ -49,25 +49,33 @@ class ReportMessage {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj)
+		if (this == obj){
 			return true;
-		if (obj == null)
+		}
+		if (obj == null){
 			return false;
-		if (!(obj instanceof ReportMessage))
+		}
+		if (!(obj instanceof ReportMessage)){
 			return false;
+		}
 		ReportMessage other = (ReportMessage) obj;
 		if (description == null) {
-			if (other.description != null)
+			if (other.description != null){
 				return false;
-		} else if (!description.equals(other.description))
+			}
+		} else if (!description.equals(other.description)){
 			return false;
-		if (priority != other.priority)
+		}
+		if (priority != other.priority){
 			return false;
+		}
 		if (title == null) {
-			if (other.title != null)
+			if (other.title != null){
 				return false;
-		} else if (!title.equals(other.title))
+			}
+		} else if (!title.equals(other.title)){
 			return false;
+		}
 		return true;
 	}
 

--- a/src/main/java/edu/isi/karma/kr2rml/TemplateTermSet.java
+++ b/src/main/java/edu/isi/karma/kr2rml/TemplateTermSet.java
@@ -67,10 +67,11 @@ public class TemplateTermSet {
 	public String toString() {
 		StringBuilder str = new StringBuilder();
 		for (TemplateTerm term:termSet) {
-			if (term instanceof StringTemplateTerm)
+			if (term instanceof StringTemplateTerm){
 				str.append("<" + term.getTemplateTermValue() + ">");
-			else if (term instanceof ColumnTemplateTerm)
+			}else if (term instanceof ColumnTemplateTerm){
 				str.append("<ColumnHNodeId:" + term.getTemplateTermValue() + ">");
+			}
 		}
 		return str.toString();
 	}
@@ -150,15 +151,17 @@ public class TemplateTermSet {
 	}
 
 	public boolean isSingleUriString() {
-		if (termSet.size() == 1 && termSet.get(0) instanceof StringTemplateTerm)
+		if (termSet.size() == 1 && termSet.get(0) instanceof StringTemplateTerm){
 			return ((StringTemplateTerm)termSet.get(0)).hasFullUri();
+		}
 		
 		return false;
 	}
 
 	public boolean isSingleColumnTerm() {
-		if (termSet.size() == 1 && termSet.get(0) instanceof ColumnTemplateTerm)
+		if (termSet.size() == 1 && termSet.get(0) instanceof ColumnTemplateTerm){
 			return true;
+		}
 		return false;
 	}
 }

--- a/src/main/java/edu/isi/karma/kr2rml/TemplateTermSetBuilder.java
+++ b/src/main/java/edu/isi/karma/kr2rml/TemplateTermSetBuilder.java
@@ -132,8 +132,10 @@ public class TemplateTermSetBuilder {
 	}
 	
 	private static String removeR2rmlFormatting(String r2rmlColName) {
-		if (r2rmlColName.startsWith("{\"") && r2rmlColName.endsWith("\"}"))
+		if (r2rmlColName.startsWith("{\"") && r2rmlColName.endsWith("\"}")){
 			return r2rmlColName.substring(2, r2rmlColName.length()-2);
-		else return r2rmlColName;
+		}else{
+			return r2rmlColName;
+		}
 	}
 }

--- a/src/main/java/edu/isi/karma/kr2rml/TriplesMapGraph.java
+++ b/src/main/java/edu/isi/karma/kr2rml/TriplesMapGraph.java
@@ -65,8 +65,9 @@ public class TriplesMapGraph {
 	}
 	
 	public List<TriplesMapLink> getAllNeighboringTriplesMap(String triplesMapId) {
-		if (neighboringTriplesMapCache.get(triplesMapId) == null)
+		if (neighboringTriplesMapCache.get(triplesMapId) == null){
 			return new ArrayList<TriplesMapLink>();
+		}
 		
 		return neighboringTriplesMapCache.get(triplesMapId);
 	}

--- a/src/main/java/edu/isi/karma/kr2rml/WorksheetR2RMLJenaModelParser.java
+++ b/src/main/java/edu/isi/karma/kr2rml/WorksheetR2RMLJenaModelParser.java
@@ -124,8 +124,9 @@ public class WorksheetR2RMLJenaModelParser {
 			throw new KarmaException("More than one resource exists with source name: " + sourceName);
 		} else if (resList.size() == 1) {
 			return resList.get(0);
-		} else 
+		}else{
 			return null;
+		}
 		
 	}
 	
@@ -342,8 +343,9 @@ public class WorksheetR2RMLJenaModelParser {
 				RDFNode typeNode = rdfTypesItr.next();
 				if (typeNode instanceof Resource) {
 					// Skip the steiner tree root type
-					if(((Resource) typeNode).getURI().equals(Uris.KM_STEINER_TREE_ROOT_NODE))
+					if(((Resource) typeNode).getURI().equals(Uris.KM_STEINER_TREE_ROOT_NODE)){
 						continue;
+					}
 					
 					StringTemplateTerm uriTerm = new StringTemplateTerm(
 							((Resource) typeNode).getURI(), true);

--- a/src/main/java/edu/isi/karma/kr2rml/WorksheetR2RMLSesameModelParser.java
+++ b/src/main/java/edu/isi/karma/kr2rml/WorksheetR2RMLSesameModelParser.java
@@ -292,8 +292,9 @@ public class WorksheetR2RMLSesameModelParser {
 				Statement typeStmt = rdfTypes.next();
 				if (typeStmt.getObject() instanceof Resource) {
 					// Skip the steiner tree root type
-					if(typeStmt.getObject().stringValue().equals(Uris.KM_STEINER_TREE_ROOT_NODE))
+					if(typeStmt.getObject().stringValue().equals(Uris.KM_STEINER_TREE_ROOT_NODE)){
 						continue;
+					}
 					
 					StringTemplateTerm uriTerm = new StringTemplateTerm(
 							typeStmt.getObject().stringValue(), true);

--- a/src/main/java/edu/isi/karma/linkedapi/server/GetRequestManager.java
+++ b/src/main/java/edu/isi/karma/linkedapi/server/GetRequestManager.java
@@ -60,8 +60,9 @@ public class GetRequestManager extends LinkedApiRequestManager {
 					getResponse().setContentType(MimeType.TEXT_PLAIN);
 					pw.write(sparql);
 					return;
-				} else
+				}else{
 					m = servicePublisher.generateInputPart();
+				}
 			}
 
 			if (getResourceType() == ResourceType.Output) {
@@ -70,17 +71,19 @@ public class GetRequestManager extends LinkedApiRequestManager {
 					getResponse().setContentType(MimeType.TEXT_PLAIN);
 					pw.write(sparql);
 					return;
-				} else
-					m = servicePublisher.generateOutputPart();;
+				}else{
+					m = servicePublisher.generateOutputPart();
+				};
 			}
 		}
 		
-		if (getFormat().equalsIgnoreCase(SerializationLang.XML))
-			getResponse().setContentType(MimeType.APPLICATION_XML); 
-		else if (getFormat().equalsIgnoreCase(SerializationLang.XML_ABBREV))
-			getResponse().setContentType(MimeType.APPLICATION_XML); 
-		else
+		if (getFormat().equalsIgnoreCase(SerializationLang.XML)){
+			getResponse().setContentType(MimeType.APPLICATION_XML);
+		}else if (getFormat().equalsIgnoreCase(SerializationLang.XML_ABBREV)){
+			getResponse().setContentType(MimeType.APPLICATION_XML);
+		}else{
 			getResponse().setContentType(MimeType.TEXT_PLAIN);
+		}
 
 		m.write(pw, getFormat());
 	}

--- a/src/main/java/edu/isi/karma/linkedapi/server/HTTPClientTest.java
+++ b/src/main/java/edu/isi/karma/linkedapi/server/HTTPClientTest.java
@@ -100,8 +100,9 @@ public class HTTPClientTest {
 			} catch (IOException e) {
 				throw new Exception("IOException while posting data", e);
 			} finally {
-				if (out != null)
+				if (out != null){
 					out.close();
+				}
 			}
 	 
 			InputStream in = urlc.getInputStream();
@@ -112,15 +113,17 @@ public class HTTPClientTest {
 			} catch (IOException e) {
 				throw new Exception("IOException while reading response", e);
 			} finally {
-				if (in != null)
+				if (in != null){
 					in.close();
+				}
 			}
 	 
 		} catch (IOException e) {
 			throw new Exception("Connection error (is server running at " + endpoint + " ?): " + e);
 		} finally {
-			if (urlc != null)
-			urlc.disconnect();
+			if (urlc != null){
+				urlc.disconnect();
+			}
 		}
 	}
 	 
@@ -174,8 +177,9 @@ public class HTTPClientTest {
 		} catch (IOException e) {
 			throw new Exception("Connection error (is server running at " + endpoint + " ?): " + e);
 		} finally {
-			if (urlc != null)
-			urlc.disconnect();
+			if (urlc != null){
+				urlc.disconnect();
+			}
 		}
 	}
 	 

--- a/src/main/java/edu/isi/karma/linkedapi/server/PostRequestManager.java
+++ b/src/main/java/edu/isi/karma/linkedapi/server/PostRequestManager.java
@@ -100,12 +100,15 @@ public class PostRequestManager extends LinkedApiRequestManager {
 		
 		listOfInputAttValues = serviceInputModel.findModelDataInJenaData(this.inputJenaModel, null);
 		
-		if (listOfInputAttValues == null)
+		if (listOfInputAttValues == null){
 			return false;
+		}
 		
-		for (Map<String, String> m : listOfInputAttValues)
-			for (String s : m.keySet())
+		for (Map<String, String> m : listOfInputAttValues){
+			for (String s : m.keySet()){
 				logger.debug(s + "-->" + m.get(s));
+			}
+		}
 		
 		//for (String s : serviceIdsAndMappings.)
 		return true;
@@ -123,8 +126,9 @@ public class PostRequestManager extends LinkedApiRequestManager {
 		
 		logger.debug(url);
 		
-		for (Attribute att : missingAttributes)
+		for (Attribute att : missingAttributes){
 			logger.debug("missing: " + att.getName() + ", grounded in:" + att.getGroundedIn());
+		}
 
 		return url;
 	}
@@ -174,14 +178,16 @@ public class PostRequestManager extends LinkedApiRequestManager {
 				
 				// creating a blank node
 				r = model.createResource();
-				if (classAtom.getClassPredicate().getPrefix() != null && classAtom.getClassPredicate().getNs() != null)
+				if (classAtom.getClassPredicate().getPrefix() != null && classAtom.getClassPredicate().getNs() != null){
 					model.setNsPrefix(classAtom.getClassPredicate().getPrefix(), classAtom.getClassPredicate().getNs());
+				}
 				predicateUri = classAtom.getClassPredicate().getUri();
 				
 				// creating the class resource
 				Resource classResource = model.getResource(predicateUri);
-				if (classResource == null)
+				if (classResource == null){
 					classResource = model.createResource(predicateUri);
+				}
 
 				argument1 = classAtom.getArgument1().getId();
 				outputVariablesToResource.put(argument1, r);
@@ -194,14 +200,16 @@ public class PostRequestManager extends LinkedApiRequestManager {
 			if (atom instanceof IndividualPropertyAtom) {
 				IndividualPropertyAtom propertyAtom = (IndividualPropertyAtom)atom;
 				
-				if (propertyAtom.getPropertyPredicate().getPrefix() != null && propertyAtom.getPropertyPredicate().getNs() != null)
+				if (propertyAtom.getPropertyPredicate().getPrefix() != null && propertyAtom.getPropertyPredicate().getNs() != null){
 					model.setNsPrefix(propertyAtom.getPropertyPredicate().getPrefix(), propertyAtom.getPropertyPredicate().getNs());
+				}
 				predicateUri = propertyAtom.getPropertyPredicate().getUri();
 
 				// creating the property resource
 				Property propertyResource = model.getProperty(predicateUri);
-				if (propertyResource == null)
+				if (propertyResource == null){
 					propertyResource = model.createProperty(predicateUri);
+				}
 
 				argument1 = propertyAtom.getArgument1().getId();
 				argument2 = propertyAtom.getArgument2().getId();
@@ -322,7 +330,9 @@ public class PostRequestManager extends LinkedApiRequestManager {
 				for (List<String> values : table.getValues()) {
 					for (int i = 0; i < table.getColumnsCount(); i++) {
 						String attId = outputAttNameToAttIds.get(table.getHeaders().get(i).getName());
-						if (attId == null) continue;
+						if (attId == null){
+							continue;
+						}
 						String value = values.get(i);
 						outputAttValues.put(attId, value);
 					}
@@ -362,7 +372,9 @@ public class PostRequestManager extends LinkedApiRequestManager {
 				for (List<String> values : table.getValues()) {
 					for (int i = 0; i < table.getColumnsCount(); i++) {
 						String attId = outputAttNameToAttIds.get(table.getHeaders().get(i).getName());
-						if (attId == null) continue;
+						if (attId == null){
+							continue;
+						}
 						String value = values.get(i);
 						outputAttValues.put(attId, value);
 					}
@@ -371,12 +383,13 @@ public class PostRequestManager extends LinkedApiRequestManager {
 			}
 		}
 		
-		if (getFormat().equalsIgnoreCase(SerializationLang.XML))
-			getResponse().setContentType(MimeType.APPLICATION_XML); 
-		else if (getFormat().equalsIgnoreCase(SerializationLang.XML_ABBREV))
-			getResponse().setContentType(MimeType.APPLICATION_XML); 
-		else
+		if (getFormat().equalsIgnoreCase(SerializationLang.XML)){
+			getResponse().setContentType(MimeType.APPLICATION_XML);
+		}else if (getFormat().equalsIgnoreCase(SerializationLang.XML_ABBREV)){
+			getResponse().setContentType(MimeType.APPLICATION_XML);
+		}else{
 			getResponse().setContentType(MimeType.TEXT_PLAIN);
+		}
 
 //		getResponse().setContentType(MimeType.TEXT_PLAIN);
 //		pw.write("Success.");

--- a/src/main/java/edu/isi/karma/model/serialization/DataSourceLoader.java
+++ b/src/main/java/edu/isi/karma/model/serialization/DataSourceLoader.java
@@ -78,8 +78,9 @@ public class DataSourceLoader extends SourceLoader {
 	public DataSource getSourceByUri(String uri) {
 		
 		Model m = Repository.Instance().getNamedModel(uri);
-		if (m == null)
+		if (m == null){
 			return null;
+		}
 
 		DataSource source = importSourceFromJenaModel(m);
 		return source;
@@ -96,12 +97,14 @@ public class DataSourceLoader extends SourceLoader {
 		
 		try {
 		if (f.exists()) {
-			if (!f.delete())
+			if (!f.delete()){
 				logger.debug("The file " + fileName + " cannot be deleted from " + dir);
-			else
+			}else{
 				logger.debug("The file " + fileName + " has been deleted from " + dir);
-		} else
+			}
+		}else{
 			logger.debug("The file " + fileName + " does not exist in " + dir);
+		}
 		} catch (Throwable t) {
 			logger.debug("cannot delete the file " + fileName + " from " + dir + " because " + t.getMessage());
 		}
@@ -134,7 +137,9 @@ public class DataSourceLoader extends SourceLoader {
 			"      } \n";
 		
 		if (sourceLimit != null) {
-			if (sourceLimit.intValue() < 0) sourceLimit = DEFAULT_SOURCE_RESULTS_SIZE;
+			if (sourceLimit.intValue() < 0){
+				sourceLimit = DEFAULT_SOURCE_RESULTS_SIZE;
+			}
 			queryString += "LIMIT " + String.valueOf(sourceLimit.intValue() + "\n");
 		}
 		
@@ -147,8 +152,9 @@ public class DataSourceLoader extends SourceLoader {
 		try {
 			ResultSet results = qexec.execSelect() ;
 			
-			if (!results.hasNext())
+			if (!results.hasNext()){
 				logger.info("query does not return any answer.");
+			}
 
 //			ResultSetFormatter.out(System.out, results, query) ;
 			 
@@ -169,13 +175,16 @@ public class DataSourceLoader extends SourceLoader {
 
 				logger.debug("source uri: " + source_uri);
 				logger.debug("source id: " + source_id);
-				if (name != null && name.isLiteral()) source_name = name.asLiteral().getString();
+				if (name != null && name.isLiteral()){
+					source_name = name.asLiteral().getString();
+				}
 				logger.debug("source name: " + source_name);
 				
-				if (source_id.trim().length() > 0)
+				if (source_id.trim().length() > 0){
 					sourceList.add(new DataSource(source_id, source_name));
-				else
+				}else{
 					logger.info("length of source id is zero.");
+				}
 			}
 			
 			return sourceList;
@@ -227,13 +236,15 @@ public class DataSourceLoader extends SourceLoader {
 		Map<String, Map<String, String>> sourceIdsAndMappings =
 			semanticModel.findInJenaModel(Repository.Instance().getModel(), sourceLimit);
 		
-		if (sourceIdsAndMappings == null)
+		if (sourceIdsAndMappings == null){
 			return null;
+		}
 		
 		for (String sourceId : sourceIdsAndMappings.keySet()) {
 			Model m = Repository.Instance().getNamedModel(sourceId);
-			if (m != null)
+			if (m != null){
 				sourcesAndMappings.put(importSourceFromJenaModel(m), sourceIdsAndMappings.get(sourceId));
+			}
 		}
 		
 		return sourcesAndMappings;
@@ -259,19 +270,22 @@ public class DataSourceLoader extends SourceLoader {
 		Model jenaModel = semanticModel.getJenaModel();
 		for (Source source : sourceList) {
 			
-			if (!(source instanceof DataSource))
+			if (!(source instanceof DataSource)){
 				continue;
+			}
 			
 			edu.isi.karma.rep.model.Model m = ((DataSource)source).getModel();
 
-			if (m == null)
+			if (m == null){
 				continue;
+			}
 			
 			Map<String, Map<String, String>> sourceIdsAndMappings =
 				m.findInJenaModel(jenaModel, null);
 			
-			if (sourceIdsAndMappings == null)
+			if (sourceIdsAndMappings == null){
 				continue;
+			}
 			
 			Iterator<String> itr = sourceIdsAndMappings.keySet().iterator();
 			if (itr.hasNext()) {
@@ -323,8 +337,9 @@ public class DataSourceLoader extends SourceLoader {
 		if (nodeIterator.hasNext() && (node = nodeIterator.next()).isLiteral()) {
 			source_name = node.asLiteral().getString();
 			logger.debug("source name: " + source_name);
-		} else
+		}else{
 			logger.debug("source does not have a name.");
+		}
 		
 		DataSource source = new DataSource(source_id);
 		source.setName(source_name);
@@ -405,8 +420,9 @@ public class DataSourceLoader extends SourceLoader {
 		if (nodeIterator.hasNext() && (node = nodeIterator.next()).isLiteral()) {
 			att_name = node.asLiteral().getString();
 			logger.debug("attribute name: " + att_name);
-		} else
+		}else{
 			logger.debug("attribute does not have a name.");
+		}
 		
 		Attribute att = new Attribute(att_id, att_resource.getNameSpace(), att_name, IOType.NONE, AttributeRequirement.NONE);
 		
@@ -520,10 +536,11 @@ public class DataSourceLoader extends SourceLoader {
 			argument1Id = node.asResource().getLocalName();
 			logger.debug("The atom argument1 is: " + argument1Id);
 			
-			if (isInstanceOfTheClass(node.asResource(), attribute))
+			if (isInstanceOfTheClass(node.asResource(), attribute)){
 				argument1Type = ArgumentType.ATTRIBUTE;
-			else if (isInstanceOfTheClass(node.asResource(), variable))
+			}else if (isInstanceOfTheClass(node.asResource(), variable)){
 				argument1Type = ArgumentType.VARIABLE;
+			}
 			
 		} else {
 			logger.info("atom does not have an argument1.");
@@ -579,10 +596,11 @@ public class DataSourceLoader extends SourceLoader {
 			argument1Id = node.asResource().getLocalName();
 			logger.debug("The atom argument1 is: " + argument1Id);
 			
-			if (isInstanceOfTheClass(node.asResource(), attribute))
+			if (isInstanceOfTheClass(node.asResource(), attribute)){
 				argument1Type = ArgumentType.ATTRIBUTE;
-			else if (isInstanceOfTheClass(node.asResource(), variable))
+			}else if (isInstanceOfTheClass(node.asResource(), variable)){
 				argument1Type = ArgumentType.VARIABLE;
+			}
 			
 		} else {
 			logger.info("atom does not have an argument1.");
@@ -595,10 +613,11 @@ public class DataSourceLoader extends SourceLoader {
 			argument2Id = node.asResource().getLocalName();
 			logger.debug("The atom argument2 is: " + argument2Id);
 			
-			if (isInstanceOfTheClass(node.asResource(), attribute))
+			if (isInstanceOfTheClass(node.asResource(), attribute)){
 				argument2Type = ArgumentType.ATTRIBUTE;
-			else if (isInstanceOfTheClass(node.asResource(), variable))
+			}else if (isInstanceOfTheClass(node.asResource(), variable)){
 				argument2Type = ArgumentType.VARIABLE;
+			}
 			
 		} else {
 			logger.info("atom does not have an argument2.");
@@ -617,25 +636,31 @@ public class DataSourceLoader extends SourceLoader {
 	private boolean isInstanceOfTheClass(Resource resource, Resource class_resource) {
 		Property type_property = ResourceFactory.createProperty(Namespaces.RDF + "type");
 		
-		if (resource == null || !resource.isResource())
+		if (resource == null || !resource.isResource()){
 			return true;
+		}
 		
-		if (resource.hasProperty(type_property, class_resource))
+		if (resource.hasProperty(type_property, class_resource)){
 			return true;
-		else
+		}else{
 			return false;
+		}
 	}
 	
 	private static void testGetSourceByUri() {
 		String uri = "http://isi.edu/integration/karma/sources/AEEA5A9A-744C-8096-B372-836ACC820D5A#";
 //		String uri = "http://isi.edu/integration/karma/sources/940466A8-8733-47B1-2597-11DC112F0437F#";
 		DataSource source = (DataSource) DataSourceLoader.getInstance().getSourceByUri(uri);
-		if (source != null) source.print();
+		if (source != null){
+			source.print();
+		}
 	}
 	private static void testGetAllSources() {
 		List<Source> sourceList = DataSourceLoader.getInstance().getSourcesDetailedInfo(null);
 		for (Source s : sourceList) {
-			if (s != null) s.print();
+			if (s != null){
+				s.print();
+			}
 		}
 	}
 	private static void testGetSourcesByIOPattern() {
@@ -665,20 +690,25 @@ public class DataSourceLoader extends SourceLoader {
 		Map<DataSource, Map<String, String>> sourcesAndMappings = 
 				DataSourceLoader.getInstance().getDataSourcesByIOPattern(semanticModel, null);
 
-		if (sourcesAndMappings == null)
+		if (sourcesAndMappings == null){
 			return;
+		}
 		
 		for (Source s : sourcesAndMappings.keySet()) {
-			if (s != null) s.print();
+			if (s != null){
+				s.print();
+			}
 		}
 		
 		System.out.println("Mappings from matched source to model arguments:");
 		for (Source s : sourcesAndMappings.keySet()) {
 			System.out.println("Source: " + s.getId());
-			if (sourcesAndMappings.get(s) == null)
+			if (sourcesAndMappings.get(s) == null){
 				continue;
-			for (String str : sourcesAndMappings.get(s).keySet())
+			}
+			for (String str : sourcesAndMappings.get(s).keySet()){
 				System.out.println(str + "-------" + sourcesAndMappings.get(s).get(str));
+			}
 		}
 
 	}
@@ -689,10 +719,18 @@ public class DataSourceLoader extends SourceLoader {
 	public static void main(String[] args) {
 
 		boolean test1 = true, test2 = false, test3 = false, test4 = false;
-		if (test1) testGetSourceByUri();
-		if (test2) testDeleteSourceByUri();
-		if (test3) testGetSourcesByIOPattern();
-		if (test4) testGetAllSources();
+		if (test1){
+			testGetSourceByUri();
+		}
+		if (test2){
+			testDeleteSourceByUri();
+		}
+		if (test3){
+			testGetSourcesByIOPattern();
+		}
+		if (test4){
+			testGetAllSources();
+		}
 
 
 	}

--- a/src/main/java/edu/isi/karma/model/serialization/DataSourcePublisher.java
+++ b/src/main/java/edu/isi/karma/model/serialization/DataSourcePublisher.java
@@ -99,21 +99,24 @@ public class DataSourcePublisher extends SourcePublisher {
 		//TODO: how to see if a model of the same source exists or not
 		// maybe we can use a combination of source name, address, ...
 		
-		if (this.model == null)
+		if (this.model == null){
 			model = exportToJenaModel();
+		}
 		
 		// update the repository active model
 		Repository.Instance().addModel(this.model, source.getUri());
 
 		// write the model to the file
-		if (writeToFile)
+		if (writeToFile){
 			writeToFile(lang);
+		}
 	}
 	
 	@Override
 	public void writeToFile(String lang) throws FileNotFoundException {
-		if (this.model == null)
+		if (this.model == null){
 			model = exportToJenaModel();
+		}
 		
 		String source_desc_file = Repository.Instance().SOURCE_REPOSITORY_DIR + 
 		 							this.source.getName() + "_" + this.source.getId() +
@@ -142,14 +145,16 @@ public class DataSourcePublisher extends SourcePublisher {
 
 		Resource my_source = model.createResource(baseNS + "");
 		my_source.addProperty(rdf_type, source_resource);
-		if (this.source.getName().length() > 0)
+		if (this.source.getName().length() > 0){
 			my_source.addProperty(has_name, this.source.getName());
+		}
 
-		if (this.source.getVariables() != null)
-		for (int i = 0; i < this.source.getVariables().size(); i++) {
-			Resource my_variable = model.createResource(baseNS + this.source.getVariables().get(i).toString());
-			my_variable.addProperty(rdf_type, variavle_resource);
-			my_source.addProperty(has_variable, my_variable);
+		if (this.source.getVariables() != null){
+			for (int i = 0; i < this.source.getVariables().size(); i++) {
+				Resource my_variable = model.createResource(baseNS + this.source.getVariables().get(i).toString());
+				my_variable.addProperty(rdf_type, variavle_resource);
+				my_source.addProperty(has_variable, my_variable);
+			}
 		}
 
 		if (this.source.getAttributes() != null) {
@@ -173,8 +178,9 @@ public class DataSourcePublisher extends SourcePublisher {
 		
 		// Add transformations
 		Property has_columnTransformation = model.createProperty(Namespaces.KARMA, "hasColumnTransformation");
-		for(String commJson : transformationCommandsJSON)
+		for(String commJson : transformationCommandsJSON){
 			my_source.addProperty(has_columnTransformation, commJson);
+		}
 		
 		// Add source information if any present
 		if(sourceInfo != null) {
@@ -225,8 +231,9 @@ public class DataSourcePublisher extends SourcePublisher {
 					Resource r = model.createResource();
 					r.addProperty(rdf_type, class_atom_resource);
 					
-					if (classAtom.getClassPredicate().getPrefix() != null && classAtom.getClassPredicate().getNs() != null)
+					if (classAtom.getClassPredicate().getPrefix() != null && classAtom.getClassPredicate().getNs() != null){
 						model.setNsPrefix(classAtom.getClassPredicate().getPrefix(), classAtom.getClassPredicate().getNs());
+					}
 					Resource className = model.createResource(classAtom.getClassPredicate().getUri());
 					r.addProperty(class_predicate, className);
 					
@@ -241,8 +248,9 @@ public class DataSourcePublisher extends SourcePublisher {
 					Resource r = model.createResource();
 					r.addProperty(rdf_type, individual_property_atom_resource);
 					
-					if (propertyAtom.getPropertyPredicate().getPrefix() != null && propertyAtom.getPropertyPredicate().getNs() != null)
+					if (propertyAtom.getPropertyPredicate().getPrefix() != null && propertyAtom.getPropertyPredicate().getNs() != null){
 						model.setNsPrefix(propertyAtom.getPropertyPredicate().getPrefix(), propertyAtom.getPropertyPredicate().getNs());
+					}
 					Resource propertyName = model.createResource(propertyAtom.getPropertyPredicate().getUri());
 					r.addProperty(property_predicate, propertyName);
 					

--- a/src/main/java/edu/isi/karma/model/serialization/Repository.java
+++ b/src/main/java/edu/isi/karma/model/serialization/Repository.java
@@ -60,12 +60,14 @@ public class Repository {
 			_InternalInstance = new Repository();
 
 			File serviceRepository = new File(_InternalInstance.SERVICE_REPOSITORY_DIR);
-			if (!serviceRepository.exists())
+			if (!serviceRepository.exists()){
 				serviceRepository.mkdir();
+			}
 			
 			File sourceRepository = new File(_InternalInstance.SOURCE_REPOSITORY_DIR);
-			if (!sourceRepository.exists())
+			if (!sourceRepository.exists()){
 				sourceRepository.mkdir();
+			}
 			
 			_InternalInstance.createRepository();
 		}
@@ -176,12 +178,19 @@ public class Repository {
 	
 	public String getFileExtension(String lang) {
 		String ext = ".rdf";
-		if (lang.equalsIgnoreCase("RDF/XML")) ext = ".rdf";
-		else if (lang.equalsIgnoreCase("RDF/XML-ABBREV")) ext = ".rdf";
-		else if (lang.equalsIgnoreCase("N-TRIPLE")) ext = ".ntriple";
-		else if (lang.equalsIgnoreCase("TURTLE")) ext = ".turtle";
-		else if (lang.equalsIgnoreCase("TTL")) ext = ".ttl";
-		else if (lang.equalsIgnoreCase("N3")) ext = ".n3";
+		if (lang.equalsIgnoreCase("RDF/XML")){
+			ext = ".rdf";
+		}else if (lang.equalsIgnoreCase("RDF/XML-ABBREV")){
+			ext = ".rdf";
+		}else if (lang.equalsIgnoreCase("N-TRIPLE")){
+			ext = ".ntriple";
+		}else if (lang.equalsIgnoreCase("TURTLE")){
+			ext = ".turtle";
+		}else if (lang.equalsIgnoreCase("TTL")){
+			ext = ".ttl";
+		}else if (lang.equalsIgnoreCase("N3")){
+			ext = ".n3";
+		}
 		return ext;
 	}
 }

--- a/src/main/java/edu/isi/karma/model/serialization/SourceLoader.java
+++ b/src/main/java/edu/isi/karma/model/serialization/SourceLoader.java
@@ -41,8 +41,9 @@ public abstract class SourceLoader {
 	
 	public Model getSourceJenaModel(String uri) {
 		Model m = Repository.Instance().getNamedModel(uri);
-		if (m == null)
+		if (m == null){
 			return null;
+		}
 
 		return m;
 	}

--- a/src/main/java/edu/isi/karma/model/serialization/WebServiceLoader.java
+++ b/src/main/java/edu/isi/karma/model/serialization/WebServiceLoader.java
@@ -78,8 +78,9 @@ public class WebServiceLoader extends SourceLoader {
 	public WebService getSourceByUri(String uri) {
 		
 		Model m = Repository.Instance().getNamedModel(uri);
-		if (m == null)
+		if (m == null){
 			return null;
+		}
 
 		WebService service = importSourceFromJenaModel(m);
 		return service;
@@ -96,12 +97,14 @@ public class WebServiceLoader extends SourceLoader {
 		
 		try {
 		if (f.exists()) {
-			if (!f.delete())
+			if (!f.delete()){
 				logger.debug("The file " + fileName + " cannot be deleted from " + dir);
-			else
+			}else{
 				logger.debug("The file " + fileName + " has been deleted from " + dir);
-		} else
+			}
+		}else{
 			logger.debug("The file " + fileName + " does not exist in " + dir);
+		}
 		} catch (Throwable t) {
 			logger.debug("cannot delete the file " + fileName + " from " + dir + " because " + t.getMessage());
 		}
@@ -135,7 +138,9 @@ public class WebServiceLoader extends SourceLoader {
 			"      } \n";
 		
 		if (serviceLimit != null) {
-			if (serviceLimit.intValue() < 0) serviceLimit = DEFAULT_SERVICE_RESULTS_SIZE;
+			if (serviceLimit.intValue() < 0){
+				serviceLimit = DEFAULT_SERVICE_RESULTS_SIZE;
+			}
 			queryString += "LIMIT " + String.valueOf(serviceLimit.intValue() + "\n");
 		}
 		
@@ -148,8 +153,9 @@ public class WebServiceLoader extends SourceLoader {
 		try {
 			ResultSet results = qexec.execSelect() ;
 			
-			if (!results.hasNext())
+			if (!results.hasNext()){
 				logger.info("query does not return any answer.");
+			}
 
 //			ResultSetFormatter.out(System.out, results, query) ;
 			 
@@ -171,15 +177,20 @@ public class WebServiceLoader extends SourceLoader {
 
 				logger.debug("service uri: " + service_uri);
 				logger.debug("service id: " + service_id);
-				if (name != null && name.isLiteral()) service_name = name.asLiteral().getString();
+				if (name != null && name.isLiteral()){
+					service_name = name.asLiteral().getString();
+				}
 				logger.debug("service name: " + service_name);
-				if (address != null && address.isLiteral()) service_address = address.asLiteral().getString();
+				if (address != null && address.isLiteral()){
+					service_address = address.asLiteral().getString();
+				}
 				logger.debug("service address: " + service_address);
 				
-				if (service_id.trim().length() > 0)
+				if (service_id.trim().length() > 0){
 					serviceList.add(new WebService(service_id, service_name, service_address));
-				else
+				}else{
 					logger.info("length of service id is zero.");
+				}
 			}
 			
 			return serviceList;
@@ -212,8 +223,9 @@ public class WebServiceLoader extends SourceLoader {
 		
 		String uri = getServiceUriByServiceAddress(address);
 		Model m = Repository.Instance().getNamedModel(uri);
-		if (m == null)
+		if (m == null){
 			return null;
+		}
 
 		WebService service = importSourceFromJenaModel(m);
 		return service;
@@ -248,8 +260,9 @@ public class WebServiceLoader extends SourceLoader {
 		try {
 			ResultSet results = qexec.execSelect() ;
 			
-			if (!results.hasNext())
+			if (!results.hasNext()){
 				logger.info("query does not return any answer.");
+			}
 
 //			ResultSetFormatter.out(System.out, results, query) ;
 			 
@@ -297,13 +310,15 @@ public class WebServiceLoader extends SourceLoader {
 		Map<String, Map<String, String>> serviceIdsAndMappings = 
 			semanticModel.findInServiceInputs(Repository.Instance().getModel(), serviceLimit);
 
-		if (serviceIdsAndMappings == null)
+		if (serviceIdsAndMappings == null){
 			return null;
+		}
 		
 		for (String serviceId : serviceIdsAndMappings.keySet()) {
 			Model m = Repository.Instance().getNamedModel(serviceId);
-			if (m != null)
+			if (m != null){
 				servicesAndMappings.put(importSourceFromJenaModel(m), serviceIdsAndMappings.get(serviceId));
+			}
 		}
 		
 		return servicesAndMappings;
@@ -333,13 +348,15 @@ public class WebServiceLoader extends SourceLoader {
 		Map<String, Map<String, String>> serviceIdsAndMappings = 
 			semanticModel.findInServiceOutputs(Repository.Instance().getModel(), serviceLimit);
 		
-		if (serviceIdsAndMappings == null)
+		if (serviceIdsAndMappings == null){
 			return null;
+		}
 		
 		for (String serviceId : serviceIdsAndMappings.keySet()) {
 			Model m = Repository.Instance().getNamedModel(serviceId);
-			if (m != null)
+			if (m != null){
 				servicesAndMappings.put(importSourceFromJenaModel(m), serviceIdsAndMappings.get(serviceId));
+			}
 		}
 		
 		return servicesAndMappings;
@@ -366,19 +383,22 @@ public class WebServiceLoader extends SourceLoader {
 		Model jenaModel = semanticModel.getJenaModel();
 		for (Source service : serviceList) {
 			
-			if (!(service instanceof WebService))
+			if (!(service instanceof WebService)){
 				continue;
+			}
 			
 			edu.isi.karma.rep.model.Model m = ((WebService)service).getInputModel();
 			
-			if (m == null)
+			if (m == null){
 				continue;
+			}
 			
 			Map<String, Map<String, String>> serviceIdsAndMappings =
 				m.findInJenaModel(jenaModel, null);
 			
-			if (serviceIdsAndMappings == null)
+			if (serviceIdsAndMappings == null){
 				continue;
+			}
 			
 			Iterator<String> itr = serviceIdsAndMappings.keySet().iterator();
 			if (itr.hasNext()) {
@@ -411,19 +431,22 @@ public class WebServiceLoader extends SourceLoader {
 		Model jenaModel = semanticModel.getJenaModel();
 		for (Source service : serviceList) {
 			
-			if (!(service instanceof WebService))
+			if (!(service instanceof WebService)){
 				continue;
+			}
 
 			edu.isi.karma.rep.model.Model m = ((WebService)service).getOutputModel();
 			
-			if (m == null)
+			if (m == null){
 				continue;
+			}
 			
 			Map<String, Map<String, String>> serviceIdsAndMappings =
 				m.findInJenaModel(jenaModel, null);
 			
-			if (serviceIdsAndMappings == null)
+			if (serviceIdsAndMappings == null){
 				continue;
+			}
 			
 			Iterator<String> itr = serviceIdsAndMappings.keySet().iterator();
 			if (itr.hasNext()) {
@@ -474,24 +497,27 @@ public class WebServiceLoader extends SourceLoader {
 		if (nodeIterator.hasNext() && (node = nodeIterator.next()).isLiteral()) {
 			service_name = node.asLiteral().getString();
 			logger.debug("service name: " + service_name);
-		} else
+		}else{
 			logger.debug("service does not have a name.");
+		}
 		
 		// service address
 		nodeIterator = model.listObjectsOfProperty(service_resource, has_address_property);
 		if (nodeIterator.hasNext() && (node = nodeIterator.next()).isLiteral()) {
 			service_address = node.asLiteral().getString();
 			logger.debug("service address: " + service_address);
-		} else
+		}else{
 			logger.debug("service does not have an address.");
+		}
 
 		// service method
 		nodeIterator = model.listObjectsOfProperty(service_resource, has_method_property);
 		if (nodeIterator.hasNext() && (node = nodeIterator.next()).isLiteral()) {
 			service_method = node.asLiteral().getString();
 			logger.debug("service method: " + service_method);
-		} else
+		}else{
 			logger.debug("service does not have a method.");
+		}
 
 		List<String> variables = null;
 		List<Attribute> inputAttributes = null;
@@ -507,16 +533,18 @@ public class WebServiceLoader extends SourceLoader {
 		if (nodeIterator.hasNext() && (node = nodeIterator.next()).isResource()) {
 			inputAttributes = getAttributes(model, node.asResource(), IOType.INPUT);
 			inputModel = getSemanticModel(model, node.asResource());
-		} else
+		}else{
 			logger.debug("service does not have an input.");
+		}
 		
 		// service output
 		nodeIterator = model.listObjectsOfProperty(service_resource, has_output_property);
 		if (nodeIterator.hasNext() && (node = nodeIterator.next()).isResource()) {
 			outputAttributes = getAttributes(model, node.asResource(), IOType.OUTPUT );
 			outputModel = getSemanticModel(model, node.asResource());
-		} else
+		}else{
 			logger.info("service does not have an output.");
+		}
 		
 		WebService service = new WebService(service_id, service_name, service_address);
 		service.setMethod(service_method);
@@ -631,22 +659,25 @@ public class WebServiceLoader extends SourceLoader {
 		if (nodeIterator.hasNext() && (node = nodeIterator.next()).isLiteral()) {
 			att_name = node.asLiteral().getString();
 			logger.debug("attribute name: " + att_name);
-		} else
+		}else{
 			logger.debug("attribute does not have a name.");
+		}
 		
 		// attribute grounded In
 		nodeIterator = model.listObjectsOfProperty(att_resource, is_gounded_in_property);
 		if (nodeIterator.hasNext() && (node = nodeIterator.next()).isLiteral()) {
 			att_groundedIn = node.asLiteral().getString();
 			logger.debug("attribute grounded in: " + att_groundedIn);
-		} else
+		}else{
 			logger.debug("attribute does not have agroundedIn value.");
+		}
 
 		Attribute att = null;
-		if (att_groundedIn.length() > 0)
+		if (att_groundedIn.length() > 0){
 			att = new Attribute(att_id, att_resource.getNameSpace(), att_name, ioType, requirement, att_groundedIn );
-		else
+		}else{
 			att = new Attribute(att_id, att_resource.getNameSpace(), att_name, ioType, requirement);
+		}
 		
 		return att;
 
@@ -758,10 +789,11 @@ public class WebServiceLoader extends SourceLoader {
 			argument1Id = node.asResource().getLocalName();
 			logger.debug("The atom argument1 is: " + argument1Id);
 			
-			if (isInstanceOfTheClass(node.asResource(), attribute))
+			if (isInstanceOfTheClass(node.asResource(), attribute)){
 				argument1Type = ArgumentType.ATTRIBUTE;
-			else if (isInstanceOfTheClass(node.asResource(), variable))
+			}else if (isInstanceOfTheClass(node.asResource(), variable)){
 				argument1Type = ArgumentType.VARIABLE;
+			}
 			
 		} else {
 			logger.info("atom does not have an argument1.");
@@ -817,10 +849,11 @@ public class WebServiceLoader extends SourceLoader {
 			argument1Id = node.asResource().getLocalName();
 			logger.debug("The atom argument1 is: " + argument1Id);
 			
-			if (isInstanceOfTheClass(node.asResource(), attribute))
+			if (isInstanceOfTheClass(node.asResource(), attribute)){
 				argument1Type = ArgumentType.ATTRIBUTE;
-			else if (isInstanceOfTheClass(node.asResource(), variable))
+			}else if (isInstanceOfTheClass(node.asResource(), variable)){
 				argument1Type = ArgumentType.VARIABLE;
+			}
 			
 		} else {
 			logger.info("atom does not have an argument1.");
@@ -833,10 +866,11 @@ public class WebServiceLoader extends SourceLoader {
 			argument2Id = node.asResource().getLocalName();
 			logger.debug("The atom argument2 is: " + argument2Id);
 			
-			if (isInstanceOfTheClass(node.asResource(), attribute))
+			if (isInstanceOfTheClass(node.asResource(), attribute)){
 				argument2Type = ArgumentType.ATTRIBUTE;
-			else if (isInstanceOfTheClass(node.asResource(), variable))
+			}else if (isInstanceOfTheClass(node.asResource(), variable)){
 				argument2Type = ArgumentType.VARIABLE;
+			}
 			
 		} else {
 			logger.info("atom does not have an argument2.");
@@ -855,13 +889,15 @@ public class WebServiceLoader extends SourceLoader {
 	private boolean isInstanceOfTheClass(Resource resource, Resource class_resource) {
 		Property type_property = ResourceFactory.createProperty(Namespaces.RDF + "type");
 		
-		if (resource == null || !resource.isResource())
+		if (resource == null || !resource.isResource()){
 			return true;
+		}
 		
-		if (resource.hasProperty(type_property, class_resource))
+		if (resource.hasProperty(type_property, class_resource)){
 			return true;
-		else
+		}else{
 			return false;
+		}
 	}
 	
 	private static void testGetServiceByUri() {
@@ -877,12 +913,16 @@ public class WebServiceLoader extends SourceLoader {
 	private static void testGetServiceByAddress() {
 		String address = "http://api.geonames.org/";
 		WebService service = WebServiceLoader.getInstance().getServiceByAddress(address);
-		if (service != null) service.print();
+		if (service != null){
+			service.print();
+		}
 	}
 	private static void testGetAllServices() {
 		List<Source> serviceList = WebServiceLoader.getInstance().getSourcesDetailedInfo(null);
 		for (Source s : serviceList) {
-			if (s != null) s.print();
+			if (s != null){
+				s.print();
+			}
 		}
 	}
 	private static void testGetServicesByIOPattern() {
@@ -917,20 +957,26 @@ public class WebServiceLoader extends SourceLoader {
 //		Map<Service, Map<String, String>> servicesAndMappings = 
 //			getServicesByIOPattern(semanticModel, IOType.INPUT, null);
 
-		if (servicesAndMappings == null)
+		if (servicesAndMappings == null){
 			return;
+		}
 		
 		for (WebService s : servicesAndMappings.keySet()) {
-			if (s != null) System.out.println((s.getUri())); //s.print();
+			if (s != null)
+			 {
+				System.out.println((s.getUri())); //s.print();
+			}
 		}
 		
 		System.out.println("Mappings from matched source to model arguments:");
 		for (WebService s : servicesAndMappings.keySet()) {
 			System.out.println("Service: " + s.getId());
-			if (servicesAndMappings.get(s) == null)
+			if (servicesAndMappings.get(s) == null){
 				continue;
-			for (String str : servicesAndMappings.get(s).keySet())
+			}
+			for (String str : servicesAndMappings.get(s).keySet()){
 				System.out.println(str + "-------" + servicesAndMappings.get(s).get(str));
+			}
 		}
 
 	}
@@ -943,11 +989,21 @@ public class WebServiceLoader extends SourceLoader {
 //		ServiceBuilder.main(new String[0]);
 
 		boolean test1 = true, test2 = false, test3 = false, test4 = false, test5 = false;
-		if (test1) testGetServiceByUri();
-		if (test2) testGetServiceByAddress();
-		if (test3) testGetServicesByIOPattern();
-		if (test4) testGetAllServices();
-		if (test5) testDeleteServiceByUri();
+		if (test1){
+			testGetServiceByUri();
+		}
+		if (test2){
+			testGetServiceByAddress();
+		}
+		if (test3){
+			testGetServicesByIOPattern();
+		}
+		if (test4){
+			testGetAllServices();
+		}
+		if (test5){
+			testDeleteServiceByUri();
+		}
 
 	}
 

--- a/src/main/java/edu/isi/karma/model/serialization/WebServicePublisher.java
+++ b/src/main/java/edu/isi/karma/model/serialization/WebServicePublisher.java
@@ -120,24 +120,28 @@ public class WebServicePublisher extends SourcePublisher {
 	public void publish(String lang, boolean writeToFile) throws FileNotFoundException {
 		
 		WebService existingService = WebServiceLoader.getInstance().getServiceByAddress(service.getAddress());
-		if (existingService != null) 
+		if (existingService != null){
 			WebServiceLoader.getInstance().deleteSourceByUri(existingService.getUri());
+		}
 		
-		if (this.model == null)
+		if (this.model == null){
 			model = exportToJenaModel();
+		}
 		
 		// update the repository active model
 		Repository.Instance().addModel(model, service.getUri());
 
 		// write the model to the file
-		if (writeToFile) 
+		if (writeToFile){
 			writeToFile(lang);
+		}
 	}
 	
 	@Override
 	public void writeToFile(String lang) throws FileNotFoundException {
-		if (this.model == null)
+		if (this.model == null){
 			model = exportToJenaModel();
+		}
 		
 		String service_desc_file = Repository.Instance().SERVICE_REPOSITORY_DIR + 
 		 							this.service.getId() +
@@ -172,21 +176,24 @@ public class WebServicePublisher extends SourcePublisher {
 		Literal service_address = model.createTypedLiteral(service.getAddress(), uri_template);
 		myservice.addProperty(rdf_type, service_resource);
 		myservice.addProperty(has_address, service_address);
-		if (service.getName().length() > 0)
+		if (service.getName().length() > 0){
 			myservice.addProperty(has_name, service.getName());
+		}
 		
-		if (service.getMethod().length() > 0)
+		if (service.getMethod().length() > 0){
 			myservice.addProperty(has_method, service.getMethod());
+		}
 		if (service.getAddress().length() > 0) {
 			Literal operation_address_literal = model.createTypedLiteral(service.getAddress(), uri_template);
 			myservice.addLiteral(has_address, operation_address_literal);
 		}
 		
-		if (service.getVariables() != null)
-		for (int i = 0; i < service.getVariables().size(); i++) {
-			Resource my_variable = model.createResource(baseNS + service.getVariables().get(i).toString());
-			my_variable.addProperty(rdf_type, variavle_resource);
-			myservice.addProperty(has_variable, my_variable);
+		if (service.getVariables() != null){
+			for (int i = 0; i < service.getVariables().size(); i++) {
+				Resource my_variable = model.createResource(baseNS + service.getVariables().get(i).toString());
+				my_variable.addProperty(rdf_type, variavle_resource);
+				myservice.addProperty(has_variable, my_variable);
+			}
 		}
 		
 		//for source description
@@ -196,10 +203,14 @@ public class WebServicePublisher extends SourcePublisher {
 		myservice.addProperty(hasSourceDesc, sourceDescription);
 			
 		Resource my_input = addInput(model, true);
-		if (my_input != null) myservice.addProperty(has_input, my_input);
+		if (my_input != null){
+			myservice.addProperty(has_input, my_input);
+		}
 
 		Resource my_output = addOutput(model, true);
-		if (my_output != null) myservice.addProperty(has_output, my_output);
+		if (my_output != null){
+			myservice.addProperty(has_output, my_output);
+		}
 
 	}
 	
@@ -228,15 +239,17 @@ public class WebServicePublisher extends SourcePublisher {
 				Attribute att = service.getInputAttributes().get(i);
 				Resource my_attribute = model.createResource(baseNS + att.getId());
 				
-				if (includeAttributeDetails)
+				if (includeAttributeDetails){
 					addAttributeDetails(model, my_attribute, att);
+				}
 				
-				if (att.getRequirement() == AttributeRequirement.NONE)
+				if (att.getRequirement() == AttributeRequirement.NONE){
 					my_input.addProperty(has_attribute, my_attribute);
-				else if (att.getRequirement() == AttributeRequirement.MANDATORY)
+				}else if (att.getRequirement() == AttributeRequirement.MANDATORY){
 					my_input.addProperty(has_mandatory_attribute, my_attribute);
-				else if (att.getRequirement() == AttributeRequirement.OPTIONAL)
+				}else if (att.getRequirement() == AttributeRequirement.OPTIONAL){
 					my_input.addProperty(has_optional_attribute, my_attribute);
+				}
 
 			}
 
@@ -270,15 +283,17 @@ public class WebServicePublisher extends SourcePublisher {
 				Attribute att = service.getOutputAttributes().get(i);
 				Resource my_attribute = model.createResource(baseNS + att.getId());
 				
-				if (includeAttributeDetails)
+				if (includeAttributeDetails){
 					addAttributeDetails(model, my_attribute, att);
+				}
 
-				if (att.getRequirement() == AttributeRequirement.NONE)
+				if (att.getRequirement() == AttributeRequirement.NONE){
 					my_output.addProperty(has_attribute, my_attribute);
-				else if (att.getRequirement() == AttributeRequirement.MANDATORY)
+				}else if (att.getRequirement() == AttributeRequirement.MANDATORY){
 					my_output.addProperty(has_mandatory_attribute, my_attribute);
-				else if (att.getRequirement() == AttributeRequirement.OPTIONAL)
+				}else if (att.getRequirement() == AttributeRequirement.OPTIONAL){
 					my_output.addProperty(has_optional_attribute, my_attribute);
+				}
 
 			}
 			addModelPart(model, my_output, service.getOutputModel());
@@ -340,8 +355,9 @@ public class WebServicePublisher extends SourcePublisher {
 					Resource r = model.createResource();
 					r.addProperty(rdf_type, class_atom_resource);
 					
-					if (classAtom.getClassPredicate().getPrefix() != null && classAtom.getClassPredicate().getNs() != null)
+					if (classAtom.getClassPredicate().getPrefix() != null && classAtom.getClassPredicate().getNs() != null){
 						model.setNsPrefix(classAtom.getClassPredicate().getPrefix(), classAtom.getClassPredicate().getNs());
+					}
 					Resource className = model.createResource(classAtom.getClassPredicate().getUri());
 					r.addProperty(class_predicate, className);
 					
@@ -356,8 +372,9 @@ public class WebServicePublisher extends SourcePublisher {
 					Resource r = model.createResource();
 					r.addProperty(rdf_type, individual_property_atom_resource);
 					
-					if (propertyAtom.getPropertyPredicate().getPrefix() != null && propertyAtom.getPropertyPredicate().getNs() != null)
+					if (propertyAtom.getPropertyPredicate().getPrefix() != null && propertyAtom.getPropertyPredicate().getNs() != null){
 						model.setNsPrefix(propertyAtom.getPropertyPredicate().getPrefix(), propertyAtom.getPropertyPredicate().getNs());
+					}
 					Resource propertyName = model.createResource(propertyAtom.getPropertyPredicate().getUri());
 					r.addProperty(property_predicate, propertyName);
 					

--- a/src/main/java/edu/isi/karma/modeling/Test.java
+++ b/src/main/java/edu/isi/karma/modeling/Test.java
@@ -292,8 +292,14 @@ public class Test {
 	
 	public static void main(String[] args) {
 		boolean test1 = true, test2 = false, test3 = false;
-		if (test1) testOntologyImport();
-		if (test2) testAlignment();
-		if (test3) getGeoNamesNeighbourhoodTree();
+		if (test1){
+			testOntologyImport();
+		}
+		if (test2){
+			testAlignment();
+		}
+		if (test3){
+			getGeoNamesNeighbourhoodTree();
+		}
 	}
 }

--- a/src/main/java/edu/isi/karma/modeling/alignment/Alignment.java
+++ b/src/main/java/edu/isi/karma/modeling/alignment/Alignment.java
@@ -98,7 +98,9 @@ public class Alignment implements OntologyUpdateListener {
 	}
 	
 	public DirectedWeightedMultigraph<Node, Link> getSteinerTree() {
-		if (this.steinerTree == null) align();
+		if (this.steinerTree == null){
+			align();
+		}
 		// GraphUtil.printGraph(this.steinerTree);
 		return this.steinerTree;
 	}
@@ -158,10 +160,13 @@ public class Alignment implements OntologyUpdateListener {
 	public ColumnNode getColumnNodeByHNodeId(String hNodeId) {
 
 		List<Node> columnNodes = this.getNodesByType(NodeType.ColumnNode);
-		if (columnNodes == null) return null;
+		if (columnNodes == null){
+			return null;
+		}
 		for (Node cNode : columnNodes) {
-			if (((ColumnNode)cNode).getHNodeId().equals(hNodeId))
+			if (((ColumnNode)cNode).getHNodeId().equals(hNodeId)){
 				return (ColumnNode)cNode;
+			}
 		}
 		return null;
 	}
@@ -172,7 +177,9 @@ public class Alignment implements OntologyUpdateListener {
 		
 		// use hNodeId as id of the node
 		ColumnNode node = new ColumnNode(hNodeId, hNodeId, columnName, rdfLiteralType);
-		if (this.graphBuilder.addNode(node)) return node;
+		if (this.graphBuilder.addNode(node)){
+			return node;
+		}
 		return null;
 	}
 	
@@ -180,7 +187,9 @@ public class Alignment implements OntologyUpdateListener {
 		
 		String id = nodeIdFactory.getNodeId(label.getUri());
 		InternalNode node = new InternalNode(id, label);
-		if (this.graphBuilder.addNode(node)) return node;
+		if (this.graphBuilder.addNode(node)){
+			return node;
+		}
 		return null;	
 	}
 	
@@ -188,7 +197,9 @@ public class Alignment implements OntologyUpdateListener {
 		
 		// use hNodeId as id of the node
 		ColumnNode node = new ColumnNode(hNodeId, hNodeId, columnName, rdfLiteralType);
-		if (this.graphBuilder.addNodeWithoutUpdatingGraph(node)) return node;
+		if (this.graphBuilder.addNodeWithoutUpdatingGraph(node)){
+			return node;
+		}
 		return null;
 	}
 	
@@ -196,7 +207,9 @@ public class Alignment implements OntologyUpdateListener {
 		
 		String id = nodeIdFactory.getNodeId(label.getUri());
 		InternalNode node = new InternalNode(id, label);
-		if (this.graphBuilder.addNodeWithoutUpdatingGraph(node)) return node;
+		if (this.graphBuilder.addNodeWithoutUpdatingGraph(node)){
+			return node;
+		}
 		return null;	
 	}
 	
@@ -228,7 +241,9 @@ public class Alignment implements OntologyUpdateListener {
 		
 		String id = LinkIdFactory.getLinkId(label.getUri(), source.getId(), target.getId());	
 		DataPropertyLink link = new DataPropertyLink(id, label, partOfKey);
-		if (this.graphBuilder.addLink(source, target, link)) return link;
+		if (this.graphBuilder.addLink(source, target, link)){
+			return link;
+		}
 		return null;
 	}
 	
@@ -237,7 +252,9 @@ public class Alignment implements OntologyUpdateListener {
 		
 		String id = LinkIdFactory.getLinkId(label.getUri(), source.getId(), target.getId());	
 		ObjectPropertyLink link = new ObjectPropertyLink(id, label);
-		if (this.graphBuilder.addLink(source, target, link)) return link;
+		if (this.graphBuilder.addLink(source, target, link)){
+			return link;
+		}
 		return null;	
 	}
 	
@@ -246,7 +263,9 @@ public class Alignment implements OntologyUpdateListener {
 		
 		String id = LinkIdFactory.getLinkId(Uris.RDFS_SUBCLASS_URI, source.getId(), target.getId());
 		SubClassLink link = new SubClassLink(id);
-		if (this.graphBuilder.addLink(source, target, link)) return link;
+		if (this.graphBuilder.addLink(source, target, link)){
+			return link;
+		}
 		return null;	
 	}
 	
@@ -254,7 +273,9 @@ public class Alignment implements OntologyUpdateListener {
 		
 		String id = LinkIdFactory.getLinkId(Uris.CLASS_INSTANCE_LINK_URI, source.getId(), target.getId());
 		ClassInstanceLink link = new ClassInstanceLink(id, keyInfo);
-		if (this.graphBuilder.addLink(source, target, link)) return link;
+		if (this.graphBuilder.addLink(source, target, link)){
+			return link;
+		}
 		return null;
 	}
 	
@@ -262,14 +283,18 @@ public class Alignment implements OntologyUpdateListener {
 		
 		String id = LinkIdFactory.getLinkId(Uris.DATAPROPERTY_OF_COLUMN_LINK_URI, source.getId(), target.getId());
 		DataPropertyOfColumnLink link = new DataPropertyOfColumnLink(id, specializedColumnHNodeId);
-		if (this.graphBuilder.addLink(source, target, link)) return link;
+		if (this.graphBuilder.addLink(source, target, link)){
+			return link;
+		}
 		return null;	
 	}
 	
 	public ObjectPropertySpecializationLink addObjectPropertySpecializationLink(Node source, Node target, Link specializedLink) {
 		String id = LinkIdFactory.getLinkId(Uris.OBJECTPROPERTY_SPECIALIZATION_LINK_URI, source.getId(), target.getId());
 		ObjectPropertySpecializationLink link = new ObjectPropertySpecializationLink(id, specializedLink);
-		if (this.graphBuilder.addLink(source, target, link)) return link;
+		if (this.graphBuilder.addLink(source, target, link)){
+			return link;
+		}
 		return null;
 	}
 
@@ -277,7 +302,9 @@ public class Alignment implements OntologyUpdateListener {
 		
 		String id = LinkIdFactory.getLinkId(Uris.COLUMN_SUBCLASS_LINK_URI, source.getId(), target.getId());
 		ColumnSubClassLink link = new ColumnSubClassLink(id);
-		if (this.graphBuilder.addLink(source, target, link)) return link;
+		if (this.graphBuilder.addLink(source, target, link)){
+			return link;
+		}
 		return null;	
 	}
 	
@@ -306,17 +333,19 @@ public class Alignment implements OntologyUpdateListener {
 				Node target = this.getNodeById(LinkIdFactory.getLinkTargetId(linkId));
 				String linkUri = LinkIdFactory.getLinkUri(linkId);
 				Link newLink;
-				if (linkUri.equalsIgnoreCase(Uris.RDFS_SUBCLASS_URI))
+				if (linkUri.equalsIgnoreCase(Uris.RDFS_SUBCLASS_URI)){
 					newLink = new SubClassLink(linkId);
-				else
+				}else{
 					newLink = new ObjectPropertyLink(linkId, 
 							this.graphBuilder.getOntologyManager().getUriLabel(linkUri));
+				}
 				
 				newLink.setStatus(LinkStatus.ForcedByUser);
 				this.graphBuilder.addLink(source, target, newLink);
 			}
-		} else
+		}else{
 			this.graphBuilder.changeLinkStatus(link, newStatus);
+		}
 	}
 	
 	/**
@@ -348,8 +377,9 @@ public class Alignment implements OntologyUpdateListener {
 	public boolean removeLink(String linkId) {
 		
 		Link link = this.getLinkById(linkId);
-		if (link != null)
+		if (link != null){
 			return this.graphBuilder.removeLink(link);
+		}
 		logger.debug("Cannot find the link " + linkId + " in the graph.");
 		return false;
 	}
@@ -357,8 +387,12 @@ public class Alignment implements OntologyUpdateListener {
 	public Set<Link> getCurrentLinksToNode(String nodeId) {
 		
 		Node node = this.getNodeById(nodeId);
-		if (node == null) return null;
-		if (!this.steinerTree.containsVertex(node)) return null;
+		if (node == null){
+			return null;
+		}
+		if (!this.steinerTree.containsVertex(node)){
+			return null;
+		}
 			
 		return this.steinerTree.incomingEdgesOf(node);
 	}
@@ -374,7 +408,9 @@ public class Alignment implements OntologyUpdateListener {
 		HashSet<Link> allLinks = new HashSet<Link>();
 
 		Node node = this.getNodeById(nodeId);
-		if (node == null) return possibleLinks;
+		if (node == null){
+			return possibleLinks;
+		}
 		
 		Set<Link> incomingLinks = this.graphBuilder.getGraph().incomingEdgesOf(node);
 		if (incomingLinks != null) {
@@ -387,8 +423,9 @@ public class Alignment implements OntologyUpdateListener {
 			allLinks.addAll(outgoingLinks);
 		}
 		
-		if (allLinks.size() == 0)
+		if (allLinks.size() == 0){
 			return possibleLinks;
+		}
 		
 		String sourceId, targetId;
 		for (Link e : allLinks) {
@@ -400,8 +437,9 @@ public class Alignment implements OntologyUpdateListener {
 				targetId = nodeId;
 			}
 			temp = getLinks(sourceId, targetId);
-			if (temp != null)
+			if (temp != null){
 				possibleLinks.addAll(temp);
+			}
 		}
 		
 		Collections.sort(possibleLinks);
@@ -426,7 +464,9 @@ public class Alignment implements OntologyUpdateListener {
 		HashSet<Link> allLinks = new HashSet<Link>();
 
 		Node node = this.getNodeById(nodeId);
-		if (node == null) return possibleLinks;
+		if (node == null){
+			return possibleLinks;
+		}
 		
 		Set<Link> incomingLinks = this.graphBuilder.getGraph().incomingEdgesOf(node);
 		if (incomingLinks != null) {
@@ -439,8 +479,9 @@ public class Alignment implements OntologyUpdateListener {
 			allLinks.addAll(outgoingLinks);
 		}
 		
-		if (allLinks.size() == 0)
+		if (allLinks.size() == 0){
 			return possibleLinks;
+		}
 		
 		String sourceId, targetId;
 		for (Link e : allLinks) {
@@ -452,8 +493,9 @@ public class Alignment implements OntologyUpdateListener {
 				targetId = e.getSource().getId();
 			}
 			temp = getLinks(sourceId, targetId);
-			if (temp != null)
+			if (temp != null){
 				possibleLinks.addAll(temp);
+			}
 		}
 		
 		Collections.sort(possibleLinks);
@@ -464,15 +506,17 @@ public class Alignment implements OntologyUpdateListener {
 	
 	private void updateLinksPreferredByUI() {
 		
-		if (this.steinerTree == null)
+		if (this.steinerTree == null){
 			return;
+		}
 		
 		// Change the status of previously preferred links to normal
 		List<Link> linksInPreviousTree = this.getLinksByStatus(LinkStatus.PreferredByUI);
 		if (linksInPreviousTree != null) {
 			Link[] links = linksInPreviousTree.toArray(new Link[0]);
-			for (Link link : links)
+			for (Link link : links){
 				this.graphBuilder.changeLinkStatus(link, LinkStatus.Normal);
+			}
 		}
 		
 		List<Link> linksForcedByUser = this.getLinksByStatus(LinkStatus.ForcedByUser);
@@ -499,8 +543,9 @@ public class Alignment implements OntologyUpdateListener {
 					steinerNodes.add(n);
 					// adding the domain
 					steinerNodes.add(domain);
-				} else 
+				}else{
 					logger.error("The column node " + n.getId() + " does not have any domain or it has more than one domain.");
+				}
 			}
 		}
 
@@ -509,11 +554,13 @@ public class Alignment implements OntologyUpdateListener {
 		if (linksForcedByUser != null) {
 			for (Link link : linksForcedByUser) {
 				
-				if (!steinerNodes.contains(link.getSource()))
+				if (!steinerNodes.contains(link.getSource())){
 					steinerNodes.add(link.getSource());
+				}
 	
-				if (!steinerNodes.contains(link.getTarget()))
-					steinerNodes.add(link.getTarget());			
+				if (!steinerNodes.contains(link.getTarget())){
+					steinerNodes.add(link.getTarget());
+				}			
 			}
 		}
 		

--- a/src/main/java/edu/isi/karma/modeling/alignment/GraphBuilder.java
+++ b/src/main/java/edu/isi/karma/modeling/alignment/GraphBuilder.java
@@ -135,8 +135,9 @@ public class GraphBuilder {
 		
 		for (Node node : this.graph.vertexSet()) {
 			
-			if (node instanceof InternalNode)
+			if (node instanceof InternalNode){
 				nodeIdFactory.getNodeId(node.getLabel().getUri());
+			}
 
 			this.idToNodeMap.put(node.getId(), node);
 			
@@ -261,8 +262,9 @@ public class GraphBuilder {
 	public void resetOntologyMaps() {
 		String[] currentUris = this.uriClosure.keySet().toArray(new String[0]);
 		this.uriClosure.clear();
-		for (String uri : currentUris)
+		for (String uri : currentUris){
 			computeUriClosure(uri);
+		}
 	}
 	
 	public void addNodeList(List<Node> nodes) {
@@ -274,11 +276,13 @@ public class GraphBuilder {
 
 		for (Node node : nodes) {
 			
-			if (!addSingleNode(node))
+			if (!addSingleNode(node)){
 				continue;
+			}
 				
-			if (node instanceof InternalNode) 
+			if (node instanceof InternalNode){
 				addNodeClosure(node, new ArrayList<Node>());
+			}
 		}
 
 		long addNodesClosure = System.currentTimeMillis();
@@ -301,8 +305,9 @@ public class GraphBuilder {
 		
 		logger.debug("<enter");
 
-		if (!addSingleNode(node))
+		if (!addSingleNode(node)){
 			return false;
+		}
 			
 		if (node instanceof InternalNode) {
 
@@ -350,8 +355,9 @@ public class GraphBuilder {
 		
 		logger.debug("<enter");
 
-		if (!addSingleNode(node))
+		if (!addSingleNode(node)){
 			return false;
+		}
 
 		logger.debug("exit>");		
 		return true;
@@ -386,20 +392,21 @@ public class GraphBuilder {
 		this.sourceToTargetConnectivity.add(target.getId() + source.getId());
 		
 		double w = 0.0;
-		if (link.getPriorityType() == LinkPriorityType.DirectDataProperty)
+		if (link.getPriorityType() == LinkPriorityType.DirectDataProperty){
 			w = ModelingParams.PROPERTY_DIRECT_WEIGHT;
-		else if (link.getPriorityType() == LinkPriorityType.IndirectObjectProperty)
+		}else if (link.getPriorityType() == LinkPriorityType.IndirectObjectProperty){
 			w = ModelingParams.PROPERTY_INDIRECT_WEIGHT;
-		else if (link.getPriorityType() == LinkPriorityType.ObjectPropertyWithOnlyDomain)
+		}else if (link.getPriorityType() == LinkPriorityType.ObjectPropertyWithOnlyDomain){
 			w = ModelingParams.PROPERTY_WITH_ONLY_DOMAIN_WEIGHT;
-		else if (link.getPriorityType() == LinkPriorityType.ObjectPropertyWithOnlyRange)
+		}else if (link.getPriorityType() == LinkPriorityType.ObjectPropertyWithOnlyRange){
 			w = ModelingParams.PROPERTY_WITH_ONLY_RANGE_WEIGHT;
-		else if (link.getPriorityType() == LinkPriorityType.ObjectPropertyWithoutDomainAndRange)
+		}else if (link.getPriorityType() == LinkPriorityType.ObjectPropertyWithoutDomainAndRange){
 			w = ModelingParams.PROPERTY_WITHOUT_DOMAIN_RANGE_WEIGHT;
-		else if (link.getPriorityType() == LinkPriorityType.SubClassOf)
+		}else if (link.getPriorityType() == LinkPriorityType.SubClassOf){
 			w = ModelingParams.SUBCLASS_WEIGHT;
-		else
+		}else{
 			w = ModelingParams.PROPERTY_DIRECT_WEIGHT;
+		}
 		
 		this.graph.setEdgeWeight(link, w);
 		
@@ -431,12 +438,18 @@ public class GraphBuilder {
 		if (source instanceof InternalNode && target instanceof ColumnNode) {
 			List<Node> closure = this.getNodeClosure(source);
 			List<Node> closureIncludingSelf = new ArrayList<Node>();
-			if (closure != null) closureIncludingSelf.addAll(closure);
-			if (!closureIncludingSelf.contains(source)) closureIncludingSelf.add(source);
+			if (closure != null){
+				closureIncludingSelf.addAll(closure);
+			}
+			if (!closureIncludingSelf.contains(source)){
+				closureIncludingSelf.add(source);
+			}
 			
 			for (Node n : closureIncludingSelf) {
 				Integer refCount = this.nodeReferences.get(n);
-				if (refCount != null) this.nodeReferences.put(source, ++refCount);
+				if (refCount != null){
+					this.nodeReferences.put(source, ++refCount);
+				}
 			}
 		}
 			
@@ -456,7 +469,9 @@ public class GraphBuilder {
 		link.setStatus(newStatus);
 		
 		List<Link> linksWithOldStatus = this.statusToLinksMap.get(oldStatus);
-		if (linksWithOldStatus != null) linksWithOldStatus.remove(link);
+		if (linksWithOldStatus != null){
+			linksWithOldStatus.remove(link);
+		}
 
 		List<Link> linksWithNewStatus = this.statusToLinksMap.get(newStatus);
 		if (linksWithNewStatus == null) {
@@ -488,17 +503,24 @@ public class GraphBuilder {
 		if (source instanceof InternalNode && target instanceof ColumnNode) {
 			List<Node> closure = this.getNodeClosure(source);
 			List<Node> closureIncludingSelf = new ArrayList<Node>();
-			if (closure != null) closureIncludingSelf.addAll(closure);
-			if (!closureIncludingSelf.contains(source)) closureIncludingSelf.add(source);
+			if (closure != null){
+				closureIncludingSelf.addAll(closure);
+			}
+			if (!closureIncludingSelf.contains(source)){
+				closureIncludingSelf.add(source);
+			}
 			
 			for (Node n : closureIncludingSelf) {
 				Integer refCount = this.nodeReferences.get(n);
-				if (refCount != null) this.nodeReferences.put(source, --refCount);
+				if (refCount != null){
+					this.nodeReferences.put(source, --refCount);
+				}
 			}
 		}
 		
-		if (!removeSingleLink(link))
+		if (!removeSingleLink(link)){
 			return false;
+		}
 		
 		return true;
 	}
@@ -517,16 +539,21 @@ public class GraphBuilder {
 		
 		List<Node> closure = this.getNodeClosure(node);
 		List<Node> closureIncludingSelf = new ArrayList<Node>();
-		if (closure != null) closureIncludingSelf.addAll(closure);
-		if (!closureIncludingSelf.contains(node)) closureIncludingSelf.add(node);
+		if (closure != null){
+			closureIncludingSelf.addAll(closure);
+		}
+		if (!closureIncludingSelf.contains(node)){
+			closureIncludingSelf.add(node);
+		}
 
 		for (Node n : closureIncludingSelf) {
 			Integer refCount = this.nodeReferences.get(n);
 			if (refCount != null) {
-				if (refCount.intValue() == 0) 
+				if (refCount.intValue() == 0){
 					removeSingleNode(n);
-			else
-				this.nodeReferences.put(n, --refCount);
+				}else{
+					this.nodeReferences.put(n, --refCount);
+				}
 			}
 		}
 
@@ -546,8 +573,9 @@ public class GraphBuilder {
 		List<Node> internalNodes = this.typeToNodesMap.get(NodeType.InternalNode);
 		if (internalNodes != null) {
 			Node[] nodes = internalNodes.toArray(new Node[0]);
-			for (Node node : nodes) 
+			for (Node node : nodes){
 				addNodeClosure(node, new ArrayList<Node>());
+			}
 		}
 
 		long addNodesClosure = System.currentTimeMillis();
@@ -645,20 +673,23 @@ public class GraphBuilder {
 			}
 		}
 		
-		if (!this.graph.removeVertex(node))
+		if (!this.graph.removeVertex(node)){
 			return false;
+		}
 		
 		// updating hashmaps
 		
 		this.idToNodeMap.remove(node.getId());
 		
 		List<Node> nodesWithSameUri = uriToNodesMap.get(node.getLabel().getUri());
-		if (nodesWithSameUri != null) 
+		if (nodesWithSameUri != null){
 			nodesWithSameUri.remove(node);
+		}
 		
 		List<Node> nodesWithSameType = typeToNodesMap.get(node.getType());
-		if (nodesWithSameType != null) 
+		if (nodesWithSameType != null){
 			nodesWithSameType.remove(node);
+		}
 		
 		this.nodeReferences.remove(node);
 				
@@ -668,24 +699,28 @@ public class GraphBuilder {
 	
 	private boolean removeSingleLink(Link link) {
 		
-		if (!this.graph.removeEdge(link))
+		if (!this.graph.removeEdge(link)){
 			return false;
+		}
 
 		// update hashmaps
 
 		this.idToLinkMap.remove(link.getId());
 
 		List<Link> linksWithSameUri = uriToLinksMap.get(link.getLabel().getUri());
-		if (linksWithSameUri != null) 
+		if (linksWithSameUri != null){
 			linksWithSameUri.remove(link);
+		}
 		
 		List<Link> linksWithSameType = typeToLinksMap.get(link.getType());
-		if (linksWithSameType != null) 
+		if (linksWithSameType != null){
 			linksWithSameType.remove(link);
+		}
 		
 		List<Link> linksWithSameStatus = statusToLinksMap.get(link.getStatus());
-		if (linksWithSameStatus != null) 
+		if (linksWithSameStatus != null){
 			linksWithSameStatus.remove(link);
+		}
 		
 		this.sourceToTargetLinkUris.remove(link.getSource().getId() + 
 				link.getTarget().getId() + 
@@ -708,10 +743,12 @@ public class GraphBuilder {
 		opDomainClasses = ontologyManager.getDomainsGivenRange(uri, true);
 		superClasses = ontologyManager.getSuperClasses(uri, false);
 
-		if (opDomainClasses != null)
+		if (opDomainClasses != null){
 			uriDirectConnections.addAll(opDomainClasses);
-		if (superClasses != null)
+		}
+		if (superClasses != null){
 			uriDirectConnections.addAll(superClasses.keySet());
+		}
 
 		return uriDirectConnections;
 	}
@@ -719,15 +756,17 @@ public class GraphBuilder {
 	private List<String> computeUriClosure(String uri) {
 		
 		List<String> closure = this.uriClosure.get(uri);
-		if (closure != null) 
+		if (closure != null){
 			return closure;
+		}
 	
 		closure = new ArrayList<String>();
 		List<String> closedList = new ArrayList<String>();
 		HashMap<String, List<String>> dependentUrisMap = new HashMap<String, List<String>>();
 		computeUriClosureRecursive(uri, closure, closedList, dependentUrisMap);
-		if (closedList.contains(uri) && !closure.contains(uri))
+		if (closedList.contains(uri) && !closure.contains(uri)){
 			closure.add(uri);
+		}
 		
 		int count = 1;
 		while (count != 0) {
@@ -773,15 +812,24 @@ public class GraphBuilder {
 						dependentUris = new ArrayList<String>();
 						dependentUrisMap.put(uri, dependentUris);
 					}
-					if (!dependentUris.contains(c)) dependentUris.add(c);
+					if (!dependentUris.contains(c)){
+						dependentUris.add(c);
+					}
 					continue;
 				}
-				if (!closure.contains(c)) closure.add(c);
-				if (!closedList.contains(c)) closedList.add(c);
+				if (!closure.contains(c)){
+					closure.add(c);
+				}
+				if (!closedList.contains(c)){
+					closedList.add(c);
+				}
 				List<String> localClosure = new ArrayList<String>();
 				computeUriClosureRecursive(c, localClosure, closedList, dependentUrisMap);
-				for (String s : localClosure)
-					if (!closure.contains(s)) closure.add(s);
+				for (String s : localClosure){
+					if (!closure.contains(s)){
+						closure.add(s);
+					}
+				}
 			}
 			this.uriClosure.put(uri, closure);
 		}
@@ -792,7 +840,9 @@ public class GraphBuilder {
 	private List<Node> getNodeClosure(Node node) {
 		
 		List<Node> nodeClosure = new ArrayList<Node>();
-		if (node instanceof ColumnNode) return nodeClosure;
+		if (node instanceof ColumnNode){
+			return nodeClosure;
+		}
 		
 		String uri = node.getLabel().getUri();
 		List<String> closure = this.uriClosure.get(uri); 
@@ -801,7 +851,9 @@ public class GraphBuilder {
 		} 
 		for (String s : closure) {
 			List<Node> nodes = uriToNodesMap.get(s);
-			if (nodes != null) nodeClosure.addAll(nodes);
+			if (nodes != null){
+				nodeClosure.addAll(nodes);
+			}
 		}
 		return nodeClosure;
 	}
@@ -817,7 +869,9 @@ public class GraphBuilder {
 
 		logger.debug("<enter");
 		
-		if (newAddedNodes == null) newAddedNodes = new ArrayList<Node>();
+		if (newAddedNodes == null){
+			newAddedNodes = new ArrayList<Node>();
+		}
 		
 		String uri = node.getLabel().getUri();
 
@@ -828,7 +882,9 @@ public class GraphBuilder {
 			if (nodesOfSameUri == null || nodesOfSameUri.size() == 0) { // the internal node is not added to the graph before
 				Node nn = new InternalNode(nodeIdFactory.getNodeId(c), 
 						ontologyManager.getUriLabel(c));
-				if (addSingleNode(nn)) newAddedNodes.add(nn);
+				if (addSingleNode(nn)){
+					newAddedNodes.add(nn);
+				}
 			} 
 		}
 
@@ -868,11 +924,13 @@ public class GraphBuilder {
 //				System.out.println(count);
 //				count++;
 				
-				if (n1.equals(n2))
+				if (n1.equals(n2)){
 					continue;
+				}
 				
-				if (this.visitedSourceTargetPairs.contains(n1.getId() + n2.getId()))
+				if (this.visitedSourceTargetPairs.contains(n1.getId() + n2.getId())){
 					continue;
+				}
 				
 				this.visitedSourceTargetPairs.add(n1.getId() + n2.getId());
 
@@ -886,70 +944,82 @@ public class GraphBuilder {
 				
 				// create a link from the domain to the range
 				objectPropertiesDirect = ontologyManager.getObjectPropertiesDirect(sourceUri, targetUri);
-				if (objectPropertiesDirect != null)
-				for (String uri : objectPropertiesDirect) {
+				if (objectPropertiesDirect != null){
+					for (String uri : objectPropertiesDirect) {
 
-					key = source.getId() + target.getId() + uri;
-					// check to see if the link is duplicate or not
-					if (sourceToTargetLinkUris.contains(key)) continue;
+						key = source.getId() + target.getId() + uri;
+						// check to see if the link is duplicate or not
+						if (sourceToTargetLinkUris.contains(key)){
+							continue;
+						}
 
-					id = LinkIdFactory.getLinkId(uri, source.getId(), target.getId());
-					label = ontologyManager.getUriLabel(uri);
-					Link link = new ObjectPropertyLink(id, label);
-					link.setPriorityType(LinkPriorityType.DirectObjectProperty);
-					addLink(source, target, link);
+						id = LinkIdFactory.getLinkId(uri, source.getId(), target.getId());
+						label = ontologyManager.getUriLabel(uri);
+						Link link = new ObjectPropertyLink(id, label);
+						link.setPriorityType(LinkPriorityType.DirectObjectProperty);
+						addLink(source, target, link);
+					}
 				}
 				
 				// create a link from the domain and all its subclasses of ObjectProperties to range and all its subclasses
 				objectPropertiesIndirect = ontologyManager.getObjectPropertiesIndirect(sourceUri, targetUri);
-				if (objectPropertiesIndirect != null)
-				for (String uri : objectPropertiesIndirect) {
+				if (objectPropertiesIndirect != null){
+					for (String uri : objectPropertiesIndirect) {
 
-					key = source.getId() + target.getId() + uri;
-					// check to see if the link is duplicate or not
-					if (sourceToTargetLinkUris.contains(key)) continue;
+						key = source.getId() + target.getId() + uri;
+						// check to see if the link is duplicate or not
+						if (sourceToTargetLinkUris.contains(key)){
+							continue;
+						}
 
-					id = LinkIdFactory.getLinkId(uri, source.getId(), target.getId());
-					label = ontologyManager.getUriLabel(uri);
-					Link link = new ObjectPropertyLink(id, label);
-					// prefer the links that are actually defined between source and target in the ontology 
-					// over inherited ones.
-					link.setPriorityType(LinkPriorityType.IndirectObjectProperty);
-					addLink(source, target, link);
+						id = LinkIdFactory.getLinkId(uri, source.getId(), target.getId());
+						label = ontologyManager.getUriLabel(uri);
+						Link link = new ObjectPropertyLink(id, label);
+						// prefer the links that are actually defined between source and target in the ontology 
+						// over inherited ones.
+						link.setPriorityType(LinkPriorityType.IndirectObjectProperty);
+						addLink(source, target, link);
+					}
 				}
 
 				objectPropertiesWithOnlyDomain = ontologyManager.getObjectPropertiesWithOnlyDomain(sourceUri, targetUri);
-				if (objectPropertiesWithOnlyDomain != null)
-				for (String uri : objectPropertiesWithOnlyDomain) {
+				if (objectPropertiesWithOnlyDomain != null){
+					for (String uri : objectPropertiesWithOnlyDomain) {
 
-					key = source.getId() + target.getId() + uri;
-					// check to see if the link is duplicate or not
-					if (sourceToTargetLinkUris.contains(key)) continue;
+						key = source.getId() + target.getId() + uri;
+						// check to see if the link is duplicate or not
+						if (sourceToTargetLinkUris.contains(key)){
+							continue;
+						}
 
-					id = LinkIdFactory.getLinkId(uri, source.getId(), target.getId());
-					label = ontologyManager.getUriLabel(uri);
-					Link link = new ObjectPropertyLink(id, label);
-					// prefer the links that are actually defined between source and target in the ontology 
-					// over inherited ones.
-					link.setPriorityType(LinkPriorityType.ObjectPropertyWithOnlyDomain);
-					addLink(source, target, link);
+						id = LinkIdFactory.getLinkId(uri, source.getId(), target.getId());
+						label = ontologyManager.getUriLabel(uri);
+						Link link = new ObjectPropertyLink(id, label);
+						// prefer the links that are actually defined between source and target in the ontology 
+						// over inherited ones.
+						link.setPriorityType(LinkPriorityType.ObjectPropertyWithOnlyDomain);
+						addLink(source, target, link);
+					}
 				}
 				
 				objectPropertiesWithOnlyRange = ontologyManager.getObjectPropertiesWithOnlyRange(sourceUri, targetUri);
-				if (objectPropertiesWithOnlyRange != null)
-				for (String uri : objectPropertiesWithOnlyRange) {
+				if (objectPropertiesWithOnlyRange != null){
+					for (String uri : objectPropertiesWithOnlyRange) {
 
-					key = source.getId() + target.getId() + uri;
-					// check to see if the link is duplicate or not
-					if (sourceToTargetLinkUris.contains(key)) continue;
+						key = source.getId() + target.getId() + uri;
+						// check to see if the link is duplicate or not
+						if (sourceToTargetLinkUris.contains(key)){
+							continue;
+						}
 
-					id = LinkIdFactory.getLinkId(uri, source.getId(), target.getId());
-					label = ontologyManager.getUriLabel(uri);
-					Link link = new ObjectPropertyLink(id, label);
-					// prefer the links that are actually defined between source and target in the ontology 
-					// over inherited ones.
-					link.setPriorityType(LinkPriorityType.ObjectPropertyWithOnlyRange);
-					addLink(source, target, link);
+						id = LinkIdFactory.getLinkId(uri, source.getId(), target.getId());
+						label = ontologyManager.getUriLabel(uri);
+						Link link = new ObjectPropertyLink(id, label);
+						// prefer the links that are actually defined between source and target in the ontology 
+						// over inherited ones.
+						link.setPriorityType(LinkPriorityType.ObjectPropertyWithOnlyRange);
+						addLink(source, target, link);
+					}
 				}
 				
 				// Add subclass links between internal nodes
@@ -957,7 +1027,9 @@ public class GraphBuilder {
 					// target is subclass of source
 					key = source.getId() + target.getId() + SubClassLink.getFixedLabel().getUri();
 					// check to see if the link is duplicate or not
-					if (sourceToTargetLinkUris.contains(key)) continue;
+					if (sourceToTargetLinkUris.contains(key)){
+						continue;
+					}
 					id = LinkIdFactory.getLinkId(SubClassLink.getFixedLabel().getUri(), source.getId(), target.getId());
 					SubClassLink subClassOfLink = new SubClassLink(id);
 					addLink(source, target, subClassOfLink);
@@ -994,13 +1066,16 @@ public class GraphBuilder {
 //				System.out.println(count);
 //				count++;
 
-				if (n1.equals(n2))
+				if (n1.equals(n2)){
 					continue;
+				}
 
-				if (this.visitedSourceTargetPairs.contains(n1.getId() + n2.getId()))
+				if (this.visitedSourceTargetPairs.contains(n1.getId() + n2.getId())){
 					continue;
-				if (this.visitedSourceTargetPairs.contains(n2.getId() + n1.getId()))
+				}
+				if (this.visitedSourceTargetPairs.contains(n2.getId() + n1.getId())){
 					continue;
+				}
 				
 				this.visitedSourceTargetPairs.add(n1.getId() + n2.getId());
 
@@ -1081,34 +1156,40 @@ public class GraphBuilder {
 
 		objectPropertiesDirect = ontologyManager.getObjectPropertiesDirect(sourceUri, targetUri);
 		if (objectPropertiesDirect != null) {
-			for (String s : objectPropertiesDirect)
-			linkUris.put(s, LinkPriorityType.DirectObjectProperty);
+			for (String s : objectPropertiesDirect){
+				linkUris.put(s, LinkPriorityType.DirectObjectProperty);
+			}
 		}
 
 		objectPropertiesIndirect = ontologyManager.getObjectPropertiesIndirect(sourceUri, targetUri);
 		if (objectPropertiesIndirect != null) {
-			for (String s : objectPropertiesIndirect)
-			linkUris.put(s, LinkPriorityType.IndirectObjectProperty);
+			for (String s : objectPropertiesIndirect){
+				linkUris.put(s, LinkPriorityType.IndirectObjectProperty);
+			}
 		}		
 
 		objectPropertiesWithOnlyDomain = ontologyManager.getObjectPropertiesWithOnlyDomain(sourceUri, targetUri);
 		if (objectPropertiesWithOnlyDomain != null) {
-			for (String s : objectPropertiesWithOnlyDomain)
-			linkUris.put(s, LinkPriorityType.ObjectPropertyWithOnlyDomain);
+			for (String s : objectPropertiesWithOnlyDomain){
+				linkUris.put(s, LinkPriorityType.ObjectPropertyWithOnlyDomain);
+			}
 		}	
 	
 		objectPropertiesWithOnlyRange = ontologyManager.getObjectPropertiesWithOnlyRange(sourceUri, targetUri);
 		if (objectPropertiesWithOnlyRange != null) {
-			for (String s : objectPropertiesWithOnlyRange)
-			linkUris.put(s, LinkPriorityType.ObjectPropertyWithOnlyRange);
+			for (String s : objectPropertiesWithOnlyRange){
+				linkUris.put(s, LinkPriorityType.ObjectPropertyWithOnlyRange);
+			}
 		}	
 
-		if (ontologyManager.isSubClass(sourceUri, targetUri, true)) 
+		if (ontologyManager.isSubClass(sourceUri, targetUri, true)){
 			linkUris.put(Uris.RDFS_SUBCLASS_URI, LinkPriorityType.SubClassOf);
+		}
 		
 		if (objectPropertiesWithoutDomainAndRange != null) {
-			for (String s : objectPropertiesWithoutDomainAndRange.keySet())
-			linkUris.put(s, LinkPriorityType.ObjectPropertyWithoutDomainAndRange);
+			for (String s : objectPropertiesWithoutDomainAndRange.keySet()){
+				linkUris.put(s, LinkPriorityType.ObjectPropertyWithoutDomainAndRange);
+			}
 		}
 
 		return linkUris;
@@ -1149,10 +1230,11 @@ public class GraphBuilder {
 			label = new Label(ontologyManager.getUriLabel(uri));
 			
 			Link newLink;
-			if (uri.equalsIgnoreCase(Uris.RDFS_SUBCLASS_URI))
+			if (uri.equalsIgnoreCase(Uris.RDFS_SUBCLASS_URI)){
 				newLink = new SubClassLink(id);
-			else
+			}else{
 				newLink = new ObjectPropertyLink(id, label);
+			}
 			
 			newLink.setPriorityType(entry.getValue());
 			sortedLinks.add(newLink);

--- a/src/main/java/edu/isi/karma/modeling/alignment/GraphPreProcess.java
+++ b/src/main/java/edu/isi/karma/modeling/alignment/GraphPreProcess.java
@@ -60,11 +60,13 @@ public class GraphPreProcess {
 		
 		logger.debug("<enter");
 
-		if (linksPreferredByUI != null) 
-			for (Link link : linksPreferredByUI) 
+		if (linksPreferredByUI != null){
+			for (Link link : linksPreferredByUI){
 				gPrime.setEdgeWeight(link, ModelingParams.PROPERTY_UI_PREFERRED_WEIGHT);
+			}
+		}
 				
-		if (linksForcedByUser != null) 
+		if (linksForcedByUser != null){
 			for (Link link : linksForcedByUser) {
 				
 //				// removing all the links to target
@@ -79,7 +81,8 @@ public class GraphPreProcess {
 //				gPrime.addEdge(link.getSource(), link.getTarget(), link);
 				
 				gPrime.setEdgeWeight(link, ModelingParams.PROPERTY_USER_PREFERRED_WEIGHT);
-			}			
+			}
+		}			
 
 		logger.debug("exit>");
 //		GraphUtil.printGraph(gPrime);

--- a/src/main/java/edu/isi/karma/modeling/alignment/GraphUtil.java
+++ b/src/main/java/edu/isi/karma/modeling/alignment/GraphUtil.java
@@ -51,8 +51,9 @@ public class GraphUtil {
 		}
 		
 		String s = node.getClass().getName();
-		if (s.indexOf(".") != -1)
+		if (s.indexOf(".") != -1){
 			s = s.substring(s.lastIndexOf(".") + 1);
+		}
     	return s;
 	}
 
@@ -64,8 +65,9 @@ public class GraphUtil {
 		}
 		
 		String s = link.getClass().getName();
-		if (s.indexOf(".") != -1)
+		if (s.indexOf(".") != -1){
 			s = s.substring(s.lastIndexOf(".") + 1);
+		}
     	return s;
 	}
 	
@@ -80,10 +82,11 @@ public class GraphUtil {
     	System.out.print( node.getLocalId());
 //    	System.out.print( vertex.getID());
     	System.out.print(", ");
-		if (node instanceof ColumnNode)
+		if (node instanceof ColumnNode){
 			System.out.print( ((ColumnNode)node).getColumnName());
-		else
+		}else{
 			System.out.print(node.getLabel().getLocalName());
+		}
     	System.out.print(", ");
     	System.out.print(getNodeTypeString(node));
     	System.out.print(")");
@@ -119,11 +122,13 @@ public class GraphUtil {
 
 		DirectedGraph<Node, Link> g = new DirectedWeightedMultigraph<Node, Link>(Link.class);
 		
-		for (Node v : undirectedGraph.vertexSet())
+		for (Node v : undirectedGraph.vertexSet()){
 			g.addVertex(v);
+		}
 		
-		for (Link e: undirectedGraph.edgeSet())
+		for (Link e: undirectedGraph.edgeSet()){
 			g.addEdge(e.getSource(), e.getTarget(), e);
+		}
 		
 		return g;
 	}
@@ -158,10 +163,11 @@ public class GraphUtil {
 
 		for (Link edge : graph.edgeSet()) {
 			System.out.print("(");
-			if (edge.getSource() instanceof ColumnNode)
+			if (edge.getSource() instanceof ColumnNode){
 				System.out.print(edge.getSource().getLocalId() + "-" + ((ColumnNode)edge.getSource()).getColumnName());
-			else
+			}else{
 				System.out.print(edge.getSource().getLocalId());
+			}
 			System.out.print(")");
 			System.out.print(" - ");
 			System.out.print("(");
@@ -169,10 +175,11 @@ public class GraphUtil {
 			System.out.print(")");
 			System.out.print(" - ");
 			System.out.print("(");
-			if (edge.getTarget() instanceof ColumnNode)
+			if (edge.getTarget() instanceof ColumnNode){
 				System.out.print(edge.getTarget().getLocalId() + "-" + ((ColumnNode)edge.getTarget()).getColumnName());
-			else
+			}else{
 				System.out.print(edge.getTarget().getLocalId());
+			}
 			System.out.print(")");
 			System.out.print(" - w=" + edge.getWeight());
 			System.out.println();
@@ -192,8 +199,9 @@ public class GraphUtil {
 
 		DirectedWeightedMultigraph<Node, Link> rootedTree = 
 				(DirectedWeightedMultigraph<Node, Link>)tree.clone();
-		if (reversedLinks == null)
+		if (reversedLinks == null){
 			reversedLinks = new HashSet<String>();
+		}
 		treeToRootedTree(rootedTree, root, null, reversedLinks);
 		return rootedTree;
 	}
@@ -225,16 +233,18 @@ public class GraphUtil {
         Object obj  = in.readObject();
         in.close();
         
-        if (obj instanceof DirectedWeightedMultigraph<?, ?>)
-        	return (DirectedWeightedMultigraph<Node, Link>)obj;
-        else 
-        	return null;
+        if (obj instanceof DirectedWeightedMultigraph<?, ?>){
+			return (DirectedWeightedMultigraph<Node, Link>)obj;
+		}else{
+			return null;
+		}
 	}
 
 	private static void treeToRootedTree(DirectedWeightedMultigraph<Node, Link> tree, Node node, Link e, Set<String> reversedLinks) {
 		
-		if (node == null)
+		if (node == null){
 			return;
+		}
 		
 		Node source, target;
 		
@@ -247,8 +257,9 @@ public class GraphUtil {
 				target = inLink.getTarget();
 				
 				// don't remove the incoming link from parent to this node
-				if (e != null && inLink.equals(e))
+				if (e != null && inLink.equals(e)){
 					continue;
+				}
 				
 				// removeEdge method should always be called before addEdge because the new edge has the same id
 				// and JGraph does not add the duplicate link
@@ -265,8 +276,9 @@ public class GraphUtil {
 
 		Set<Link> outgoingLinks = tree.outgoingEdgesOf(node);
 
-		if (outgoingLinks == null)
+		if (outgoingLinks == null){
 			return;
+		}
 		
 		
 		for (Link outLink : outgoingLinks) {

--- a/src/main/java/edu/isi/karma/modeling/alignment/LinkIdFactory.java
+++ b/src/main/java/edu/isi/karma/modeling/alignment/LinkIdFactory.java
@@ -54,26 +54,29 @@ public class LinkIdFactory {
 	
 	public static String getLinkUri(String linkId) {
 		String[] parts = linkId.split(separator);
-		if (parts != null && parts.length == 3)
+		if (parts != null && parts.length == 3){
 			return parts[1];
-		else
+		}else{
 			return null;
+		}
 	}
 	
 	public static String getLinkSourceId(String linkId) {
 		String[] parts = linkId.split(separator);
-		if (parts != null && parts.length == 3)
+		if (parts != null && parts.length == 3){
 			return parts[0];
-		else
+		}else{
 			return null;
+		}
 	}
 	
 	public static String getLinkTargetId(String linkId) {
 		String[] parts = linkId.split(separator);
-		if (parts != null && parts.length == 3)
+		if (parts != null && parts.length == 3){
 			return parts[2];
-		else
+		}else{
 			return null;
+		}
 	}
 	
 	public boolean duplicateUri(String uriString) {
@@ -81,9 +84,10 @@ public class LinkIdFactory {
 	}
 	
 	public int lastIndexOf(String uri) {
-		if (linksUris.containsKey(uri))
+		if (linksUris.containsKey(uri)){
 			return linksUris.get(uri).intValue();
-		else
+		}else{
 			return -1;
+		}
 	}
 }

--- a/src/main/java/edu/isi/karma/modeling/alignment/NodeIdFactory.java
+++ b/src/main/java/edu/isi/karma/modeling/alignment/NodeIdFactory.java
@@ -53,9 +53,10 @@ public class NodeIdFactory {
 	}
 	
 	public int lastIndexOf(String uri) {
-		if (nodeUris.containsKey(uri))
+		if (nodeUris.containsKey(uri)){
 			return nodeUris.get(uri).intValue();
-		else
+		}else{
 			return -1;
+		}
 	}
 }

--- a/src/main/java/edu/isi/karma/modeling/alignment/SteinerTree.java
+++ b/src/main/java/edu/isi/karma/modeling/alignment/SteinerTree.java
@@ -79,11 +79,13 @@ public class SteinerTree {
 			
 			for (Node n2 : this.steinerNodes) {
 				
-				if (n1.equals(n2))
+				if (n1.equals(n2)){
 					continue;
+				}
 				
-				if (g.containsEdge(n1, n2))
+				if (g.containsEdge(n1, n2)){
 					continue;
+				}
 				
 				Link e = new SimpleLink(null, null);
 				g.addEdge(n1, n2, e);
@@ -120,8 +122,9 @@ public class SteinerTree {
 		
 		List<Link> edgesSortedById = new ArrayList<Link>();
 		
-		for (Link e : edges) 
+		for (Link e : edges){
 			edgesSortedById.add(e);
+		}
 		
 		Collections.sort(edgesSortedById);
 		
@@ -161,22 +164,26 @@ public class SteinerTree {
 			path = new DijkstraShortestPath<Node, Link>(this.graph, source, target);
 			List<Link> pathEdges = path.getPathEdgeList();
 			
-			if (pathEdges == null)
+			if (pathEdges == null){
 				continue;
+			}
 			
 			for (int i = 0; i < pathEdges.size(); i++) {
 				
-				if (g3.edgeSet().contains(pathEdges.get(i)))
+				if (g3.edgeSet().contains(pathEdges.get(i))){
 					continue;
+				}
 				
 				source = pathEdges.get(i).getSource();
 				target = pathEdges.get(i).getTarget();
 				
-				if (!g3.vertexSet().contains(source) )
+				if (!g3.vertexSet().contains(source) ){
 					g3.addVertex(source);
+				}
 
-				if (!g3.vertexSet().contains(target) )
+				if (!g3.vertexSet().contains(target) ){
 					g3.addVertex(target);
+				}
 
 				g3.addEdge(source, target, pathEdges.get(i));
 			}
@@ -208,8 +215,9 @@ public class SteinerTree {
 		
 		List<Link> edgesSortedById = new ArrayList<Link>();
 		
-		for (Link e : edges) 
+		for (Link e : edges){
 			edgesSortedById.add(e);
+		}
 		
 		Collections.sort(edgesSortedById);
 		
@@ -253,8 +261,9 @@ public class SteinerTree {
 				target = this.graph.getEdgeTarget(e);
 				
 				// this should not happen, but just in case of ...
-				if (target.equals(source)) 
+				if (target.equals(source)){
 					target = e.getSource();
+				}
 				
 				g5.removeVertex(source);
 				source = target;
@@ -278,7 +287,9 @@ public class SteinerTree {
 		
 		if (g1.vertexSet().size() < 2) {
 			this.tree = new WeightedMultigraph<Node, Link>(Link.class);
-			for (Node n : g1.vertexSet()) this.tree.addVertex(n);
+			for (Node n : g1.vertexSet()){
+				this.tree.addVertex(n);
+			}
 			return;
 		}
 		

--- a/src/main/java/edu/isi/karma/modeling/alignment/TreePostProcess.java
+++ b/src/main/java/edu/isi/karma/modeling/alignment/TreePostProcess.java
@@ -76,11 +76,12 @@ public class TreePostProcess {
 		List<Node> possibleRoots = new ArrayList<Node>();
 
 		// If tree contains the Thing, we return it as the root
-		for (Node v: this.tree.vertexSet()) 
+		for (Node v: this.tree.vertexSet()){
 			if (v.equals(this.thingNode)) {
 				possibleRoots.add(v);
 				return possibleRoots;
 			}
+		}
 
 		int maxReachableNodes = -1;
 		int reachableNodes = -1;
@@ -106,17 +107,20 @@ public class TreePostProcess {
 			}
 		}
 		
-		for (int i = 0; i < vertexList.size(); i++)
-			if (reachableNodesList.get(i).intValue() == maxReachableNodes)
+		for (int i = 0; i < vertexList.size(); i++){
+			if (reachableNodesList.get(i).intValue() == maxReachableNodes){
 				possibleRoots.add(vertexList.get(i));
+			}
+		}
 	
 		return possibleRoots;
 	}
 	
 	private void selectRoot(List<Node> possibleRoots) {
 		
-		if (possibleRoots == null || possibleRoots.size() == 0)
+		if (possibleRoots == null || possibleRoots.size() == 0){
 			return;
+		}
 		
 		Collections.sort(possibleRoots);
 		
@@ -133,7 +137,9 @@ public class TreePostProcess {
 		List<Link> possibleLinks = new ArrayList<Link>();
 		
 		for (Link link : links) {
-			if (!(link instanceof SimpleLink)) continue;
+			if (!(link instanceof SimpleLink)){
+				continue;
+			}
 			
 			// links from source to target
 			sourceId = link.getSource().getId();
@@ -142,9 +148,13 @@ public class TreePostProcess {
 			possibleLinks.clear();
 			
 			temp = this.graphBuilder.getPossibleLinks(sourceId, targetId);
-			if (temp != null) possibleLinks.addAll(temp);
+			if (temp != null){
+				possibleLinks.addAll(temp);
+			}
 			temp = this.graphBuilder.getPossibleLinks(targetId, sourceId);
-			if (temp != null) possibleLinks.addAll(temp);
+			if (temp != null){
+				possibleLinks.addAll(temp);
+			}
 
 			Collections.sort(possibleLinks, new LinkPriorityComparator());
 			if (possibleLinks.size() > 0) {

--- a/src/main/java/edu/isi/karma/modeling/ontology/OntologyCache.java
+++ b/src/main/java/edu/isi/karma/modeling/ontology/OntologyCache.java
@@ -446,8 +446,12 @@ class OntologyCache {
 
 	public Label getUriLabel(String uri) {
 		Label label = this.classes.get(uri);
-		if (label == null) label = this.properties.get(uri);
-		if (label == null) label = this.ontHandler.getUriLabel(uri);
+		if (label == null){
+			label = this.properties.get(uri);
+		}
+		if (label == null){
+			label = this.ontHandler.getUriLabel(uri);
+		}
 		return label;
 	}
 	
@@ -463,11 +467,13 @@ class OntologyCache {
 			
 			OntClass c = itrC.next();
 			
-			if (!c.isURIResource())
+			if (!c.isURIResource()){
 				continue;
+			}
 			
-			if (!classes.containsKey(c.getURI()))
+			if (!classes.containsKey(c.getURI())){
 				classes.put(c.getURI(), ontHandler.getResourceLabel(c));
+			}
 
 		}
 		
@@ -479,11 +485,13 @@ class OntologyCache {
 			
 			Resource r = itr.next();
 			
-			if (!r.isURIResource())
+			if (!r.isURIResource()){
 				continue;
+			}
 			
-			if (!classes.containsKey(r.getURI()))
+			if (!classes.containsKey(r.getURI())){
 				classes.put(r.getURI(), ontHandler.getResourceLabel(r));
+			}
 
 		}
 
@@ -497,22 +505,26 @@ class OntologyCache {
 			
 			OntProperty p = itrP.next();
 			
-			if (!p.isURIResource())
+			if (!p.isURIResource()){
 				continue;
+			}
 			
-			if (!properties.containsKey(p.getURI()))
+			if (!properties.containsKey(p.getURI())){
 				properties.put(p.getURI(), ontHandler.getResourceLabel(p));
+			}
 			
 			if (p.isDatatypeProperty() || !p.isObjectProperty())
 			{
-				if (!dataProperties.containsKey(p.getURI()))
+				if (!dataProperties.containsKey(p.getURI())){
 					dataProperties.put(p.getURI(), ontHandler.getResourceLabel(p));
+				}
 			}
 
 			if (p.isObjectProperty() || !p.isDatatypeProperty())
 			{
-				if (!objectProperties.containsKey(p.getURI()))
+				if (!objectProperties.containsKey(p.getURI())){
 					objectProperties.put(p.getURI(), ontHandler.getResourceLabel(p));
+				}
 			}
 		}
 	}
@@ -522,7 +534,9 @@ class OntologyCache {
 		List<OntologyTreeNode> children = new ArrayList<OntologyTreeNode>();
 		if (node.getParent() == null) {
 			for (String s : this.classes.keySet()) {
-				if (s.equalsIgnoreCase(Uris.THING_URI)) continue;
+				if (s.equalsIgnoreCase(Uris.THING_URI)){
+					continue;
+				}
 				Set<String> superClasses = this.ontHandler.getSuperClasses(s, false).keySet();
 				if (superClasses == null || superClasses.size() == 0) {
 					Label label = this.classes.get(s);
@@ -563,7 +577,7 @@ class OntologyCache {
 			HashMap<String, Label> subProperties = 
 					this.ontHandler.getSubProperties(node.getLabel().getUri(), false);
 
-			if (subProperties != null)
+			if (subProperties != null){
 				for (String s : subProperties.keySet()) {
 					Label label = subProperties.get(s);
 					OntologyTreeNode childNode = new OntologyTreeNode(label, node, null);
@@ -571,6 +585,7 @@ class OntologyCache {
 					buildDataPropertyHierarchy(childNode);
 					children.add(childNode);
 				}
+			}
 		}
 		node.setChildren(children);	
 	}
@@ -592,7 +607,7 @@ class OntologyCache {
 			HashMap<String, Label> subProperties = 
 					this.ontHandler.getSubProperties(node.getLabel().getUri(), false);
 
-			if (subProperties != null)
+			if (subProperties != null){
 				for (String s : subProperties.keySet()) {
 					Label label = subProperties.get(s);
 					OntologyTreeNode childNode = new OntologyTreeNode(label, node, null);
@@ -600,6 +615,7 @@ class OntologyCache {
 					buildObjectPropertyHierarchy(childNode);
 					children.add(childNode);
 				}
+			}
 		}
 		node.setChildren(children);	
 	}
@@ -607,9 +623,11 @@ class OntologyCache {
 	private void buildSubClassesMaps() {
 		
 		HashMap<String, Label> allClassesExceptThing = new HashMap<String, Label>();
-		for (Entry<String, Label> entry : this.classes.entrySet())
-			if (!entry.getKey().equalsIgnoreCase(Uris.THING_URI))
+		for (Entry<String, Label> entry : this.classes.entrySet()){
+			if (!entry.getKey().equalsIgnoreCase(Uris.THING_URI)){
 				allClassesExceptThing.put(entry.getKey(), entry.getValue());
+			}
+		}
 
 		HashMap<String, Label> directSubClassesLocal;
 		HashMap<String, Label> indirectSubClassesLocal;
@@ -620,17 +638,22 @@ class OntologyCache {
 			directSubClassesLocal = this.ontHandler.getSubClasses(c, false);
 			allSubClassesLocal = this.ontHandler.getSubClasses(c, true);
 			indirectSubClassesLocal = new HashMap<String, Label>();
-			for (Entry<String, Label> entry : allSubClassesLocal.entrySet())
-				if (!directSubClassesLocal.containsKey(entry.getKey()))
+			for (Entry<String, Label> entry : allSubClassesLocal.entrySet()){
+				if (!directSubClassesLocal.containsKey(entry.getKey())){
 					indirectSubClassesLocal.put(entry.getKey(), entry.getValue());
+				}
+			}
 			
 			// Thing node
 			if (c.equalsIgnoreCase(Uris.THING_URI)) {
 				List<OntologyTreeNode> thingDirectChildren = this.classHierarchy.getChildren();
-				if (thingDirectChildren != null) 
-					for (OntologyTreeNode node : thingDirectChildren) 
-						if (node.getLabel() != null && node.getLabel().getUri() != null)
+				if (thingDirectChildren != null){
+					for (OntologyTreeNode node : thingDirectChildren){
+						if (node.getLabel() != null && node.getLabel().getUri() != null){
 							directSubClassesLocal.put(node.getLabel().getUri(), node.getLabel());
+						}
+					}
+				}
 				
 				indirectSubClassesLocal = allClassesExceptThing;
 			}
@@ -638,23 +661,27 @@ class OntologyCache {
 			this.directSubClasses.put(c, directSubClassesLocal);
 			this.indirectSubClasses.put(c, indirectSubClassesLocal);
 
-			for (String s : directSubClassesLocal.keySet())
+			for (String s : directSubClassesLocal.keySet()){
 				this.directSubClassCheck.add(s + c);
+			}
 			
-			for (String s : indirectSubClassesLocal.keySet())
+			for (String s : indirectSubClassesLocal.keySet()){
 				this.indirectSubClassCheck.add(s + c);
+			}
 		}
 		
 		for (String superclass : this.directSubClasses.keySet()) {
 			Set<String> subClasses = this.directSubClasses.get(superclass).keySet();
-			for (String subclass : subClasses)
+			for (String subclass : subClasses){
 				this.directSubclassSuperclassPairs.add(new SubclassSuperclassPair(subclass, superclass));
+			}
 		}
 		
 		for (String superclass : this.indirectSubClasses.keySet()) {
 			Set<String> subClasses = this.indirectSubClasses.get(superclass).keySet();
-			for (String subclass : subClasses)
+			for (String subclass : subClasses){
 				this.indirectSubclassSuperclassPairs.add(new SubclassSuperclassPair(subclass, superclass));
+			}
 		}
 	}
 	
@@ -672,9 +699,11 @@ class OntologyCache {
 			
 			allSuperClassesLocal = this.ontHandler.getSuperClasses(c, true);
 			indirectSuperClassesLocal = new HashMap<String, Label>();
-			for (Entry<String, Label> entry : allSuperClassesLocal.entrySet())
-				if (!directSuperClassesLocal.containsKey(entry.getKey()))
+			for (Entry<String, Label> entry : allSuperClassesLocal.entrySet()){
+				if (!directSuperClassesLocal.containsKey(entry.getKey())){
 					indirectSuperClassesLocal.put(entry.getKey(), entry.getValue());
+				}
+			}
 			
 			this.indirectSuperClasses.put(c, indirectSuperClassesLocal);
 		}		
@@ -682,8 +711,9 @@ class OntologyCache {
 		for (String c : this.indirectSuperClasses.keySet()) {
 			
 			HashMap<String, Label> superClasses = this.indirectSuperClasses.get(c);
-			if (superClasses != null && !superClasses.containsKey(Uris.THING_URI))
+			if (superClasses != null && !superClasses.containsKey(Uris.THING_URI)){
 				superClasses.put(Uris.THING_URI, new Label(Uris.THING_URI, Namespaces.OWL, Prefixes.OWL));
+			}
 		}
 		
 	}
@@ -700,18 +730,22 @@ class OntologyCache {
 			
 			allSubPropertiesLocal = this.ontHandler.getSubProperties(p, true);
 			indirectSubPropertiesLocal = new HashMap<String, Label>();
-			for (Entry<String, Label> entry : allSubPropertiesLocal.entrySet())
-				if (!directSubPropertiesLocal.containsKey(entry.getKey()))
+			for (Entry<String, Label> entry : allSubPropertiesLocal.entrySet()){
+				if (!directSubPropertiesLocal.containsKey(entry.getKey())){
 					indirectSubPropertiesLocal.put(entry.getKey(), entry.getValue());
+				}
+			}
 			
 			this.directSubProperties.put(p, directSubPropertiesLocal);
 			this.indirectSubProperties.put(p, indirectSubPropertiesLocal);
 
-			for (String s : directSubPropertiesLocal.keySet())
+			for (String s : directSubPropertiesLocal.keySet()){
 				this.directSubPropertyCheck.add(s + p);
+			}
 
-			for (String s : indirectSubPropertiesLocal.keySet())
+			for (String s : indirectSubPropertiesLocal.keySet()){
 				this.indirectSubPropertyCheck.add(s + p);
+			}
 		}
 	}
 
@@ -729,9 +763,11 @@ class OntologyCache {
 			
 			allSuperPropertiesLocal = this.ontHandler.getSuperProperties(p, true);
 			indirectSuperPropertiesLocal = new HashMap<String, Label>();
-			for (Entry<String, Label> entry : allSuperPropertiesLocal.entrySet())
-				if (!directSuperPropertiesLocal.containsKey(entry.getKey()))
+			for (Entry<String, Label> entry : allSuperPropertiesLocal.entrySet()){
+				if (!directSuperPropertiesLocal.containsKey(entry.getKey())){
 					indirectSuperPropertiesLocal.put(entry.getKey(), entry.getValue());
+				}
+			}
 			
 			this.indirectSuperProperties.put(p, indirectSuperPropertiesLocal);
 		}		
@@ -775,8 +811,9 @@ class OntologyCache {
 			allRangesUris = new HashSet<String>();
 			
 			OntProperty property = this.ontHandler.getOntModel().getOntProperty(propertyUri);
-			if (!property.isURIResource())
+			if (!property.isURIResource()){
 				continue;
+			}
 			
 			// direct domain
 			ExtendedIterator<? extends OntResource> itrDomains = property.listDomain();
@@ -787,10 +824,11 @@ class OntologyCache {
 			directDomainsUris = ontHandler.getResourcesUris(directDomains);
 			
 			temp  = propertyDirectDomains.get(property.getURI());
-			if (temp == null)
+			if (temp == null){
 				propertyDirectDomains.put(property.getURI(), directDomainsUris);
-			else 
+			}else{
 				temp.addAll(directDomainsUris);
+			}
 			
 			for (OntResource domain : directDomains) {
 				temp = directOutDataProperties.get(domain.getURI());
@@ -802,9 +840,9 @@ class OntologyCache {
 			}
 
 			// all domains
-			if (directDomainsUris.contains(Uris.THING_URI))
+			if (directDomainsUris.contains(Uris.THING_URI)){
 				allDomainsUris = new HashSet<String>(this.classes.keySet());
-			else {
+			}else {
 				for (OntResource domain : directDomains) {
 					allDomains.add(domain);
 					ontHandler.getChildren(domain, allDomains, true);
@@ -814,15 +852,17 @@ class OntologyCache {
 
 			// indirect domains
 			for (String domainUri : allDomainsUris) {
-				if (!directDomainsUris.contains(domainUri))
+				if (!directDomainsUris.contains(domainUri)){
 					indirectDomainsUris.add(domainUri);
+				}
 			}
 
 			temp  = propertyIndirectDomains.get(property.getURI());
-			if (temp == null)
+			if (temp == null){
 				propertyIndirectDomains.put(property.getURI(), indirectDomainsUris);
-			else 
+			}else{
 				temp.addAll(indirectDomainsUris);
+			}
 			
 			for (String domainUri : indirectDomainsUris) {
 				temp = indirectOutDataProperties.get(domainUri);
@@ -842,10 +882,11 @@ class OntologyCache {
 			directRangesUris = ontHandler.getResourcesUris(directRanges);
 
 			temp  = propertyDirectRanges.get(property.getURI());
-			if (temp == null)
+			if (temp == null){
 				propertyDirectRanges.put(property.getURI(), directRangesUris);
-			else 
+			}else{
 				temp.addAll(directRangesUris);
+			}
 			
 			// all ranges
 			for (OntResource range : directRanges) {
@@ -856,15 +897,17 @@ class OntologyCache {
 			
 			// indirect ranges
 			for (String rangeUri : allRangesUris) {
-				if (!directRangesUris.contains(rangeUri))
+				if (!directRangesUris.contains(rangeUri)){
 					indirectRangesUris.add(rangeUri);
+				}
 			}
 			
 			temp  = propertyIndirectRanges.get(property.getURI());
-			if (temp == null)
+			if (temp == null){
 				propertyIndirectRanges.put(property.getURI(), indirectRangesUris);
-			else 
+			}else{
 				temp.addAll(indirectRangesUris);
+			}
 			
 		}	
 	}
@@ -889,8 +932,9 @@ class OntologyCache {
 		for (String propertyUri : this.objectProperties.keySet()) {
 
 			OntProperty property = this.ontHandler.getOntModel().getOntProperty(propertyUri);
-			if (!property.isURIResource())
+			if (!property.isURIResource()){
 				continue;
+			}
 			
 			directDomains = new HashSet<OntResource>();
 			directDomainsUris = new HashSet<String>();
@@ -912,10 +956,11 @@ class OntologyCache {
 			directDomainsUris = ontHandler.getResourcesUris(directDomains);
 			
 			temp  = propertyDirectDomains.get(property.getURI());
-			if (temp == null)
+			if (temp == null){
 				propertyDirectDomains.put(property.getURI(), directDomainsUris);
-			else 
+			}else{
 				temp.addAll(directDomainsUris);
+			}
 			
 			for (OntResource domain : directDomains) {
 				temp = directOutObjectProperties.get(domain.getURI());
@@ -927,9 +972,9 @@ class OntologyCache {
 			}
 
 			// all domains
-			if (directDomainsUris.contains(Uris.THING_URI))
+			if (directDomainsUris.contains(Uris.THING_URI)){
 				allDomainsUris = new HashSet<String>(this.classes.keySet());
-			else {
+			}else {
 				for (OntResource domain : directDomains) {
 					allDomains.add(domain);
 					ontHandler.getChildren(domain, allDomains, true);
@@ -939,15 +984,17 @@ class OntologyCache {
 
 			// indirect domains
 			for (String domainUri : allDomainsUris) {
-				if (!directDomainsUris.contains(domainUri))
+				if (!directDomainsUris.contains(domainUri)){
 					indirectDomainsUris.add(domainUri);
+				}
 			}
 
 			temp  = propertyIndirectDomains.get(property.getURI());
-			if (temp == null)
+			if (temp == null){
 				propertyIndirectDomains.put(property.getURI(), indirectDomainsUris);
-			else 
+			}else{
 				temp.addAll(indirectDomainsUris);
+			}
 			
 			for (String domainUri : indirectDomainsUris) {
 				temp = indirectOutObjectProperties.get(domainUri);
@@ -967,10 +1014,11 @@ class OntologyCache {
 			directRangesUris = ontHandler.getResourcesUris(directRanges);
 
 			temp  = propertyDirectRanges.get(property.getURI());
-			if (temp == null)
+			if (temp == null){
 				propertyDirectRanges.put(property.getURI(), directRangesUris);
-			else 
+			}else{
 				temp.addAll(directRangesUris);
+			}
 			
 			for (OntResource range : directRanges) {
 				temp = directInObjectProperties.get(range.getURI());
@@ -982,9 +1030,9 @@ class OntologyCache {
 			}
 			
 			// all ranges
-			if (directRangesUris.contains(Uris.THING_URI))
+			if (directRangesUris.contains(Uris.THING_URI)){
 				allRangesUris = new HashSet<String>(this.classes.keySet());
-			else {
+			}else {
 				for (OntResource range : directRanges) {
 					allRanges.add(range);
 					ontHandler.getChildren(range, allRanges, true);
@@ -994,15 +1042,17 @@ class OntologyCache {
 			
 			// indirect ranges
 			for (String rangeUri : allRangesUris) {
-				if (!directRangesUris.contains(rangeUri))
+				if (!directRangesUris.contains(rangeUri)){
 					indirectRangesUris.add(rangeUri);
+				}
 			}
 			
 			temp  = propertyIndirectRanges.get(property.getURI());
-			if (temp == null)
+			if (temp == null){
 				propertyIndirectRanges.put(property.getURI(), indirectRangesUris);
-			else 
+			}else{
 				temp.addAll(indirectRangesUris);
+			}
 			
 			for (String rangeUri : indirectRangesUris) {
 				temp = indirectInObjectProperties.get(rangeUri);
@@ -1027,7 +1077,9 @@ class OntologyCache {
 			
 			for (String domain : allDomainsUris) {
 				for (String range : allRangesUris) {
-					if (directDomainsUris.contains(domain) && directRangesUris.contains(range)) continue;
+					if (directDomainsUris.contains(domain) && directRangesUris.contains(range)){
+						continue;
+					}
 					temp = domainRangeToIndirectProperties.get(domain + range);
 					if (temp == null) {
 						temp = new HashSet<String>();
@@ -1093,8 +1145,9 @@ class OntologyCache {
 		ontHandler.getOntModel().setNsPrefix("rdfs", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
 		ontHandler.getOntModel().setNsPrefix("rdfs", "http://www.w3.org/2000/01/rdf-schema#");
 		
-		for (String uri : uris) 
+		for (String uri : uris){
 			ontHandler.getOntModel().createDatatypeProperty(uri);
+		}
 
 		
 		// add label and comment property to the properties of all the classes
@@ -1104,8 +1157,9 @@ class OntologyCache {
 				temp = new HashSet<String>();
 				indirectOutDataProperties.put(s, temp);
 			}
-			for (String uri : uris)
+			for (String uri : uris){
 				temp.add(uri);
+			}
 		}
 
 		// add uris to properties hashmap
@@ -1115,9 +1169,11 @@ class OntologyCache {
 				temp = new HashSet<String>();
 				propertyIndirectDomains.put(labelUri, temp);
 			}
-			for (String s : this.classes.keySet())
-				if (!temp.contains(s))
+			for (String s : this.classes.keySet()){
+				if (!temp.contains(s)){
 					temp.add(s);
+				}
+			}
 		}
 		
 	}
@@ -1138,10 +1194,16 @@ class OntologyCache {
 			
 			Set<String> directSuperPropertiesLocal = this.directSuperProperties.get(p).keySet();
 			Set<String> indirectSuperPropertiesLocal = this.indirectSuperProperties.get(p).keySet();
-			if (directSuperPropertiesLocal != null) allSuperPropertiesLocal.addAll(directSuperPropertiesLocal);
-			if (indirectSuperPropertiesLocal != null) allSuperPropertiesLocal.addAll(indirectSuperPropertiesLocal);
+			if (directSuperPropertiesLocal != null){
+				allSuperPropertiesLocal.addAll(directSuperPropertiesLocal);
+			}
+			if (indirectSuperPropertiesLocal != null){
+				allSuperPropertiesLocal.addAll(indirectSuperPropertiesLocal);
+			}
 			
-			if (allSuperPropertiesLocal.size() == 0) continue;
+			if (allSuperPropertiesLocal.size() == 0){
+				continue;
+			}
 			
 			HashSet<String> temp = null;
 			
@@ -1152,8 +1214,12 @@ class OntologyCache {
 			for (String superP : allSuperPropertiesLocal) {
 				seuperDirectDomains = this.propertyDirectDomains.get(superP);
 				seuperIndirectDomains = this.propertyIndirectDomains.get(superP);
-				if (seuperDirectDomains != null) superAllDomains.addAll(seuperDirectDomains);
-				if (seuperIndirectDomains != null && inheritance) superAllDomains.addAll(seuperIndirectDomains);
+				if (seuperDirectDomains != null){
+					superAllDomains.addAll(seuperDirectDomains);
+				}
+				if (seuperIndirectDomains != null && inheritance){
+					superAllDomains.addAll(seuperIndirectDomains);
+				}
 			}
 
 			HashSet<String> indirectDomains = propertyIndirectDomains.get(p);
@@ -1163,23 +1229,28 @@ class OntologyCache {
 			}
 			
 			for (String d : superAllDomains) {
-				if (!indirectDomains.contains(d))
+				if (!indirectDomains.contains(d)){
 					indirectDomains.add(d);
+				}
 			}
 			
-			if (this.objectProperties.containsKey(p)) 
+			if (this.objectProperties.containsKey(p)){
 				for (String d : superAllDomains) {
 					temp = indirectOutObjectProperties.get(d);
-					if (temp != null)
+					if (temp != null){
 						temp.add(p);
+					}
 				}
+			}
 
-			if (this.dataProperties.containsKey(p)) 
+			if (this.dataProperties.containsKey(p)){
 				for (String d : superAllDomains) {
 					temp = indirectOutDataProperties.get(d);
-					if (temp != null)
+					if (temp != null){
 						temp.add(p);
+					}
 				}
+			}
 
 			// ranges
 			HashSet<String> seuperDirectRanges = new HashSet<String>();
@@ -1188,8 +1259,12 @@ class OntologyCache {
 			for (String superP : allSuperPropertiesLocal) {
 				seuperDirectRanges = this.propertyDirectRanges.get(superP);
 				seuperIndirectRanges = this.propertyIndirectRanges.get(superP);
-				if (seuperDirectRanges != null) superAllRanges.addAll(seuperDirectRanges);
-				if (seuperIndirectRanges != null && inheritance) superAllRanges.addAll(seuperIndirectRanges);
+				if (seuperDirectRanges != null){
+					superAllRanges.addAll(seuperDirectRanges);
+				}
+				if (seuperIndirectRanges != null && inheritance){
+					superAllRanges.addAll(seuperIndirectRanges);
+				}
 			}
 
 			HashSet<String> indirectRanges = propertyIndirectRanges.get(p);
@@ -1199,31 +1274,44 @@ class OntologyCache {
 			}
 			
 			for (String r : superAllRanges) {
-				if (!indirectRanges.contains(r))
+				if (!indirectRanges.contains(r)){
 					indirectRanges.add(r);
+				}
 			}
 			
-			if (this.objectProperties.containsKey(p)) 
+			if (this.objectProperties.containsKey(p)){
 				for (String r : superAllRanges) {
 					temp = indirectInObjectProperties.get(r);
-					if (temp != null)
+					if (temp != null){
 						temp.add(p);
+					}
 				}
+			}
 				
 			HashSet<String> directDomains = this.propertyDirectDomains.get(p);
 			HashSet<String> allDomains = new HashSet<String>();
 			HashSet<String> directRanges = this.propertyDirectRanges.get(p);
 			HashSet<String> allRanges = new HashSet<String>();
 			
-			if (directDomains != null) allRanges.addAll(directDomains);
-			if (indirectDomains != null) allDomains.addAll(indirectDomains);
+			if (directDomains != null){
+				allRanges.addAll(directDomains);
+			}
+			if (indirectDomains != null){
+				allDomains.addAll(indirectDomains);
+			}
 
-			if (directRanges != null) allDomains.addAll(directRanges);
-			if (indirectRanges != null) allRanges.addAll(indirectRanges);
+			if (directRanges != null){
+				allDomains.addAll(directRanges);
+			}
+			if (indirectRanges != null){
+				allRanges.addAll(indirectRanges);
+			}
 			
 			for (String domain : allDomains) {
 				for (String range : allRanges) {
-					if (directDomains.contains(domain) && directRanges.contains(range)) continue;
+					if (directDomains.contains(domain) && directRanges.contains(range)){
+						continue;
+					}
 					temp = domainRangeToIndirectProperties.get(domain + range);
 					if (temp == null) {
 						temp = new HashSet<String>();
@@ -1257,11 +1345,13 @@ class OntologyCache {
 			haveDomain = true;
 			
 			if ((directDomains == null || directDomains.size() == 0) &&
-					(indirectDomains == null || indirectDomains.size() == 0))
+					(indirectDomains == null || indirectDomains.size() == 0)){
 				haveDomain = false;
+			}
 			
-			if (!haveDomain)
+			if (!haveDomain){
 				this.dataPropertiesWithoutDomain.put(p, label);
+			}
 		}
 		
 		for (String p : this.objectProperties.keySet()) {
@@ -1278,20 +1368,23 @@ class OntologyCache {
 			haveRange = true;
 			
 			if ((directDomains == null || directDomains.size() == 0) &&
-					(indirectDomains == null || indirectDomains.size() == 0))
+					(indirectDomains == null || indirectDomains.size() == 0)){
 				haveDomain = false;
+			}
 			
 			if ((directRanges == null || directRanges.size() == 0) &&
-					(indirectRanges == null || indirectRanges.size() == 0))
+					(indirectRanges == null || indirectRanges.size() == 0)){
 				haveRange = false;
+			}
 			
-			if (haveDomain && !haveRange) 
+			if (haveDomain && !haveRange){
 				this.objectPropertiesWithOnlyDomain.put(p, label);
-			else if (!haveDomain && haveRange) {
+			}else if (!haveDomain && haveRange) {
 				this.objectPropertiesWithOnlyRange.put(p, label);
 			}
-			else if (!haveDomain && !haveRange) 
+			else if (!haveDomain && !haveRange){
 				this.objectPropertiesWithoutDomainAndRange.put(p, label);
+			}
 		}
 }
 	
@@ -1313,8 +1406,9 @@ class OntologyCache {
 			for (int j = 0; j < classList.size(); j++) {
 				String c2 = classList.get(j);
 				
-				if (c1.equals(c2))
+				if (c1.equals(c2)){
 					continue;
+				}
 				
 				directProperties = this.domainRangeToDirectProperties.get(c1+c2);
 				if (directProperties != null && directProperties.size() > 0) { 
@@ -1330,38 +1424,45 @@ class OntologyCache {
 				foundDomainlessProperty = false;
 				directInProperties = this.directInObjectProperties.get(c1);
 				if (directInProperties != null) {
-					for (String s : directInProperties) 
+					for (String s : directInProperties){
 						if (this.objectPropertiesWithOnlyRange.containsKey(s)) {
 							foundDomainlessProperty = true;
 							break;
 						}
+					}
 				}
 				if (!foundDomainlessProperty) {
 					directInProperties = this.directInObjectProperties.get(c2);
-					if (directInProperties != null)
-						for (String s : directInProperties) 
+					if (directInProperties != null){
+						for (String s : directInProperties){
 							if (this.objectPropertiesWithOnlyRange.containsKey(s)) {
 								foundDomainlessProperty = true;
 								break;
-							}			
+							}
+						}
+					}			
 				}
 				if (!foundDomainlessProperty) {
 					indirectInProperties = this.indirectInObjectProperties.get(c1);
-					if (indirectInProperties != null)
-						for (String s : indirectInProperties) 
+					if (indirectInProperties != null){
+						for (String s : indirectInProperties){
 							if (this.objectPropertiesWithOnlyRange.containsKey(s)) {
 								foundDomainlessProperty = true;
 								break;
 							}
+						}
+					}
 				}
 				if (!foundDomainlessProperty) {
 					indirectInProperties = this.indirectInObjectProperties.get(c2);
-					if (indirectInProperties != null)
-						for (String s : indirectInProperties) 
+					if (indirectInProperties != null){
+						for (String s : indirectInProperties){
 							if (this.objectPropertiesWithOnlyRange.containsKey(s)) {
 								foundDomainlessProperty = true;
 								break;
 							}
+						}
+					}
 				}
 				
 				// rangeless property
@@ -1369,38 +1470,45 @@ class OntologyCache {
 				foundRangelessProperty = false;
 				directOutProperties = this.directOutObjectProperties.get(c1);
 				if (directOutProperties != null) {
-					for (String s : directOutProperties) 
+					for (String s : directOutProperties){
 						if (this.objectPropertiesWithOnlyDomain.containsKey(s)) {
 							foundRangelessProperty = true;
 							break;
 						}
+					}
 				}
 				if (!foundRangelessProperty) {
 					directOutProperties = this.directOutObjectProperties.get(c2);
-					if (directOutProperties != null)
-						for (String s : directOutProperties) 
+					if (directOutProperties != null){
+						for (String s : directOutProperties){
 							if (this.objectPropertiesWithOnlyDomain.containsKey(s)) {
 								foundRangelessProperty = true;
 								break;
 							}
+						}
+					}
 				}
 				if (!foundRangelessProperty) {
 					indirectOutProperties = this.indirectOutObjectProperties.get(c1);
-					if (indirectOutProperties != null)
-						for (String s : indirectOutProperties) 
+					if (indirectOutProperties != null){
+						for (String s : indirectOutProperties){
 							if (this.objectPropertiesWithOnlyDomain.containsKey(s)) {
 								foundRangelessProperty = true;
 								break;
 							}
+						}
+					}
 				}
 				if (!foundRangelessProperty) {
 					indirectOutProperties = this.indirectOutObjectProperties.get(c2);
-					if (indirectOutProperties != null)
-						for (String s : indirectOutProperties) 
+					if (indirectOutProperties != null){
+						for (String s : indirectOutProperties){
 							if (this.objectPropertiesWithOnlyDomain.containsKey(s)) {
 								foundRangelessProperty = true;
 								break;
 							}
+						}
+					}
 				}				
 				
 				if (foundRangelessProperty) { 

--- a/src/main/java/edu/isi/karma/modeling/ontology/OntologyHandler.java
+++ b/src/main/java/edu/isi/karma/modeling/ontology/OntologyHandler.java
@@ -73,14 +73,19 @@ class OntologyHandler {
 			return null;
 		}
 		String ns = r.getNameSpace();
-		if (ns == null || ns.trim().length() == 0) ns = null;
+		if (ns == null || ns.trim().length() == 0){
+			ns = null;
+		}
 		String prefix = ontModel.getNsURIPrefix(r.getNameSpace());
-		if (prefix == null || prefix.trim().length() == 0) prefix = null;
+		if (prefix == null || prefix.trim().length() == 0){
+			prefix = null;
+		}
 		
 		OntResource ontR = null;
 		try { ontR = (OntResource)r;} catch(Exception e) {}
-		if (ontR == null)
+		if (ontR == null){
 			return new Label(r.getURI(), ns, prefix);
+		}
 		
 		String rdfsLabel = ontR.getLabel(null);
 		String rdfsComment = ontR.getComment(null);
@@ -96,10 +101,11 @@ class OntologyHandler {
 	 */
 	public HashSet<String> getResourcesUris(HashSet<OntResource> resources) {
 		HashSet<String> resourcesURIs = new HashSet<String>();
-		if (resources != null)
+		if (resources != null){
 			for (OntResource r: resources) {
 				resourcesURIs.add(r.getURI());
 			}
+		}
 		return resourcesURIs;
 	}
 	
@@ -110,18 +116,20 @@ class OntologyHandler {
 	 */
 	public HashMap<String, Label> getResourcesLabels(HashSet<OntResource> resources) {
 		HashMap<String, Label> resourcesLabels = new HashMap<String, Label>();
-		if (resources != null)
+		if (resources != null){
 			for (OntResource r: resources) {
 				resourcesLabels.put(r.getURI(), getResourceLabel(r));
 			}
+		}
 		return resourcesLabels;
 	}
 	
 	public boolean isClass(String uri) {
 		
 		OntClass c = ontModel.getOntClass(uri);
-		if (c != null)
+		if (c != null){
 			return true;
+		}
 		
 		return false;
 	}
@@ -129,8 +137,9 @@ class OntologyHandler {
 	public boolean isDataProperty(String uri) {
 
 		DatatypeProperty dp = ontModel.getDatatypeProperty(uri);
-		if (dp != null)
+		if (dp != null){
 			return true;
+		}
 		
 		return false;
 	}
@@ -138,8 +147,9 @@ class OntologyHandler {
 	public boolean isProperty(String uri) {
 
 		Property p = ontModel.getProperty(uri);
-		if (p != null)
+		if (p != null){
 			return true;
+		}
 		
 		return false;
 	}
@@ -147,8 +157,9 @@ class OntologyHandler {
 	public boolean isObjectProperty(String uri) {
 
 		ObjectProperty op = ontModel.getObjectProperty(uri);
-		if (op != null)
+		if (op != null){
 			return true;
+		}
 		
 		return false;
 	}
@@ -160,17 +171,18 @@ class OntologyHandler {
 	 */
 	public Label getInverseProperty(String uri) {
 		ObjectProperty op = ontModel.getObjectProperty(uri);
-		if (op == null)
+		if (op == null){
 			return null;
+		}
 		OntProperty inverseProp = null;
 		try {
 			inverseProp = op.getInverse();
 		} catch (ConversionException e) {}
 		if (inverseProp != null) {
 			return getUriLabel(inverseProp.getURI());
-		}
-		else
+		}else{
 			return null;
+		}
 	}
 	
 	/**
@@ -180,17 +192,18 @@ class OntologyHandler {
 	 */
 	public Label getInverseOfProperty(String uri) {
 		ObjectProperty op = ontModel.getObjectProperty(uri);
-		if (op == null)
+		if (op == null){
 			return null;
+		}
 		OntProperty inverseOfProp = null;
 		try {
 			inverseOfProp = op.getInverse();
 		} catch (ConversionException e) {}
 		if (inverseOfProp != null) {
 			return getUriLabel(inverseOfProp.getURI());
-		}
-		else
+		}else{
 			return null;
+		}
 	}
 	
 	/**
@@ -205,18 +218,21 @@ class OntologyHandler {
 		OntClass c = null;
 		OntProperty p = null;
 		
-		if (resources == null) 
+		if (resources == null){
 			resources = new HashSet<OntResource>();
+		}
 
-		if (r == null)
+		if (r == null){
 			return;
+		}
 		
-		if (r.isClass())
+		if (r.isClass()){
 			c = r.asClass();
-		else if  (r.isProperty())
+		}else if  (r.isProperty()){
 			p = r.asProperty();
-		else
+		}else{
 			return;
+		}
 		
 		if (c != null) { // && c.hasSuperClass()) {
 			ExtendedIterator<OntClass> i = null;
@@ -232,15 +248,17 @@ class OntologyHandler {
                 OntClass superC = (OntClass) i.next();
                 if (superC.isURIResource()) {
                 	resources.add(superC);
-                	if (recursive)
-                		getParents(superC, resources, recursive);
+                	if (recursive){
+						getParents(superC, resources, recursive);
+					}
                 } else {
                 	HashSet<OntResource> members = new HashSet<OntResource>();
                 	getMembers(superC, members, false);
                 	for (OntResource or : members) {
                 		resources.add(or);
-                		if (recursive)
-                			getParents(or, resources, recursive);
+                		if (recursive){
+							getParents(or, resources, recursive);
+						}
                 	}
                 }
             }
@@ -262,8 +280,9 @@ class OntologyHandler {
             	//if (superP.a)
                 if (superP.isURIResource()) {
                 	resources.add(superP);
-                	if (recursive)
-                		getParents(superP, resources, recursive);
+                	if (recursive){
+						getParents(superP, resources, recursive);
+					}
                 } 
 //                else {
 //            		List<OntResource> members = new ArrayList<OntResource>();
@@ -290,18 +309,21 @@ class OntologyHandler {
 		OntClass c = null;
 		OntProperty p = null;
 		
-		if (resources == null) 
+		if (resources == null){
 			resources = new HashSet<OntResource>();
+		}
 
-		if (r == null)
+		if (r == null){
 			return;
+		}
 
-		if (r.isClass())
+		if (r.isClass()){
 			c = r.asClass();
-		else if  (r.isProperty())
+		}else if  (r.isProperty()){
 			p = r.asProperty();
-		else
+		}else{
 			return;
+		}
 		
 		if (c != null) {
 			ExtendedIterator<OntClass> i = null;
@@ -317,15 +339,17 @@ class OntologyHandler {
                 OntClass subC = (OntClass) i.next();
                 if (subC.isURIResource()) {
                 	resources.add(subC);
-                	if (recursive)
-                		getChildren(subC, resources, recursive);
+                	if (recursive){
+						getChildren(subC, resources, recursive);
+					}
                 } else {
                 	HashSet<OntResource> members = new HashSet<OntResource>();
                 	getMembers(subC, members, false);
                 	for (OntResource or : members) {
                 		resources.add(or);
-                		if (recursive)
-                			getChildren(or, resources, recursive);
+                		if (recursive){
+							getChildren(or, resources, recursive);
+						}
                 	}
                 }
             }
@@ -345,8 +369,9 @@ class OntologyHandler {
                 OntProperty subP = (OntProperty) i.next();
                 if (subP.isURIResource()) {
                 	resources.add(subP);
-                	if (recursive)
-                		getChildren(subP, resources, recursive);
+                	if (recursive){
+						getChildren(subP, resources, recursive);
+					}
                 }
 //                else {
 //            		List<OntResource> members = new ArrayList<OntResource>();
@@ -371,11 +396,13 @@ class OntologyHandler {
 	 */
 	public void getMembers(OntResource r, HashSet<OntResource> resources, boolean recursive) {
 
-		if (resources == null) 
+		if (resources == null){
 			resources = new HashSet<OntResource>();
+		}
 
-		if (r == null)
+		if (r == null){
 			return;
+		}
 
 		if (r.isClass()) { 
 			OntClass c = r.asClass();
@@ -383,8 +410,9 @@ class OntologyHandler {
 			// simple class
 			if (c.isURIResource()) {
 				resources.add(c);
-				if (recursive)
+				if (recursive){
 					getChildren(c, resources, true);
+				}
 				return;
 			}
 			
@@ -417,7 +445,9 @@ class OntologyHandler {
 
 		HashSet<OntResource> resources = new HashSet<OntResource>();
 		OntResource r = ontModel.getOntClass(classUri);
-		if (r == null) return new HashMap<String, Label>();
+		if (r == null){
+			return new HashMap<String, Label>();
+		}
 		getChildren(r, resources, recursive);
 		return getResourcesLabels(resources);
 	}
@@ -432,7 +462,9 @@ class OntologyHandler {
 		
 		HashSet<OntResource> resources = new HashSet<OntResource>();
 		OntResource r = ontModel.getOntClass(classUri);
-		if (r == null) return new HashMap<String, Label>();
+		if (r == null){
+			return new HashMap<String, Label>();
+		}
 		getParents(r, resources, recursive);
 		return getResourcesLabels(resources);
 	}
@@ -447,7 +479,9 @@ class OntologyHandler {
 
 		HashSet<OntResource> resources = new HashSet<OntResource>();
 		OntResource r = ontModel.getOntProperty(propertyUri);
-		if (r == null) return new HashMap<String, Label>();
+		if (r == null){
+			return new HashMap<String, Label>();
+		}
 		getChildren(r, resources, recursive);
 		return getResourcesLabels(resources);
 	}
@@ -462,7 +496,9 @@ class OntologyHandler {
 
 		HashSet<OntResource> resources = new HashSet<OntResource>();
 		OntResource r = ontModel.getOntProperty(propertyUri);
-		if (r == null) return new HashMap<String, Label>();
+		if (r == null){
+			return new HashMap<String, Label>();
+		}
 		getParents(r, resources, recursive);
 		return getResourcesLabels(resources);
 	}

--- a/src/main/java/edu/isi/karma/modeling/ontology/OntologyManager.java
+++ b/src/main/java/edu/isi/karma/modeling/ontology/OntologyManager.java
@@ -80,8 +80,9 @@ public class OntologyManager  {
 	}
 	
 	private void notifyListeners() {
-		for (OntologyUpdateListener o : ontUpdateListeners)
+		for (OntologyUpdateListener o : ontUpdateListeners){
 			o.ontologyModelUpdated();
+		}
 	}
 	
 	public boolean doImportAndUpdateCache(File sourceFile) {
@@ -227,10 +228,11 @@ public class OntologyManager  {
 	 */
 	public boolean isSubClass(String subClassUri, String superClassUri, boolean recursive) {
 		
-		if (ontCache.getDirectSubClassCheck().contains(subClassUri + superClassUri))
+		if (ontCache.getDirectSubClassCheck().contains(subClassUri + superClassUri)){
 			return true;
-		else if (recursive) 
+		}else if (recursive){
 			return ontCache.getIndirectSubClassCheck().contains(subClassUri + superClassUri);
+		}
 		
 		return false;
 	}
@@ -245,10 +247,11 @@ public class OntologyManager  {
 	 */
 	public boolean isSubProperty(String subPropertyUri, String superPropertyUri, boolean recursive) {
 		
-		if (ontCache.getDirectSubPropertyCheck().contains(subPropertyUri + superPropertyUri))
+		if (ontCache.getDirectSubPropertyCheck().contains(subPropertyUri + superPropertyUri)){
 			return true;
-		else if (recursive) 
+		}else if (recursive){
 			return ontCache.getIndirectSubPropertyCheck().contains(subPropertyUri + superPropertyUri);
+		}
 		
 		return false;
 	}
@@ -268,9 +271,15 @@ public class OntologyManager  {
 		HashSet<String> indirect = null;
 		
 		direct = ontCache.getPropertyDirectDomains().get(propertyUri);
-		if (direct != null) results.addAll(direct);
-		if (recursive) indirect = ontCache.getPropertyIndirectDomains().get(propertyUri);
-		if (indirect != null) results.addAll(indirect);
+		if (direct != null){
+			results.addAll(direct);
+		}
+		if (recursive){
+			indirect = ontCache.getPropertyIndirectDomains().get(propertyUri);
+		}
+		if (indirect != null){
+			results.addAll(indirect);
+		}
 		
 		return results;
 
@@ -290,9 +299,15 @@ public class OntologyManager  {
 		HashSet<String> indirect = null;
 		
 		direct = ontCache.getPropertyDirectRanges().get(propertyUri);		
-		if (direct != null) results.addAll(direct);
-		if (recursive) indirect = ontCache.getPropertyIndirectRanges().get(propertyUri);
-		if (indirect != null) results.addAll(indirect);
+		if (direct != null){
+			results.addAll(direct);
+		}
+		if (recursive){
+			indirect = ontCache.getPropertyIndirectRanges().get(propertyUri);
+		}
+		if (indirect != null){
+			results.addAll(indirect);
+		}
 		
 		return results;
 
@@ -313,14 +328,21 @@ public class OntologyManager  {
 		HashSet<String> direct = null;
 		HashSet<String> indirect = null;
 		
-		if (objectProperties == null)
+		if (objectProperties == null){
 			return results;
+		}
 		
 		for (String op : objectProperties) {
 			direct = ontCache.getPropertyDirectDomains().get(op);
-			if (direct != null) results.addAll(direct);
-			if (recursive) indirect = ontCache.getPropertyIndirectDomains().get(op);
-			if (indirect != null) results.addAll(indirect);
+			if (direct != null){
+				results.addAll(direct);
+			}
+			if (recursive){
+				indirect = ontCache.getPropertyIndirectDomains().get(op);
+			}
+			if (indirect != null){
+				results.addAll(indirect);
+			}
 		}
 		
 		return results;
@@ -331,8 +353,9 @@ public class OntologyManager  {
 		Map<String, String> prefixMap = new HashMap<String, String>();
 		
 		for(String ns: nsMap.keySet()) {
-			if (!ns.equals("") && !prefixMap.containsKey(nsMap.get(ns)))
+			if (!ns.equals("") && !prefixMap.containsKey(nsMap.get(ns))){
 				prefixMap.put(nsMap.get(ns), ns);
+			}
 		}
 		return prefixMap;
 	}
@@ -346,12 +369,18 @@ public class OntologyManager  {
 	public HashMap<String, Label> getSubClasses(String classUri, boolean recursive) {
 		
 		HashMap<String, Label> direct = ontCache.getDirectSubClasses().get(classUri);
-		if (!recursive) return direct;
+		if (!recursive){
+			return direct;
+		}
 		
 		HashMap<String, Label> all = new HashMap<String, Label>();
 		HashMap<String, Label> indirect = ontCache.getIndirectSubClasses().get(classUri);
-		if (direct != null) all.putAll(direct);
-		if (indirect != null) all.putAll(indirect);
+		if (direct != null){
+			all.putAll(direct);
+		}
+		if (indirect != null){
+			all.putAll(indirect);
+		}
 		return all;
 	}
 	
@@ -364,12 +393,18 @@ public class OntologyManager  {
 	public HashMap<String, Label> getSuperClasses(String classUri, boolean recursive) {
 		
 		HashMap<String, Label> direct = ontCache.getDirectSuperClasses().get(classUri);
-		if (!recursive) return direct;
+		if (!recursive){
+			return direct;
+		}
 		
 		HashMap<String, Label> all = new HashMap<String, Label>();
 		HashMap<String, Label> indirect = ontCache.getIndirectSuperClasses().get(classUri);
-		if (direct != null) all.putAll(direct);
-		if (indirect != null) all.putAll(indirect);
+		if (direct != null){
+			all.putAll(direct);
+		}
+		if (indirect != null){
+			all.putAll(indirect);
+		}
 		return all;
 	}
 	
@@ -382,12 +417,18 @@ public class OntologyManager  {
 	public HashMap<String, Label> getSubProperties(String propertyUri, boolean recursive) {
 
 		HashMap<String, Label> direct = ontCache.getDirectSubProperties().get(propertyUri);
-		if (!recursive) return direct;
+		if (!recursive){
+			return direct;
+		}
 		
 		HashMap<String, Label> all = new HashMap<String, Label>();
 		HashMap<String, Label> indirect = ontCache.getIndirectSubProperties().get(propertyUri);
-		if (direct != null) all.putAll(direct);
-		if (indirect != null) all.putAll(indirect);
+		if (direct != null){
+			all.putAll(direct);
+		}
+		if (indirect != null){
+			all.putAll(indirect);
+		}
 		return all;
 
 	}
@@ -401,12 +442,18 @@ public class OntologyManager  {
 	public HashMap<String, Label> getSuperProperties(String propertyUri, boolean recursive) {
 
 		HashMap<String, Label> direct = ontCache.getDirectSuperProperties().get(propertyUri);
-		if (!recursive) return direct;
+		if (!recursive){
+			return direct;
+		}
 		
 		HashMap<String, Label> all = new HashMap<String, Label>();
 		HashMap<String, Label> indirect = ontCache.getIndirectSuperProperties().get(propertyUri);
-		if (direct != null) all.putAll(direct);
-		if (indirect != null) all.putAll(indirect);
+		if (direct != null){
+			all.putAll(direct);
+		}
+		if (indirect != null){
+			all.putAll(indirect);
+		}
 		return all;
 
 	}
@@ -421,12 +468,18 @@ public class OntologyManager  {
 	public HashSet<String> getDataPropertiesOfClass(String domainUri, boolean inheritance) {
 
 		HashSet<String> direct = ontCache.getDirectOutDataProperties().get(domainUri);
-		if (!inheritance) return direct;
+		if (!inheritance){
+			return direct;
+		}
 		
 		HashSet<String> all = new HashSet<String>();
 		HashSet<String> indirect = ontCache.getIndirectOutDataProperties().get(domainUri);
-		if (direct != null) all.addAll(direct);
-		if (indirect != null) all.addAll(indirect);
+		if (direct != null){
+			all.addAll(direct);
+		}
+		if (indirect != null){
+			all.addAll(indirect);
+		}
 		return all;
 
 	}
@@ -441,100 +494,136 @@ public class OntologyManager  {
 	public HashSet<String> getObjectPropertiesOfClass(String domainUri, boolean inheritance) {
 
 		HashSet<String> direct = ontCache.getDirectOutObjectProperties().get(domainUri);
-		if (!inheritance) return direct;
+		if (!inheritance){
+			return direct;
+		}
 		
 		HashSet<String> all = new HashSet<String>();
 		HashSet<String> indirect = ontCache.getIndirectOutObjectProperties().get(domainUri);
-		if (direct != null) all.addAll(direct);
-		if (indirect != null) all.addAll(indirect);
+		if (direct != null){
+			all.addAll(direct);
+		}
+		if (indirect != null){
+			all.addAll(indirect);
+		}
 		return all;
 	}
 	
 	public HashSet<String> getObjectPropertiesDirect(String sourceUri, String targetUri) {
 		
-		if (sourceUri == null || targetUri == null) return null;
+		if (sourceUri == null || targetUri == null){
+			return null;
+		}
 		return this.ontCache.getDomainRangeToDirectProperties().get(sourceUri + targetUri);
 	}
 
 	public HashSet<String> getObjectPropertiesIndirect(String sourceUri, String targetUri) {
 		
-		if (sourceUri == null || targetUri == null) return null;
+		if (sourceUri == null || targetUri == null){
+			return null;
+		}
 		return this.ontCache.getDomainRangeToIndirectProperties().get(sourceUri + targetUri);
 	}
 
 	public HashSet<String> getObjectPropertiesWithOnlyDomain(String sourceUri, String targetUri) {
 		
-		if (sourceUri == null || targetUri == null) return null;
+		if (sourceUri == null || targetUri == null){
+			return null;
+		}
 		
 		HashSet<String> directOutProperties;
 		HashSet<String> indirectOutProperties;
 		HashSet<String> results = new HashSet<String>();
 
 		directOutProperties = this.ontCache.getDirectOutObjectProperties().get(sourceUri);
-		if (directOutProperties != null)
-			for (String s : directOutProperties) 
-				if (this.ontCache.getObjectPropertiesWithOnlyDomain().containsKey(s)) 
+		if (directOutProperties != null){
+			for (String s : directOutProperties){
+				if (this.ontCache.getObjectPropertiesWithOnlyDomain().containsKey(s)){
 					results.add(s);
+				}
+			}
+		}
 
 		indirectOutProperties = this.ontCache.getIndirectOutObjectProperties().get(sourceUri);
-		if (indirectOutProperties != null) 
-			for (String s : indirectOutProperties) 
-				if (this.ontCache.getObjectPropertiesWithOnlyDomain().containsKey(s)) 
+		if (indirectOutProperties != null){
+			for (String s : indirectOutProperties){
+				if (this.ontCache.getObjectPropertiesWithOnlyDomain().containsKey(s)){
 					results.add(s);
+				}
+			}
+		}
 		
 		return results;
 	}
 
 	public HashSet<String> getObjectPropertiesWithOnlyRange(String sourceUri, String targetUri) {
 		
-		if (sourceUri == null || targetUri == null) return null;
+		if (sourceUri == null || targetUri == null){
+			return null;
+		}
 		
 		HashSet<String> directInProperties;
 		HashSet<String> indirectInProperties;
 		HashSet<String> results = new HashSet<String>();
 		
 		directInProperties = this.ontCache.getDirectInObjectProperties().get(targetUri);
-		if (directInProperties != null)
-			for (String s : directInProperties) 
-				if (this.ontCache.getObjectPropertiesWithOnlyRange().containsKey(s)) 
+		if (directInProperties != null){
+			for (String s : directInProperties){
+				if (this.ontCache.getObjectPropertiesWithOnlyRange().containsKey(s)){
 					results.add(s);
+				}
+			}
+		}
 
 		indirectInProperties = this.ontCache.getIndirectInObjectProperties().get(targetUri);
-		if (indirectInProperties != null) 
-			for (String s : indirectInProperties) 
-				if (this.ontCache.getObjectPropertiesWithOnlyRange().containsKey(s)) 
+		if (indirectInProperties != null){
+			for (String s : indirectInProperties){
+				if (this.ontCache.getObjectPropertiesWithOnlyRange().containsKey(s)){
 					results.add(s);
+				}
+			}
+		}
 		
 		return results;
 	}
 
 	public boolean isConnectedByDirectProperty(String sourceUri, String targetUri) {
 		
-		if (sourceUri == null || targetUri == null) return false;
+		if (sourceUri == null || targetUri == null){
+			return false;
+		}
 		return this.ontCache.getConnectedByDirectProperties().contains(sourceUri + targetUri);
 	}
 
 	public boolean isConnectedByIndirectProperty(String sourceUri, String targetUri) {
 		
-		if (sourceUri == null || targetUri == null) return false;
+		if (sourceUri == null || targetUri == null){
+			return false;
+		}
 		return this.ontCache.getConnectedByIndirectProperties().contains(sourceUri + targetUri);
 	}
 
 	public boolean isConnectedByDomainlessProperty(String sourceUri, String targetUri) {
 		
-		if (sourceUri == null || targetUri == null) return false;
+		if (sourceUri == null || targetUri == null){
+			return false;
+		}
 		return this.ontCache.getConnectedByDomainlessProperties().contains(sourceUri + targetUri);
 	}
 
 	public boolean isConnectedByRangelessProperty(String sourceUri, String targetUri) {
 		
-		if (sourceUri == null || targetUri == null) return false;
+		if (sourceUri == null || targetUri == null){
+			return false;
+		}
 		return this.ontCache.getConnectedByRangelessProperties().contains(sourceUri + targetUri);
 	}
 	
 	public boolean isConnectedByDomainlessAndRangelessProperty(String sourceUri, String targetUri) {
 		
-		if (sourceUri == null || targetUri == null) return false;
+		if (sourceUri == null || targetUri == null){
+			return false;
+		}
 		return (this.ontCache.getObjectPropertiesWithoutDomainAndRange().size() > 0);
 	}
 }

--- a/src/main/java/edu/isi/karma/modeling/ontology/OntologyTreeNode.java
+++ b/src/main/java/edu/isi/karma/modeling/ontology/OntologyTreeNode.java
@@ -65,14 +65,21 @@ public class OntologyTreeNode {
 	}
 	
 	private void printRecursively(OntologyTreeNode node, int level) {
-		for (int i = 0; i < level; i++) System.out.print("---"); System.out.print(" ");
+		for (int i = 0; i < level; i++){
+			System.out.print("---");
+		} System.out.print(" ");
 		System.out.println("URI: " + node.getLabel().getUri());
-		for (int i = 0; i < level; i++) System.out.print("   "); System.out.print(" ");
+		for (int i = 0; i < level; i++){
+			System.out.print("   ");
+		} System.out.print(" ");
 		System.out.println("Label: " + node.getLabel().getRdfsLabel());
-		for (int i = 0; i < level; i++) System.out.print("   "); System.out.print(" ");
+		for (int i = 0; i < level; i++){
+			System.out.print("   ");
+		} System.out.print(" ");
 		System.out.println("Comment: " + node.getLabel().getRdfsComment());
-		if (node.children == null || node.children.size() == 0)
+		if (node.children == null || node.children.size() == 0){
 			return;
+		}
 		for (OntologyTreeNode child : node.getChildren()) {
 			printRecursively(child, level + 1);
 		}

--- a/src/main/java/edu/isi/karma/modeling/research/GraphVizUtil.java
+++ b/src/main/java/edu/isi/karma/modeling/research/GraphVizUtil.java
@@ -43,8 +43,9 @@ public class GraphVizUtil {
 
 		org.kohsuke.graphviz.Graph gViz = new org.kohsuke.graphviz.Graph();
 
-		if (path == null)
+		if (path == null){
 			return gViz;
+		}
 			
 		org.kohsuke.graphviz.Style internalNodeStyle = new org.kohsuke.graphviz.Style();
 //		internalNodeStyle.attr("shape", "circle");
@@ -100,12 +101,13 @@ public class GraphVizUtil {
 //					gViz.nodeWith(inputNodeStyle);
 //				else if (id.indexOf("att") != -1 && id.indexOf("o") != -1)  // output
 //					gViz.nodeWith(outputNodeStyle);
-				if (source instanceof ColumnNode)  // attribute
+				if (source instanceof ColumnNode){
 					gViz.nodeWith(parameterNodeStyle);
-				else if (source instanceof LiteralNode)  // literal
+				}else if (source instanceof LiteralNode){
 					gViz.nodeWith(literalNodeStyle);
-				else  // internal node
+				}else{
 					gViz.nodeWith(internalNodeStyle);
+				}
 					
 				gViz.node(n);
 			}
@@ -122,12 +124,13 @@ public class GraphVizUtil {
 //					gViz.nodeWith(inputNodeStyle);
 //				else if (id.indexOf("att") != -1 && id.indexOf("o") != -1)  // output
 //					gViz.nodeWith(outputNodeStyle);
-				if (target instanceof ColumnNode)  // attribute
+				if (target instanceof ColumnNode){
 					gViz.nodeWith(parameterNodeStyle);
-				else if (target instanceof LiteralNode)  // literal
+				}else if (target instanceof LiteralNode){
 					gViz.nodeWith(literalNodeStyle);
-				else  // internal node
+				}else{
 					gViz.nodeWith(internalNodeStyle);
+				}
 					
 				gViz.node(n);
 			}
@@ -174,8 +177,9 @@ public class GraphVizUtil {
 
 		org.kohsuke.graphviz.Graph gViz = new org.kohsuke.graphviz.Graph();
 
-		if (model == null)
+		if (model == null){
 			return gViz;
+		}
 
 		org.kohsuke.graphviz.Style internalNodeStyle = new org.kohsuke.graphviz.Style();
 //		internalNodeStyle.attr("shape", "circle");
@@ -228,12 +232,13 @@ public class GraphVizUtil {
 //					gViz.nodeWith(inputNodeStyle);
 //				else if (id.indexOf("att") != -1 && id.indexOf("o") != -1)  // output
 //					gViz.nodeWith(outputNodeStyle);
-				if (source instanceof ColumnNode)  // attribute
+				if (source instanceof ColumnNode){
 					gViz.nodeWith(parameterNodeStyle);
-				else if (source instanceof LiteralNode)  // literal
+				}else if (source instanceof LiteralNode){
 					gViz.nodeWith(literalNodeStyle);
-				else  // internal node
+				}else{
 					gViz.nodeWith(internalNodeStyle);
+				}
 					
 				gViz.node(n);
 			}
@@ -250,12 +255,13 @@ public class GraphVizUtil {
 //					gViz.nodeWith(inputNodeStyle);
 //				else if (id.indexOf("att") != -1 && id.indexOf("o") != -1)  // output
 //					gViz.nodeWith(outputNodeStyle);
-				if (target instanceof ColumnNode)  // attribute
+				if (target instanceof ColumnNode){
 					gViz.nodeWith(parameterNodeStyle);
-				else if (target instanceof LiteralNode)  // literal
+				}else if (target instanceof LiteralNode){
 					gViz.nodeWith(literalNodeStyle);
-				else  // internal node
+				}else{
 					gViz.nodeWith(internalNodeStyle);
+				}
 					
 				gViz.node(n);
 			}
@@ -267,10 +273,12 @@ public class GraphVizUtil {
 			String label = (uri == null?id:uri);
 			label += "-(" + roundTwoDecimals(e.getWeight()) + ")-";
 			label += "-[";
-			for (String pId : e.getPatternIds())
+			for (String pId : e.getPatternIds()){
 				label += pId + ",";
-			if (label.endsWith(","))
+			}
+			if (label.endsWith(",")){
 				label = label.substring(0, label.length() - 1);
+			}
 			label += "]";
 
 			edge.attr("label", label);

--- a/src/main/java/edu/isi/karma/modeling/research/Util.java
+++ b/src/main/java/edu/isi/karma/modeling/research/Util.java
@@ -42,8 +42,9 @@ public class Util {
 	public static List<Node> getAttributes(DirectedWeightedMultigraph<Node, Link> graph) {
 		List<Node> attributes = new ArrayList<Node>();
 		for (Node n : graph.vertexSet()) {
-			if (n instanceof ColumnNode || n instanceof LiteralNode)
+			if (n instanceof ColumnNode || n instanceof LiteralNode){
 				attributes.add(n);
+			}
 		}
 		Collections.sort(attributes);
 		return attributes;
@@ -63,9 +64,9 @@ public class Util {
 				new HashMap<Node, edu.isi.karma.modeling.research.graph.roek.nlpged.graph.Node>();
 		
 		for (Node n : g.vertexSet()) {
-			if (n instanceof InternalNode)
+			if (n instanceof InternalNode){
 				label = n.getLabel().getUri();
-			else {
+			}else {
 				Set<Link> incomingLinks = g.incomingEdgesOf(n);
 				link = incomingLinks.toArray(new Link[0])[0];
 				domain = link.getSource();
@@ -111,11 +112,11 @@ public class Util {
 		
 		for (Node n : graph.vertexSet()) {
 			nodeToIds.put(n, nodeCount);
-			if (n instanceof InternalNode)
+			if (n instanceof InternalNode){
 				s += "<node id=\"" + nodeCount + 
 						"\"><attr name=\"label\"><string>" + 
 						n.getLabel().getUri() + "</string></attr></node>";
-			else {
+			}else {
 				Set<Link> incomingLinks = graph.incomingEdgesOf(n);
 				if (incomingLinks != null && incomingLinks.size() > 0) { 
 					link = incomingLinks.toArray(new Link[0])[0];

--- a/src/main/java/edu/isi/karma/modeling/research/experiment1/Algorithm.java
+++ b/src/main/java/edu/isi/karma/modeling/research/experiment1/Algorithm.java
@@ -78,13 +78,18 @@ public class Algorithm {
 		
 		HashMap<String, Node> attMap1 = new HashMap<String, Node>();
 		HashMap<String, Node> attMap2 = new HashMap<String, Node>();
-		for (Node n : attributes1) attMap1.put(n.getId(), n);
-		for (Node n : attributes2) attMap2.put(n.getId(), n);
+		for (Node n : attributes1){
+			attMap1.put(n.getId(), n);
+		}
+		for (Node n : attributes2){
+			attMap2.put(n.getId(), n);
+		}
 		
 		int attCount = attributes1.size(); // = attributes2.size();
 		Set<String> keys = attMap1.keySet();
-		if (attMap2.keySet().size() < attMap1.keySet().size())
+		if (attMap2.keySet().size() < attMap1.keySet().size()){
 			keys = attMap2.keySet();
+		}
 
 		
 		Set<Set<String>> powerSet = powerSet(keys);
@@ -93,13 +98,16 @@ public class Algorithm {
 			
 			// if numberOfattributes specified by the user is null or greater than total number of attributes,
 			// we compute all the possible subgraphs
-			if (numberOfAttributes != null && numberOfAttributes.intValue() < attCount)
-				if (k != numberOfAttributes)
+			if (numberOfAttributes != null && numberOfAttributes.intValue() < attCount){
+				if (k != numberOfAttributes){
 					continue;
+				}
+			}
 			
 			for (Set<String> set : powerSet) {
-				if (set.size() != k)
+				if (set.size() != k){
 					continue;
+				}
 				
 				List<Node> steinerNodes1 = new ArrayList<Node>();
 				List<Node> steinerNodes2 = new ArrayList<Node>();

--- a/src/main/java/edu/isi/karma/modeling/research/experiment1/Approach1.java
+++ b/src/main/java/edu/isi/karma/modeling/research/experiment1/Approach1.java
@@ -137,13 +137,14 @@ public class Approach1 {
 		
 		Set<String> inputModelSourceLinkTargetTriples = new HashSet<String>();
 		for (Link link : this.inputModel.edgeSet()) {
-			if (link.getTarget() instanceof InternalNode)
+			if (link.getTarget() instanceof InternalNode){
 				inputModelSourceLinkTargetTriples.add(link.getSource().getLabel().getUri() + 
 						link.getLabel().getUri() +
 						link.getTarget().getLabel().getUri() );
-			else
+			}else{
 				inputModelSourceLinkTargetTriples.add(link.getSource().getLabel().getUri() + 
 						link.getLabel().getUri());
+			}
 		}
 		
 		int count;
@@ -154,13 +155,14 @@ public class Approach1 {
 			modelSourceLinkTargetTriples = new HashSet<String>();
 
 			for (Link link : m.edgeSet()) {
-				if (link.getTarget() instanceof InternalNode)
+				if (link.getTarget() instanceof InternalNode){
 					modelSourceLinkTargetTriples.add(link.getSource().getLabel().getUri() + 
 							link.getLabel().getUri() +
 							link.getTarget().getLabel().getUri() );
-				else
+				}else{
 					modelSourceLinkTargetTriples.add(link.getSource().getLabel().getUri() + 
 							link.getLabel().getUri());
+				}
 			}
 			
 			Set<String> commonLinks = 
@@ -209,9 +211,11 @@ public class Approach1 {
 //		Multimap<Integer, String> index = Multimaps.index(this.similarityMap.keySet(), countFunction);
 
 		int totalCommonLinks = 0;
-		for (Integer i : this.similarityMap.values()) 
-			if (i != null)
+		for (Integer i : this.similarityMap.values()){
+			if (i != null){
 				totalCommonLinks += i.intValue();
+			}
+		}
 		
 		int count;
 		for (Entry<String, Integer> entry : this.similarityMap.entrySet()) {
@@ -252,8 +256,11 @@ public class Approach1 {
 						this.sourceTargetToLinkWeightMap.put(key, linkWeight);
 					} else {
 						w = linkWeight.get(link.getLabel().getUri());
-						if (w == null) linkWeight.put(link.getLabel().getUri(), modelWeight);
-						else linkWeight.put(link.getLabel().getUri(), (w.doubleValue() + modelWeight) );
+						if (w == null){
+							linkWeight.put(link.getLabel().getUri(), modelWeight);
+						}else{
+							linkWeight.put(link.getLabel().getUri(), (w.doubleValue() + modelWeight) );
+						}
 					}
 				}
 			}
@@ -267,7 +274,9 @@ public class Approach1 {
 		List<SemanticLabel1> semanticLabels = new ArrayList<SemanticLabel1>();
 
 		for (Node n : model.vertexSet()) {
-			if (!(n instanceof ColumnNode) && !(n instanceof LiteralNode)) continue;
+			if (!(n instanceof ColumnNode) && !(n instanceof LiteralNode)){
+				continue;
+			}
 			
 			Set<Link> incomingLinks = model.incomingEdgesOf(n);
 			if (incomingLinks != null) { // && incomingLinks.size() == 1) {
@@ -277,7 +286,9 @@ public class Approach1 {
 				SemanticLabel1 sl = new SemanticLabel1(domain.getLabel(), link.getLabel(), n.getId());
 				semanticLabels.add(sl);
 				
-				if (!updateNodeToSemanticLabelsMap) continue;
+				if (!updateNodeToSemanticLabelsMap){
+					continue;
+				}
 				
 				List<SemanticLabel1> attachedSLs = this.nodeToSemanticLabels.get(domain);
 				if (attachedSLs == null) {
@@ -301,12 +312,22 @@ public class Approach1 {
 			List<SemanticLabel1> slList1 = null, slList2 = null;
 			for (MatchedSubGraphs m : matchedSubGraphs) {
 				slList1 = getModelSemanticLabels(m.getSubGraph1(), false);
-				if (slList1 != null && slList1.size() == 1) sl1 = slList1.get(0); else sl1 = null;
+				if (slList1 != null && slList1.size() == 1){
+					sl1 = slList1.get(0);
+				}else{
+					sl1 = null;
+				}
 				
 				slList2 = getModelSemanticLabels(m.getSubGraph2(), false);
-				if (slList2 != null && slList2.size() == 1) sl2 = slList2.get(0); else sl2 = null;
+				if (slList2 != null && slList2.size() == 1){
+					sl2 = slList2.get(0);
+				}else{
+					sl2 = null;
+				}
 				
-				if (sl1 == null || sl2 == null) continue;
+				if (sl1 == null || sl2 == null){
+					continue;
+				}
 				
 				if (sl1.compareTo(semanticLabel) == 0) {
 					matchedSemanticLabels.add(sl2); 
@@ -325,8 +346,9 @@ public class Approach1 {
 		
 		// select the most frequent semantic label from the matched list 
 
-		if (matchedSemanticLabels == null || matchedSemanticLabels.size() == 0)
+		if (matchedSemanticLabels == null || matchedSemanticLabels.size() == 0){
 			return null;
+		}
 		
 		int indexOfMostFrequentSemanticLabel = 0;
 		int countOfEqualSemanticLabels = 1;
@@ -372,8 +394,9 @@ public class Approach1 {
 		
 		logger.info("=====================================================================");
 		logger.info("Input Semantic Labels: ");
-		for (SemanticLabel1 sl: inputSemanticLabels)
+		for (SemanticLabel1 sl: inputSemanticLabels){
 			sl.print();
+		}
 		logger.info("=====================================================================");
 		
 		for (SemanticLabel1 sl : inputSemanticLabels) {
@@ -409,8 +432,9 @@ public class Approach1 {
 			}
 			
 			logger.info("Matched Semantic Labels: ");
-			for (SemanticLabel1 matched: matchedSemanticLabels)
+			for (SemanticLabel1 matched: matchedSemanticLabels){
 				matched.print();
+			}
 			logger.info("-------------------------------------------");
 
 			SemanticLabel1 bestMatch = selectBestMatchedSemanticLabel(matchedSemanticLabels);
@@ -431,8 +455,9 @@ public class Approach1 {
 
 		logger.info("=====================================================================");
 		logger.info("Output Semantic Labels: ");
-		for (SemanticLabel1 sl: outputSemanticLabels)
+		for (SemanticLabel1 sl: outputSemanticLabels){
 			sl.print();
+		}
 		logger.info("=====================================================================");
 		
 	}
@@ -444,9 +469,11 @@ public class Approach1 {
 		for (List<SemanticLabel1> slList : this.nodeToSemanticLabels.values()) {
 			
 			List<SemanticLabel1> mappedOutputLabel = new ArrayList<SemanticLabel1>();
-			for (SemanticLabel1 sl : slList)
-				if (this.inputLabelsToOutputLabelsMatching.get(sl) != null)
+			for (SemanticLabel1 sl : slList){
+				if (this.inputLabelsToOutputLabelsMatching.get(sl) != null){
 					mappedOutputLabel.add(this.inputLabelsToOutputLabelsMatching.get(sl));
+				}
+			}
 			
 	
 			Map<String,List<SemanticLabel1>> groupedMappedOutputLabelsByNodeUri =
@@ -529,7 +556,9 @@ public class Approach1 {
 			objectPropertiesWithOnlyRange = ontologyManager.getObjectPropertiesWithOnlyRange(dr.getDomain(), dr.getRange());
 			
 			HashMap<String, Double> linkWeight = this.sourceTargetToLinkWeightMap.get(dr.getDomain() + dr.getRange());
-			if (linkWeight == null || linkWeight.size() == 0) continue;
+			if (linkWeight == null || linkWeight.size() == 0){
+				continue;
+			}
 
 			boolean linkExistInOntology;
 			
@@ -543,16 +572,17 @@ public class Approach1 {
 						
 						linkExistInOntology = false;
 						
-						if (objectPropertiesWithoutDomainAndRange != null && objectPropertiesWithoutDomainAndRange.containsKey(s)) 
+						if (objectPropertiesWithoutDomainAndRange != null && objectPropertiesWithoutDomainAndRange.containsKey(s)){
 							linkExistInOntology = true;
-						else if (objectPropertiesDirect != null && objectPropertiesDirect.contains(s))
+						}else if (objectPropertiesDirect != null && objectPropertiesDirect.contains(s)){
 							linkExistInOntology = true;
-						else if (objectPropertiesIndirect != null && objectPropertiesIndirect.contains(s))
+						}else if (objectPropertiesIndirect != null && objectPropertiesIndirect.contains(s)){
 							linkExistInOntology = true;
-						else if (objectPropertiesWithOnlyDomain != null && objectPropertiesWithOnlyDomain.contains(s))
+						}else if (objectPropertiesWithOnlyDomain != null && objectPropertiesWithOnlyDomain.contains(s)){
 							linkExistInOntology = true;
-						else if (objectPropertiesWithOnlyRange != null && objectPropertiesWithOnlyRange.contains(s))
+						}else if (objectPropertiesWithOnlyRange != null && objectPropertiesWithOnlyRange.contains(s)){
 							linkExistInOntology = true;
+						}
 						
 						if (!linkExistInOntology) {
 //							logger.warn("The link " + s + " from " + dr.getDomain() + " to " + dr.getRange() + 
@@ -563,7 +593,9 @@ public class Approach1 {
 						}
 						
 						linkWeightInTrainingset = linkWeight.get(s);
-						if (linkWeightInTrainingset == null) continue;
+						if (linkWeightInTrainingset == null){
+							continue;
+						}
 						
 						id = LinkIdFactory.getLinkId(s, n1.getId(), n2.getId());
 						label = new Label(s);
@@ -573,7 +605,9 @@ public class Approach1 {
 						graph.addEdge(n1, n2, newLink);
 						
 						weight = ModelingParams.PROPERTY_DIRECT_WEIGHT - 10 * linkWeightInTrainingset.doubleValue();
-						if (weight < 0) weight = 0.0;
+						if (weight < 0){
+							weight = 0.0;
+						}
 						
 						graph.setEdgeWeight(newLink,  weight);
 					}					
@@ -664,7 +698,9 @@ public class Approach1 {
 				ontologyManager.getObjectPropertiesWithoutDomainAndRange();
 		
 		for (Link link : links) {
-			if (!(link instanceof SimpleLink)) continue;
+			if (!(link instanceof SimpleLink)){
+				continue;
+			}
 			
 			// links from source to target
 			sourceUri = link.getSource().getLabel().getUri();
@@ -675,30 +711,46 @@ public class Approach1 {
 
 			if (link.getWeight() == ModelingParams.PROPERTY_DIRECT_WEIGHT) {
 				objectPropertiesDirect = ontologyManager.getObjectPropertiesDirect(sourceUri, targetUri);
-				if (objectPropertiesDirect != null) possibleLinksFromSourceToTarget.addAll(objectPropertiesDirect);
+				if (objectPropertiesDirect != null){
+					possibleLinksFromSourceToTarget.addAll(objectPropertiesDirect);
+				}
 				objectPropertiesDirect = ontologyManager.getObjectPropertiesDirect(targetUri, sourceUri);
-				if (objectPropertiesDirect != null) possibleLinksFromTargetToSource.addAll(objectPropertiesDirect);
+				if (objectPropertiesDirect != null){
+					possibleLinksFromTargetToSource.addAll(objectPropertiesDirect);
+				}
 			}
 			
 			if (link.getWeight() == ModelingParams.PROPERTY_INDIRECT_WEIGHT) {
 				objectPropertiesIndirect = ontologyManager.getObjectPropertiesIndirect(sourceUri, targetUri);
-				if (objectPropertiesIndirect != null) possibleLinksFromSourceToTarget.addAll(objectPropertiesIndirect);
+				if (objectPropertiesIndirect != null){
+					possibleLinksFromSourceToTarget.addAll(objectPropertiesIndirect);
+				}
 				objectPropertiesIndirect = ontologyManager.getObjectPropertiesIndirect(targetUri, sourceUri);
-				if (objectPropertiesIndirect != null) possibleLinksFromTargetToSource.addAll(objectPropertiesIndirect);
+				if (objectPropertiesIndirect != null){
+					possibleLinksFromTargetToSource.addAll(objectPropertiesIndirect);
+				}
 			} 
 
 			if (link.getWeight() == ModelingParams.PROPERTY_WITH_ONLY_DOMAIN_WEIGHT) {
 				objectPropertiesWithOnlyDomain = ontologyManager.getObjectPropertiesWithOnlyDomain(sourceUri, targetUri);
-				if (objectPropertiesWithOnlyDomain != null) possibleLinksFromSourceToTarget.addAll(objectPropertiesWithOnlyDomain);
+				if (objectPropertiesWithOnlyDomain != null){
+					possibleLinksFromSourceToTarget.addAll(objectPropertiesWithOnlyDomain);
+				}
 				objectPropertiesWithOnlyDomain = ontologyManager.getObjectPropertiesWithOnlyDomain(targetUri, sourceUri);
-				if (objectPropertiesWithOnlyDomain != null) possibleLinksFromTargetToSource.addAll(objectPropertiesWithOnlyDomain);
+				if (objectPropertiesWithOnlyDomain != null){
+					possibleLinksFromTargetToSource.addAll(objectPropertiesWithOnlyDomain);
+				}
 			} 
 			
 			if (link.getWeight() == ModelingParams.PROPERTY_WITH_ONLY_RANGE_WEIGHT) {
 				objectPropertiesWithOnlyRange = ontologyManager.getObjectPropertiesWithOnlyRange(sourceUri, targetUri);
-				if (objectPropertiesWithOnlyRange != null) possibleLinksFromSourceToTarget.addAll(objectPropertiesWithOnlyRange);
+				if (objectPropertiesWithOnlyRange != null){
+					possibleLinksFromSourceToTarget.addAll(objectPropertiesWithOnlyRange);
+				}
 				objectPropertiesWithOnlyRange = ontologyManager.getObjectPropertiesWithOnlyRange(targetUri, sourceUri);
-				if (objectPropertiesWithOnlyRange != null) possibleLinksFromTargetToSource.addAll(objectPropertiesWithOnlyRange);
+				if (objectPropertiesWithOnlyRange != null){
+					possibleLinksFromTargetToSource.addAll(objectPropertiesWithOnlyRange);
+				}
 			} 
 			
 			if (link.getWeight() == ModelingParams.PROPERTY_WITHOUT_DOMAIN_RANGE_WEIGHT) {
@@ -709,10 +761,12 @@ public class Approach1 {
 			}
 			
 			if (link.getWeight() == ModelingParams.SUBCLASS_WEIGHT) {
-				if (ontologyManager.isSubClass(sourceUri, targetUri, true)) 
+				if (ontologyManager.isSubClass(sourceUri, targetUri, true)){
 					possibleLinksFromSourceToTarget.add(Uris.RDFS_SUBCLASS_URI);
-				if (ontologyManager.isSubClass(targetUri, sourceUri, true)) 
+				}
+				if (ontologyManager.isSubClass(targetUri, sourceUri, true)){
 					possibleLinksFromTargetToSource.add(Uris.RDFS_SUBCLASS_URI);
+				}
 			}
 
 			if (possibleLinksFromSourceToTarget.size() > 0) {
@@ -721,10 +775,11 @@ public class Approach1 {
 				label = new Label(uri);
 				
 				Link newLink;
-				if (uri.equalsIgnoreCase(Uris.RDFS_SUBCLASS_URI))
+				if (uri.equalsIgnoreCase(Uris.RDFS_SUBCLASS_URI)){
 					newLink = new SubClassLink(id);
-				else
+				}else{
 					newLink = new ObjectPropertyLink(id, label);
+				}
 				
 				tree.addEdge(link.getSource(), link.getTarget(), newLink);
 				tree.removeEdge(link);
@@ -735,10 +790,11 @@ public class Approach1 {
 				label = new Label(uri);
 				
 				Link newLink;
-				if (uri.equalsIgnoreCase(Uris.RDFS_SUBCLASS_URI))
+				if (uri.equalsIgnoreCase(Uris.RDFS_SUBCLASS_URI)){
 					newLink = new SubClassLink(id);
-				else
+				}else{
 					newLink = new ObjectPropertyLink(id, label);
+				}
 				
 				tree.addEdge(link.getTarget(), link.getSource(), newLink);
 				tree.removeEdge(link);
@@ -756,8 +812,9 @@ public class Approach1 {
 	private static void testApproach() throws IOException {
 		
 		List<ServiceModel1> serviceModels = ModelReader1.importServiceModels();
-		for (ServiceModel1 sm : serviceModels)
+		for (ServiceModel1 sm : serviceModels){
 			sm.computeMatchedSubGraphs(1);
+		}
 
 		List<ServiceModel1> trainingData = new ArrayList<ServiceModel1>();
 		
@@ -782,7 +839,9 @@ public class Approach1 {
 			logger.info("======================================================");
 			
 			for (int j = 0; j < serviceModels.size(); j++) {
-				if (j != inputModelIndex) trainingData.add(serviceModels.get(j));
+				if (j != inputModelIndex){
+					trainingData.add(serviceModels.get(j));
+				}
 			}
 			
 			DirectedWeightedMultigraph<Node, Link> inputModel = sm.getModels().get(0);

--- a/src/main/java/edu/isi/karma/modeling/research/experiment1/ModelReader1.java
+++ b/src/main/java/edu/isi/karma/modeling/research/experiment1/ModelReader1.java
@@ -140,60 +140,65 @@ public class ModelReader1 {
 		
 		int count = 1;
 		
-		if (modelExamples != null)
-		for (File f : modelExamples) {
+		if (modelExamples != null){
+			for (File f : modelExamples) {
 
-			matcher = fileNamePattern.matcher(f.getName());
-			if (!matcher.find()) {
-				continue;
-			}
-
-			ServiceModel1 serviceModel = new ServiceModel1("S" + String.valueOf(count));
-			
-			LineNumberReader lr = new LineNumberReader(new FileReader(f));
-			String curLine = "";
-			while ((curLine = lr.readLine()) != null) {
-				
-				matcher = serviceNamePattern.matcher(curLine);
-				if (matcher.find()) {
-					serviceModel.setServiceDescription(curLine.trim());
-					serviceModel.setServiceNameWithPrefix(f.getName().replaceAll(".txt", ""));
-					serviceName = matcher.group(2).trim();
-					serviceModel.setServiceName(serviceName);
-//					System.out.println(serviceName);
-				}
-				
-				if (!curLine.trim().startsWith("<N3>"))
+				matcher = fileNamePattern.matcher(f.getName());
+				if (!matcher.find()) {
 					continue;
+				}
+
+				ServiceModel1 serviceModel = new ServiceModel1("S" + String.valueOf(count));
 				
-				List<Statement> statements = new ArrayList<Statement>();
+				LineNumberReader lr = new LineNumberReader(new FileReader(f));
+				String curLine = "";
 				while ((curLine = lr.readLine()) != null) {
-					if (curLine.trim().startsWith("</N3>"))
-						break;
-//					System.out.println(curLine);
 					
-					String[] parts = curLine.trim().split("\\s+");
-					if (parts == null || parts.length < 3) {
-						System.out.println("Cannot extract statement from \"" + curLine + " \"");
+					matcher = serviceNamePattern.matcher(curLine);
+					if (matcher.find()) {
+						serviceModel.setServiceDescription(curLine.trim());
+						serviceModel.setServiceNameWithPrefix(f.getName().replaceAll(".txt", ""));
+						serviceName = matcher.group(2).trim();
+						serviceModel.setServiceName(serviceName);
+//					System.out.println(serviceName);
+					}
+					
+					if (!curLine.trim().startsWith("<N3>")){
 						continue;
 					}
 					
-					subject = parts[0].trim();
-					predicate = parts[1].trim();
-					object = parts[2].trim();
-					Statement st = new Statement(subject, predicate, object);
-					statements.add(st);
+					List<Statement> statements = new ArrayList<Statement>();
+					while ((curLine = lr.readLine()) != null) {
+						if (curLine.trim().startsWith("</N3>"))
+						 {
+							break;
+//					System.out.println(curLine);
+						}
+						
+						String[] parts = curLine.trim().split("\\s+");
+						if (parts == null || parts.length < 3) {
+							System.out.println("Cannot extract statement from \"" + curLine + " \"");
+							continue;
+						}
+						
+						subject = parts[0].trim();
+						predicate = parts[1].trim();
+						object = parts[2].trim();
+						Statement st = new Statement(subject, predicate, object);
+						statements.add(st);
+					}
+					
+					DirectedWeightedMultigraph<Node, Link> graph = buildGraphsFromStatements2(statements);
+					if (graph != null){
+						serviceModel.addModel(graph);
+					}
+				
 				}
 				
-				DirectedWeightedMultigraph<Node, Link> graph = buildGraphsFromStatements2(statements);
-				if (graph != null)
-					serviceModel.addModel(graph);
-			
+				lr.close();
+				serviceModels.add(serviceModel);
+				count++;
 			}
-			
-			lr.close();
-			serviceModels.add(serviceModel);
-			count++;
 		}
 		
 		return serviceModels;
@@ -254,8 +259,9 @@ public class ModelReader1 {
 		DirectedWeightedMultigraph<Node, Link> graph = 
 				new DirectedWeightedMultigraph<Node, Link>(Link.class);
 		
-		if (statements == null || statements.size() == 0)
+		if (statements == null || statements.size() == 0){
 			return null;
+		}
 		
 		// Assumption: there is only one rdf:type for each URI
 		HashMap<String, Node> uri2Classes = new HashMap<String, Node>();
@@ -288,8 +294,9 @@ public class ModelReader1 {
 			predicateStr = getUri(predicateStr);
 			objStr = getUri(objStr);
 
-			if (predicateStr.equalsIgnoreCase(typePredicate)) 
+			if (predicateStr.equalsIgnoreCase(typePredicate)){
 				continue;
+			}
 			
 			Node subj = uri2Classes.get(subjStr);
 			if (subj == null) {
@@ -299,12 +306,13 @@ public class ModelReader1 {
 
 			Node obj = uri2Classes.get(objStr);
 			if (obj == null) {
-				if (objStr.startsWith(attPrefix))
+				if (objStr.startsWith(attPrefix)){
 					obj = new ColumnNode(objStr, null, null, "");
-				else if (objStr.indexOf(":") == -1 && objStr.indexOf("\"") != -1)
+				}else if (objStr.indexOf(":") == -1 && objStr.indexOf("\"") != -1){
 					obj = new LiteralNode(objStr, objStr, null);
-				else
+				}else{
 					obj = new InternalNode(objStr, new Label(objStr));
+				}
 				
 				graph.addVertex(obj);
 			}

--- a/src/main/java/edu/isi/karma/modeling/research/experiment1/SemanticLabel1.java
+++ b/src/main/java/edu/isi/karma/modeling/research/experiment1/SemanticLabel1.java
@@ -59,22 +59,40 @@ public class SemanticLabel1 implements Comparable<SemanticLabel1>{
 
 	@Override
 	public int compareTo(SemanticLabel1 sl) {
-		if (this.nodeLabel == null || sl.getNodeLabel() == null) return 1;
-		if (this.nodeLabel.getUri() == null || sl.getNodeLabel().getUri() == null) return 1;
+		if (this.nodeLabel == null || sl.getNodeLabel() == null){
+			return 1;
+		}
+		if (this.nodeLabel.getUri() == null || sl.getNodeLabel().getUri() == null){
+			return 1;
+		}
 		if (this.nodeLabel.getUri().equalsIgnoreCase(sl.getNodeLabel().getUri ())) {
-			if (this.linkLabel == null && sl.getLinkLabel() == null) return 0;
-			if (this.linkLabel == null || sl.getLinkLabel() == null) return 1;
-			if (this.linkLabel.getUri() == null || sl.getLinkLabel().getUri() == null) return 1;
-			if (this.linkLabel.getUri().equalsIgnoreCase(sl.getLinkLabel().getUri ())) return 0;
+			if (this.linkLabel == null && sl.getLinkLabel() == null){
+				return 0;
+			}
+			if (this.linkLabel == null || sl.getLinkLabel() == null){
+				return 1;
+			}
+			if (this.linkLabel.getUri() == null || sl.getLinkLabel().getUri() == null){
+				return 1;
+			}
+			if (this.linkLabel.getUri().equalsIgnoreCase(sl.getLinkLabel().getUri ())){
+				return 0;
+			}
 		}
 		return 1;
 	}
 
 	public void print() {
 		String s = "";
-		if (this.nodeLabel != null && this.nodeLabel.getUri() != null) s += this.nodeLabel.getUri();
-		if (this.linkLabel != null && this.linkLabel.getUri() != null) s += " --- " + this.linkLabel.getUri();
-		if (this.leafName != null)  s += " --- " + this.leafName;
+		if (this.nodeLabel != null && this.nodeLabel.getUri() != null){
+			s += this.nodeLabel.getUri();
+		}
+		if (this.linkLabel != null && this.linkLabel.getUri() != null){
+			s += " --- " + this.linkLabel.getUri();
+		}
+		if (this.leafName != null){
+			s += " --- " + this.leafName;
+		}
 		logger.info(s);
 	}
 

--- a/src/main/java/edu/isi/karma/modeling/research/experiment1/ServiceModel1.java
+++ b/src/main/java/edu/isi/karma/modeling/research/experiment1/ServiceModel1.java
@@ -112,8 +112,9 @@ public class ServiceModel1 {
 	public void print() {
 		System.out.println(this.getServiceName());
 		System.out.println();
-		for (DirectedWeightedMultigraph<Node, Link> g : this.getModels())
-				GraphUtil.printGraphSimple(g);
+		for (DirectedWeightedMultigraph<Node, Link> g : this.getModels()){
+			GraphUtil.printGraphSimple(g);
+		}
 		System.out.println();
 		
 		List<String> sortedKeys = Arrays.asList(shortestPathsBetweenTwoAttributes.keySet().toArray(new String[0]));
@@ -127,8 +128,9 @@ public class ServiceModel1 {
 				
 				List<Link> pathEdges = path.getPathEdgeList();
 				lastNodeId = ""; nextId = ""; currentId = "";
-				if (pathEdges == null)
+				if (pathEdges == null){
 					continue;
+				}
 				for (int i = 0; i < pathEdges.size(); i++) {
 					
 					Link e = pathEdges.get(i);
@@ -240,7 +242,9 @@ public class ServiceModel1 {
 	
 	public void exportMatchedSubGraphToGraphviz(String exportDirectory) throws FileNotFoundException {
 		
-		if (this.matchedSubGraphs == null) return;
+		if (this.matchedSubGraphs == null){
+			return;
+		}
 		
 		OutputStream out = new FileOutputStream(exportDirectory + this.getServiceNameWithPrefix() + "_subgraphs.dot");
 		org.kohsuke.graphviz.Graph graphViz = new org.kohsuke.graphviz.Graph();

--- a/src/main/java/edu/isi/karma/modeling/research/experiment2/Approach2.java
+++ b/src/main/java/edu/isi/karma/modeling/research/experiment2/Approach2.java
@@ -114,47 +114,49 @@ public class Approach2 {
 //			double factor = 0.01;
 			int c = this.count;
 			
-			if (type == 1)
+			if (type == 1){
 				w = ModelingParams.PROPERTY_DIRECT_WEIGHT - ((c) / ModelingParams.PROPERTY_DIRECT_WEIGHT);
-			else if (type == 2)
+			}else if (type == 2){
 				w = ModelingParams.PROPERTY_DIRECT_WEIGHT - ((c/10) / ModelingParams.PROPERTY_DIRECT_WEIGHT);
-			else if (type == 3)
+			}else if (type == 3){
 				w = ModelingParams.PROPERTY_DIRECT_WEIGHT - ((c/10) / ModelingParams.PROPERTY_DIRECT_WEIGHT);
-			else if (type == 4)
+			}else if (type == 4){
 				w = ModelingParams.PROPERTY_DIRECT_WEIGHT - ((c/50) / ModelingParams.PROPERTY_DIRECT_WEIGHT);
-			else if (type == 5)
+			}else if (type == 5){
 				w = ModelingParams.PROPERTY_DIRECT_WEIGHT;
-			else if (type == 6)
+			}else if (type == 6){
 				w = ModelingParams.PROPERTY_DIRECT_WEIGHT + 0.01;
-			else if (type == 7)
+			}else if (type == 7){
 				w = ModelingParams.PROPERTY_DIRECT_WEIGHT + 0.02;
-			else if (type == 8)
+			}else if (type == 8){
 				w = ModelingParams.PROPERTY_DIRECT_WEIGHT + 0.03;
-			else if (type == 9)
+			}else if (type == 9){
 				w = ModelingParams.PROPERTY_DIRECT_WEIGHT + 0.04;
-			else if (type == 10)
+			}else if (type == 10){
 				w = ModelingParams.PROPERTY_DIRECT_WEIGHT + 0.05;
+			}
 			return w;
 		}
 		
 		@Override
 		public int compareTo(LinkFrequency o) {
-			if (linkUri == null && o.linkUri != null)
+			if (linkUri == null && o.linkUri != null){
 				return -1;
-			else if (linkUri != null && o.linkUri == null)
+			}else if (linkUri != null && o.linkUri == null){
 				return 1;
-			else if (linkUri == null && o.linkUri == null)
+			}else if (linkUri == null && o.linkUri == null){
 				return 0;
-			else {
-				if (type < o.type)
+			}else {
+				if (type < o.type){
 					return 1;
-				else if (type > o.type)
+				}else if (type > o.type){
 					return -1;
-				else {
-					if (count >= o.count) 
+				}else {
+					if (count >= o.count){
 						return 1;
-					else 
+					}else{
 						return -1;
+					}
 				}
 			}
 		}
@@ -236,7 +238,9 @@ public class Approach2 {
 					for (Link link : inLinks) {
 						Node domain = link.getSource();
 						
-						if (!(domain instanceof InternalNode)) continue;
+						if (!(domain instanceof InternalNode)){
+							continue;
+						}
 						
 						SemanticLabel2 sl = new SemanticLabel2(domain.getLabel().getUri(), link.getLabel().getUri(), n.getId());
 						
@@ -248,14 +252,16 @@ public class Approach2 {
 						labelStructs.add(new LabelStruct((InternalNode)domain, link, (ColumnNode)n));
 					}
 					
-				} else 
+				}else{
 					logger.error("The column node " + n.getId() + " does not have any domain or it has more than one domain.");
+				}
 			}
 		}
 		
 		for (Link l : this.graphBuilder.getGraph().edgeSet()) {
-			if (l.getPatternIds().size() > 0)
+			if (l.getPatternIds().size() > 0){
 				this.patternLinks.add(l);
+			}
 		}
 	}
 
@@ -265,7 +271,9 @@ public class Approach2 {
 		List<SemanticLabel2> SemanticLabel2s = new ArrayList<SemanticLabel2>();
 
 		for (Node n : model.vertexSet()) {
-			if (!(n instanceof ColumnNode) && !(n instanceof LiteralNode)) continue;
+			if (!(n instanceof ColumnNode) && !(n instanceof LiteralNode)){
+				continue;
+			}
 			
 			Set<Link> incomingLinks = model.incomingEdgesOf(n);
 			if (incomingLinks != null) { // && incomingLinks.size() == 1) {
@@ -287,8 +295,9 @@ public class Approach2 {
 		
 		for (ServiceModel2 sm : this.trainingData) {
 			
-			if (sm.getModel() == null) 
+			if (sm.getModel() == null){
 				continue;
+			}
 			
 			patternId = sm.getId();
 			
@@ -309,8 +318,12 @@ public class Approach2 {
 			Set<String> mappedNodes = new HashSet<String>();
 			Set<String> mappedLinks = new HashSet<String>();
 			if (containment.containedIn(mappedNodes, mappedLinks)) {
-				for (String n : mappedNodes) this.graphBuilder.getIdToNodeMap().get(n).getPatternIds().add(patternId);
-				for (String l : mappedLinks) this.graphBuilder.getIdToLinkMap().get(l).getPatternIds().add(patternId);
+				for (String n : mappedNodes){
+					this.graphBuilder.getIdToNodeMap().get(n).getPatternIds().add(patternId);
+				}
+				for (String l : mappedLinks){
+					this.graphBuilder.getIdToLinkMap().get(l).getPatternIds().add(patternId);
+				}
 				return;
 			}
 		}
@@ -327,8 +340,9 @@ public class Approach2 {
 		
 		// adding the patterns to the graph
 		
-		if (pattern == null) 
+		if (pattern == null){
 			return;
+		}
 		
 		visitedNodes = new HashMap<Node, Node>();
 	
@@ -348,7 +362,9 @@ public class Approach2 {
 					if (this.graphBuilder.addNodeWithoutUpdatingGraph(node)) {
 						n1 = node;
 						component.addVertex(node);
-					} else continue;
+					}else{
+						continue;
+					}
 				}
 				else {
 					String id = nodeIdFactory.getNodeId(source.getId());
@@ -356,7 +372,9 @@ public class Approach2 {
 					if (this.graphBuilder.addNodeWithoutUpdatingGraph(node)) {
 						n1 = node;
 						component.addVertex(node);
-					} else continue;
+					}else{
+						continue;
+					}
 				}
 
 				visitedNodes.put(source, n1);
@@ -370,14 +388,18 @@ public class Approach2 {
 					if (this.graphBuilder.addNodeWithoutUpdatingGraph(node)) {
 						n2 = node;
 						component.addVertex(node);
-					} else continue;
+					}else{
+						continue;
+					}
 				}
 				else {
 					ColumnNode node = new ColumnNode(target.getId(), "", "", "");
 					if (this.graphBuilder.addNodeWithoutUpdatingGraph(node)) {
 						n2 = node;
 						component.addVertex(node);
-					} else continue;
+					}else{
+						continue;
+					}
 				}
 
 				visitedNodes.put(target, n2);
@@ -385,10 +407,11 @@ public class Approach2 {
 
 			Link link;
 			String id = LinkIdFactory.getLinkId(e.getLabel().getUri(), n1.getId(), n2.getId());	
-			if (n2 instanceof ColumnNode) 
+			if (n2 instanceof ColumnNode){
 				link = new DataPropertyLink(id, e.getLabel(), false);
-			else 
+			}else{
 				link = new ObjectPropertyLink(id, e.getLabel());
+			}
 			
 			
 			link.getPatternIds().add(patternId);
@@ -398,11 +421,13 @@ public class Approach2 {
 				this.graphBuilder.changeLinkWeight(link, ModelingParams.PATTERN_LINK_WEIGHT);
 			}
 			
-			if (!n1.getPatternIds().contains(patternId))
+			if (!n1.getPatternIds().contains(patternId)){
 				n1.getPatternIds().add(patternId);
+			}
 			
-			if (!n2.getPatternIds().contains(patternId))
+			if (!n2.getPatternIds().contains(patternId)){
 				n2.getPatternIds().add(patternId);
+			}
 
 		}
 		
@@ -427,7 +452,9 @@ public class Approach2 {
 
 			for (Link link : m.edgeSet()) {
 
-				if (link instanceof DataPropertyLink) continue;
+				if (link instanceof DataPropertyLink){
+					continue;
+				}
 				
 				sourceUri = link.getSource().getLabel().getUri();
 				targetUri = link.getTarget().getLabel().getUri();
@@ -435,23 +462,35 @@ public class Approach2 {
 				
 				key = sourceUri + "<" + linkUri + ">" + targetUri;
 				Integer count = this.linkCountMap.get(key);
-				if (count == null) this.linkCountMap.put(key, 1);
-				else this.linkCountMap.put(key, count.intValue() + 1);
+				if (count == null){
+					this.linkCountMap.put(key, 1);
+				}else{
+					this.linkCountMap.put(key, count.intValue() + 1);
+				}
 				
 				key = sourceUri+ "<" + linkUri;
 				count = this.linkCountMap.get(key);
-				if (count == null) this.linkCountMap.put(key, 1);
-				else this.linkCountMap.put(key, count.intValue() + 1);
+				if (count == null){
+					this.linkCountMap.put(key, 1);
+				}else{
+					this.linkCountMap.put(key, count.intValue() + 1);
+				}
 
 				key = linkUri + ">" + targetUri;
 				count = this.linkCountMap.get(key);
-				if (count == null) this.linkCountMap.put(key, 1);
-				else this.linkCountMap.put(key, count.intValue() + 1);
+				if (count == null){
+					this.linkCountMap.put(key, 1);
+				}else{
+					this.linkCountMap.put(key, count.intValue() + 1);
+				}
 
 				key = linkUri;
 				count = this.linkCountMap.get(key);
-				if (count == null) this.linkCountMap.put(key, 1);
-				else this.linkCountMap.put(key, count.intValue() + 1);
+				if (count == null){
+					this.linkCountMap.put(key, 1);
+				}else{
+					this.linkCountMap.put(key, count.intValue() + 1);
+				}
 
 				this.sourceToTargetLinks.put(sourceUri + "---" + targetUri, linkUri);
 			}
@@ -475,8 +514,9 @@ public class Approach2 {
 		String key1, key2;
 		for (Link link : this.graphBuilder.getGraph().edgeSet()) {
 			
-			if (!(link instanceof SimpleLink))
+			if (!(link instanceof SimpleLink)){
 				continue;
+			}
 			
 			key1 = link.getSource().getLabel().getUri() + 
 					link.getTarget().getLabel().getUri();
@@ -514,14 +554,16 @@ public class Approach2 {
 				targets.add(link.getSource());
 				newLinks.add(lf2.linkUri);
 				weights.add(lf2.getWeight());
-			} else
+			}else{
 				continue;
+			}
 			
 			oldLinks.add(link);
 		}
 		
-		for (Link link : oldLinks)
+		for (Link link : oldLinks){
 			this.graphBuilder.getGraph().removeEdge(link);
+		}
 		
 		String id;
 		String uri;
@@ -531,10 +573,11 @@ public class Approach2 {
 			uri = newLinks.get(i);
 			id = LinkIdFactory.getLinkId(uri, sources.get(i).getId(), targets.get(i).getId());
 			label = new Label(uri);
-			if (uri.equalsIgnoreCase(Uris.RDFS_SUBCLASS_URI))
+			if (uri.equalsIgnoreCase(Uris.RDFS_SUBCLASS_URI)){
 				newLink = new SubClassLink(id);
-			else
+			}else{
 				newLink = new ObjectPropertyLink(id, label);
+			}
 			this.graphBuilder.addLink(sources.get(i), targets.get(i), newLink);
 			this.graphBuilder.changeLinkWeight(newLink, weights.get(i));
 		}
@@ -556,9 +599,9 @@ public class Approach2 {
 			
 			if (matchedLabels.containsKey(sl)) {
 				Set<LabelStruct> temp = matchedLabels.get(sl);
-				if (temp.size() == 1)
+				if (temp.size() == 1){
 					createNew = true;
-				else {
+				}else {
 					LabelStruct ll = temp.iterator().next();
 					temp.remove(ll);
 					labelStructs = new HashSet<LabelStruct>();
@@ -625,16 +668,18 @@ public class Approach2 {
 						
 						boolean propertyLinkExists = false;
 						List<Link> linkWithSameUris = this.graphBuilder.getUriToLinksMap().get(sl.getLinkUri());
-						if (linkWithSameUris != null)
-						for (Link l : linkWithSameUris) {
-							if (l.getSource().equals(source)) {
-								propertyLinkExists = true;
-								break;
+						if (linkWithSameUris != null){
+							for (Link l : linkWithSameUris) {
+								if (l.getSource().equals(source)) {
+									propertyLinkExists = true;
+									break;
+								}
 							}
 						}
 						
-						if (propertyLinkExists)
+						if (propertyLinkExists){
 							continue;
+						}
 
 						String nodeId = nodeIdFactory.getNodeId(sl.getLeafName());
 						ColumnNode target = new ColumnNode(nodeId, "", "", "");
@@ -675,16 +720,18 @@ public class Approach2 {
 		Collections.sort(rankedSteinerSets);
 
 
-		if (rankedSteinerSets != null && rankedSteinerSets.size() > MAX_STEINER_NODES_SETS )
+		if (rankedSteinerSets != null && rankedSteinerSets.size() > MAX_STEINER_NODES_SETS ){
 			return rankedSteinerSets.subList(0, MAX_STEINER_NODES_SETS);
+		}
 		
 		return rankedSteinerSets;
 	}
 	
 	private Set<Set<Node>> getSteinerNodeSets(List<Set<LabelStruct>> labelStructSets) {
 
-		if (labelStructSets == null)
+		if (labelStructSets == null){
 			return null;
+		}
 		
 		Set<List<LabelStruct>> labelStructLists = Sets.cartesianProduct(labelStructSets);
 		
@@ -719,8 +766,9 @@ public class Approach2 {
 		
 		List<Link> updatedLinks = new ArrayList<Link>();
 		for (Link l : this.patternLinks) { 
-			if (steinerNodes.contains(l.getSource()) && steinerNodes.contains(l.getTarget()))
+			if (steinerNodes.contains(l.getSource()) && steinerNodes.contains(l.getTarget())){
 				continue;
+			}
 			updatedLinks.add(l);
 		}
 		
@@ -759,8 +807,9 @@ public class Approach2 {
 	private List<RankedModel> rankModels(List<DirectedWeightedMultigraph<Node, Link>> models) {
 		
 		List<RankedModel> rankedModels = new ArrayList<RankedModel>();
-		if (models == null || models.size() == 0)
+		if (models == null || models.size() == 0){
 			return rankedModels;
+		}
 
 		int count = 1;
 		
@@ -779,14 +828,18 @@ public class Approach2 {
 	public List<RankedModel> hypothesize(List<SemanticLabel2> semanticLabels) {
 
 		List<Set<LabelStruct>> labelStructSets = getLabelStructSets(semanticLabels);
-		if (labelStructSets == null || labelStructSets.size() == 0) return null;
+		if (labelStructSets == null || labelStructSets.size() == 0){
+			return null;
+		}
 		
 		for (Set<LabelStruct> labelStructs : labelStructSets) {
 			logger.info("set of " + labelStructs.size() + " label structs.");
 		}
 
 		Set<Set<Node>> steinerNodeSets = getSteinerNodeSets(labelStructSets);
-		if (steinerNodeSets == null || steinerNodeSets.size() == 0) return null;
+		if (steinerNodeSets == null || steinerNodeSets.size() == 0){
+			return null;
+		}
 		
 		logger.info("number of possible steiner nodes sets:" + steinerNodeSets.size());
 		
@@ -822,12 +875,15 @@ public class Approach2 {
 			logger.info("computing steiner tree for steiner nodes set " + count + " ...");
 			DirectedWeightedMultigraph<Node, Link> tree = computeSteinerTree(r.getNodes());
 			count ++;
-			if (tree != null) models.add(tree);
+			if (tree != null){
+				models.add(tree);
+			}
 		}
 		
 		List<RankedModel> rankedModels = rankModels(models);
-		if (rankedModels != null && rankedModels.size() > MAX_CANDIDATES )
+		if (rankedModels != null && rankedModels.size() > MAX_CANDIDATES ){
 			return rankedModels.subList(0, MAX_CANDIDATES);
+		}
 		
 		
 		return rankedModels;
@@ -855,19 +911,28 @@ public class Approach2 {
 		possibleLinksFromSourceToTarget.clear();
 
 		objectPropertiesDirect = ontologyManager.getObjectPropertiesDirect(sourceUri, targetUri);
-		if (objectPropertiesDirect != null) possibleLinksFromSourceToTarget.addAll(objectPropertiesDirect);
+		if (objectPropertiesDirect != null){
+			possibleLinksFromSourceToTarget.addAll(objectPropertiesDirect);
+		}
 
 		objectPropertiesIndirect = ontologyManager.getObjectPropertiesIndirect(sourceUri, targetUri);
-		if (objectPropertiesIndirect != null) possibleLinksFromSourceToTarget.addAll(objectPropertiesIndirect);
+		if (objectPropertiesIndirect != null){
+			possibleLinksFromSourceToTarget.addAll(objectPropertiesIndirect);
+		}
 
 		objectPropertiesWithOnlyDomain = ontologyManager.getObjectPropertiesWithOnlyDomain(sourceUri, targetUri);
-		if (objectPropertiesWithOnlyDomain != null) possibleLinksFromSourceToTarget.addAll(objectPropertiesWithOnlyDomain);
+		if (objectPropertiesWithOnlyDomain != null){
+			possibleLinksFromSourceToTarget.addAll(objectPropertiesWithOnlyDomain);
+		}
 
 		objectPropertiesWithOnlyRange = ontologyManager.getObjectPropertiesWithOnlyRange(sourceUri, targetUri);
-		if (objectPropertiesWithOnlyRange != null) possibleLinksFromSourceToTarget.addAll(objectPropertiesWithOnlyRange);
+		if (objectPropertiesWithOnlyRange != null){
+			possibleLinksFromSourceToTarget.addAll(objectPropertiesWithOnlyRange);
+		}
 
-		if (ontologyManager.isSubClass(sourceUri, targetUri, true)) 
+		if (ontologyManager.isSubClass(sourceUri, targetUri, true)){
 			possibleLinksFromSourceToTarget.add(Uris.RDFS_SUBCLASS_URI);
+		}
 
 		if (objectPropertiesWithoutDomainAndRange != null) {
 			possibleLinksFromSourceToTarget.addAll(objectPropertiesWithoutDomainAndRange.keySet());
@@ -1023,8 +1088,9 @@ public class Approach2 {
 //			int[] trainingModels = {0, 4};
 //			for (int n = 0; n < trainingModels.length; n++) { int j = trainingModels[n];
 			for (int j = 0; j < serviceModels.size(); j++) {
-				if (j != newServiceIndex) 
+				if (j != newServiceIndex){
 					trainingData.add(serviceModels.get(j));
+				}
 			}
 			
 			Approach2 app = new Approach2(trainingData, ontManager);
@@ -1062,7 +1128,7 @@ public class Approach2 {
 			Map<String, DirectedWeightedMultigraph<Node, Link>> graphs = 
 					new TreeMap<String, DirectedWeightedMultigraph<Node,Link>>();
 			
-			if (hypothesisList != null)
+			if (hypothesisList != null){
 				for (int k = 0; k < hypothesisList.size() && k < 3; k++) {
 					
 					RankedModel m = hypothesisList.get(k);
@@ -1070,9 +1136,10 @@ public class Approach2 {
 							graphResultsDir1 + newService.getServiceNameWithPrefix() + ".rank" + (k+1) + ".jgraph");
 					
 				}
+			}
 			
 			graphs.put("1-correct model", correctModel);
-			if (hypothesisList != null)
+			if (hypothesisList != null){
 				for (int k = 0; k < hypothesisList.size(); k++) {
 					
 					RankedModel m = hypothesisList.get(k);
@@ -1089,6 +1156,7 @@ public class Approach2 {
 					
 					graphs.put(label, m.getModel());
 				}
+			}
 			
 			GraphVizUtil.exportJGraphToGraphvizFile(graphs, 
 					newService.getServiceDescription(), 

--- a/src/main/java/edu/isi/karma/modeling/research/experiment2/ComputeGED.java
+++ b/src/main/java/edu/isi/karma/modeling/research/experiment2/ComputeGED.java
@@ -90,7 +90,9 @@ public class ComputeGED {
 				}					
 			}
 			
-			if (gMain == null) continue;
+			if (gMain == null){
+				continue;
+			}
 			String label; double distance;
 			
 			Map<String, DirectedWeightedMultigraph<Node, Link>> graphs = 

--- a/src/main/java/edu/isi/karma/modeling/research/experiment2/PatternContainment.java
+++ b/src/main/java/edu/isi/karma/modeling/research/experiment2/PatternContainment.java
@@ -78,8 +78,9 @@ public class PatternContainment {
 		
 		Set<String> sharedLinks = Sets.intersection(mainLinks.keySet(), newLinks.keySet());
 		for (String key : sharedLinks) {
-			if (mainLinks.get(key).size() != newLinks.get(key).size())
+			if (mainLinks.get(key).size() != newLinks.get(key).size()){
 				return false;
+			}
 		}
 		
 		if (sharedLinks.size() == newLinks.keySet().size()) {

--- a/src/main/java/edu/isi/karma/modeling/research/experiment2/RankedModel.java
+++ b/src/main/java/edu/isi/karma/modeling/research/experiment2/RankedModel.java
@@ -51,18 +51,19 @@ public class RankedModel implements Comparable<RankedModel>{
 		
 		@Override
 		public int compareTo(Coherence c) {
-			if (c == null)
+			if (c == null){
 				return 1;
-			else if (this.linkCount > c.linkCount)
+			}else if (this.linkCount > c.linkCount){
 				return 1;
-			else if (this.linkCount < c.linkCount)
+			}else if (this.linkCount < c.linkCount){
 				return -1;
-			else if (this.patternFrequency > c.patternFrequency)
+			}else if (this.patternFrequency > c.patternFrequency){
 				return 1;
-			else if (this.patternFrequency < c.patternFrequency)
+			}else if (this.patternFrequency < c.patternFrequency){
 				return -1;
-			else
+			}else{
 				return 0;
+			}
 		}
 	}
 	
@@ -93,8 +94,9 @@ public class RankedModel implements Comparable<RankedModel>{
 
 	public String getCoherenceString() {
 		String s = "";
-		for (Coherence c : this.coherence)
+		for (Coherence c : this.coherence){
 			s += "(" + c.linkCount + "," + c.patternFrequency + ")";
+		}
 		return s;
 	}
 	
@@ -148,8 +150,9 @@ public class RankedModel implements Comparable<RankedModel>{
 	
 	private List<Coherence> computeCoherence() {
 		
-		if (model == null || model.edgeSet().size() == 0)
+		if (model == null || model.edgeSet().size() == 0){
 			return null;
+		}
 		  
 		List<Coherence> coherence = new ArrayList<Coherence>();
 
@@ -157,11 +160,12 @@ public class RankedModel implements Comparable<RankedModel>{
 		HashMap<String, HashSet<String>> patternToLinks = new HashMap<String, HashSet<String>>();
 		HashMap<String, Integer> patternToFrequency = new HashMap<String, Integer>();
 		
-		for (Link e : model.edgeSet()) 
+		for (Link e : model.edgeSet()){
 			for (String s : e.getPatternIds()) {
 				
-				if (!patternIds.contains(s))
+				if (!patternIds.contains(s)){
 					patternIds.add(s);
+				}
 				
 				patternToFrequency.put(s, 1);
 				
@@ -172,25 +176,35 @@ public class RankedModel implements Comparable<RankedModel>{
 				}
 				links.add(e.getId());
 			}
+		}
 		
 		int size1, size2, size3;
 		String p1, p2;
 		for (int i = 0; i < patternIds.size() - 1; i++) {
 			p1 = patternIds.get(i);
-			if (!patternToLinks.containsKey(p1)) continue;
+			if (!patternToLinks.containsKey(p1)){
+				continue;
+			}
 			size1 = patternToLinks.get(p1).size();
 			for (int j = i + 1; j < patternIds.size(); j++) {
 				p2 = patternIds.get(j);
-				if (!patternToLinks.containsKey(p1)) continue;
-				if (!patternToLinks.containsKey(p2)) continue;
+				if (!patternToLinks.containsKey(p1)){
+					continue;
+				}
+				if (!patternToLinks.containsKey(p2)){
+					continue;
+				}
 				size2 = patternToLinks.get(p2).size();
 				
 				Set<String> shared = Sets.intersection(patternToLinks.get(p1), patternToLinks.get(p2));
-				if (shared == null) continue;
+				if (shared == null){
+					continue;
+				}
 				
 				size3 = shared.size();
-				if (size3 < size2 && size3 < size1) continue;
-				else if (size3 == size1 && size3 < size2) {
+				if (size3 < size2 && size3 < size1){
+					continue;
+				}else if (size3 == size1 && size3 < size2) {
 					patternToLinks.remove(p1);
 					patternToFrequency.remove(p1);
 				} else if (size3 == size2 && size3 < size1) { 
@@ -266,36 +280,41 @@ public class RankedModel implements Comparable<RankedModel>{
 //	}
 	
 	private int compareCoherence(List<Coherence> c1, List<Coherence> c2) {
-		if (c1 == null || c2 == null)
+		if (c1 == null || c2 == null){
 			return 0;
+		}
 		
 		for (int i = 0; i < c1.size(); i++) {
 			if (i < c2.size()) {
-				if (c1.get(i).compareTo(c2.get(i)) > 0) return 1;
-				else if (c1.get(i).compareTo(c2.get(i)) < 0) return -1;
+				if (c1.get(i).compareTo(c2.get(i)) > 0){
+					return 1;
+				}else if (c1.get(i).compareTo(c2.get(i)) < 0){
+					return -1;
+				}
 			}
 		}
-		if (c1.size() < c2.size())
+		if (c1.size() < c2.size()){
 			return 1;
-		else if (c2.size() < c1.size())
+		}else if (c2.size() < c1.size()){
 			return -1;
-		else
+		}else{
 			return 0;
+		}
 	}
 	
 	@Override
 	public int compareTo(RankedModel m) {
 		
 		int k = compareCoherence(this.coherence, m.coherence);
-		if (k > 0)
+		if (k > 0){
 			return -1;
-		else if (k < 0)
+		}else if (k < 0){
 			return 1;
-		else if (this.cost < m.cost)
+		}else if (this.cost < m.cost){
 			return -1;
-		else if (m.cost < this.cost)
+		}else if (m.cost < this.cost){
 			return 1;
-		else {
+		}else {
 			return 0;
 		}
 	}

--- a/src/main/java/edu/isi/karma/modeling/research/experiment2/RankedSteinerSet.java
+++ b/src/main/java/edu/isi/karma/modeling/research/experiment2/RankedSteinerSet.java
@@ -49,21 +49,25 @@ public class RankedSteinerSet implements Comparable<RankedSteinerSet>{
 
 	public String getCohesionString() {
 		String s = "";
-		for (Integer i : this.cohesion)
+		for (Integer i : this.cohesion){
 			s += String.valueOf(i);
+		}
 		return s;
 	}
 	
 	private List<Integer> computeCohesion() {
 		
-		if (nodes == null)
+		if (nodes == null){
 			return null;
+		}
 		  
 		List<String> patternIds = new ArrayList<String>();
 		
-		for (Node n : nodes) 
-			for (String s : n.getPatternIds())
+		for (Node n : nodes){
+			for (String s : n.getPatternIds()){
 				patternIds.add(s);
+			}
+		}
 		
 		Function<String, String> stringEqualiy = new Function<String, String>() {
 		  @Override public String apply(final String s) {
@@ -86,21 +90,26 @@ public class RankedSteinerSet implements Comparable<RankedSteinerSet>{
 	}
 
 	private int compareCohesions(List<Integer> c1, List<Integer> c2) {
-		if (c1 == null || c2 == null)
+		if (c1 == null || c2 == null){
 			return 0;
+		}
 		
 		for (int i = 0; i < c1.size(); i++) {
 			if (i < c2.size()) {
-				if (c1.get(i) > c2.get(i)) return 1;
-				else if (c1.get(i) < c2.get(i)) return -1;
+				if (c1.get(i) > c2.get(i)){
+					return 1;
+				}else if (c1.get(i) < c2.get(i)){
+					return -1;
+				}
 			}
 		}
-		if (c1.size() < c2.size())
+		if (c1.size() < c2.size()){
 			return 1;
-		else if (c2.size() < c1.size())
+		}else if (c2.size() < c1.size()){
 			return -1;
-		else
+		}else{
 			return 0;
+		}
 	}
 	
 	@Override
@@ -109,12 +118,13 @@ public class RankedSteinerSet implements Comparable<RankedSteinerSet>{
 		int size1 = this.nodes == null ? 0 : this.nodes.size();
 		int size2 = s.getNodes() == null ? 0 : s.getNodes().size();
 		
-		if (size1 < size2)
+		if (size1 < size2){
 			return -1;
-		else if (size1 > size2)
+		}else if (size1 > size2){
 			return 1;
-		else
+		}else{
 			return -compareCohesions(this.cohesion, s.cohesion);
+		}
 		}
 	
 }

--- a/src/main/java/edu/isi/karma/modeling/research/experiment2/SemanticLabel2.java
+++ b/src/main/java/edu/isi/karma/modeling/research/experiment2/SemanticLabel2.java
@@ -53,8 +53,12 @@ public class SemanticLabel2{
 	
 	public void print() {
 		String s = "";
-		if (this.nodeUri != null) s += this.nodeUri;
-		if (this.linkUri != null) s += this.linkUri;
+		if (this.nodeUri != null){
+			s += this.nodeUri;
+		}
+		if (this.linkUri != null){
+			s += this.linkUri;
+		}
 		logger.info(s);
 	}
 
@@ -71,23 +75,30 @@ public class SemanticLabel2{
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj)
+		if (this == obj){
 			return true;
-		if (obj == null)
+		}
+		if (obj == null){
 			return false;
-		if (getClass() != obj.getClass())
+		}
+		if (getClass() != obj.getClass()){
 			return false;
+		}
 		SemanticLabel2 other = (SemanticLabel2) obj;
 		if (linkUri == null) {
-			if (other.linkUri != null)
+			if (other.linkUri != null){
 				return false;
-		} else if (!linkUri.equalsIgnoreCase(other.linkUri))
+			}
+		} else if (!linkUri.equalsIgnoreCase(other.linkUri)){
 			return false;
+		}
 		if (nodeUri == null) {
-			if (other.nodeUri != null)
+			if (other.nodeUri != null){
 				return false;
-		} else if (!nodeUri.equalsIgnoreCase(other.nodeUri))
+			}
+		} else if (!nodeUri.equalsIgnoreCase(other.nodeUri)){
 			return false;
+		}
 		return true;
 	}
 

--- a/src/main/java/edu/isi/karma/modeling/research/experiment2/paperFigures.java
+++ b/src/main/java/edu/isi/karma/modeling/research/experiment2/paperFigures.java
@@ -50,8 +50,9 @@ public class paperFigures {
 
 		org.kohsuke.graphviz.Graph gViz = new org.kohsuke.graphviz.Graph();
 
-		if (model == null)
+		if (model == null){
 			return gViz;
+		}
 
 		org.kohsuke.graphviz.Style internalNodeStyle = new org.kohsuke.graphviz.Style();
 //		internalNodeStyle.attr("shape", "circle");
@@ -108,7 +109,10 @@ public class paperFigures {
 			String id = source.getId();
 			String uri = source.getLabel().getUri();
 			String label = (uri == null?id:uri);
-			if (source instanceof ColumnNode) label = "";// ((ColumnNode)source).getColumnName();
+			if (source instanceof ColumnNode)
+			 {
+				label = "";// ((ColumnNode)source).getColumnName();
+			}
 			if (n == null) {
 				n = new org.kohsuke.graphviz.Node();
 				n.attr("label", label);
@@ -118,12 +122,13 @@ public class paperFigures {
 //					gViz.nodeWith(inputNodeStyle);
 //				else if (id.indexOf("att") != -1 && id.indexOf("o") != -1)  // output
 //					gViz.nodeWith(outputNodeStyle);
-				if (source instanceof ColumnNode)  // attribute
+				if (source instanceof ColumnNode){
 					gViz.nodeWith(parameterNodeStyle);
-				else if (source instanceof LiteralNode)  // literal
+				}else if (source instanceof LiteralNode){
 					gViz.nodeWith(literalNodeStyle);
-				else  // internal node
+				}else{
 					gViz.nodeWith(internalNodeStyle);
+				}
 					
 				gViz.node(n);
 			}
@@ -132,7 +137,10 @@ public class paperFigures {
 			id = target.getId();
 			uri = target.getLabel().getUri();
 			label = (uri == null?id:uri);
-			if (target instanceof ColumnNode) label = "";//((ColumnNode)target).getColumnName();
+			if (target instanceof ColumnNode)
+			 {
+				label = "";//((ColumnNode)target).getColumnName();
+			}
 			if (n == null) {
 				n = new org.kohsuke.graphviz.Node();
 				n.attr("label", label);
@@ -142,12 +150,13 @@ public class paperFigures {
 //					gViz.nodeWith(inputNodeStyle);
 //				else if (id.indexOf("att") != -1 && id.indexOf("o") != -1)  // output
 //					gViz.nodeWith(outputNodeStyle);
-				if (target instanceof ColumnNode)  // attribute
+				if (target instanceof ColumnNode){
 					gViz.nodeWith(parameterNodeStyle);
-				else if (target instanceof LiteralNode)  // literal
+				}else if (target instanceof LiteralNode){
 					gViz.nodeWith(literalNodeStyle);
-				else  // internal node
+				}else{
 					gViz.nodeWith(internalNodeStyle);
+				}
 					
 				gViz.node(n);
 			}
@@ -158,15 +167,18 @@ public class paperFigures {
 			
 			label = (uri == null?id:uri);
 			if (e instanceof SubClassLink)
+			 {
 				label = "";//"subClassOf";
+			}
 			edge.attr("label", label);
 			
-			if (e instanceof SubClassLink)
+			if (e instanceof SubClassLink){
 				gViz.edgeWith(subClassLinkStyle);
-			else if (e instanceof DataPropertyLink)
+			}else if (e instanceof DataPropertyLink){
 				gViz.edgeWith(dataPropertyLinkStyle);
-			else
+			}else{
 				gViz.edgeWith(objectPropertyLinkStyle);
+			}
 
 			gViz.edge(edge);
 		}

--- a/src/main/java/edu/isi/karma/modeling/research/graph/konstantinosnedas/HungarianAlgorithm.java
+++ b/src/main/java/edu/isi/karma/modeling/research/graph/konstantinosnedas/HungarianAlgorithm.java
@@ -65,12 +65,15 @@ public class HungarianAlgorithm {
 		int minutes = (int)floor((time%3600)/60);
 		int seconds = (int)round(time%60);
 		
-		if (days > 0)
+		if (days > 0){
 			timeElapsed = Integer.toString(days) + "d:";
-		if (hours > 0)
+		}
+		if (hours > 0){
 			timeElapsed = timeElapsed + Integer.toString(hours) + "h:";
-		if (minutes > 0)
+		}
+		if (minutes > 0){
 			timeElapsed = timeElapsed + Integer.toString(minutes) + "m:";
+		}
 		
 		timeElapsed = timeElapsed + Integer.toString(seconds) + "s";
 		System.out.print("\nTotal time required: " + timeElapsed + "\n\n");

--- a/src/main/java/edu/isi/karma/modeling/research/graphmatching/algorithms/VolgenantJonker.java
+++ b/src/main/java/edu/isi/karma/modeling/research/graphmatching/algorithms/VolgenantJonker.java
@@ -63,8 +63,9 @@ class VolgenantJonker {
 									// augmenting/alternating path.
 
 			// init how many times a row will be assigned in the column reduction.
-			for (i = 0; i < dim; i++)
+			for (i = 0; i < dim; i++){
 				matches[i] = 0;
+			}
 
 			// COLUMN REDUCTION
 			for (j = dim - 1; j >= 0; j--) // reverse order gives better results.
@@ -72,36 +73,43 @@ class VolgenantJonker {
 				// find minimum cost over rows.
 				min = assigncost[0][j];
 				imin = 0;
-				for (i = 1; i < dim; i++)
+				for (i = 1; i < dim; i++){
 					if (assigncost[i][j] < min) {
 						min = assigncost[i][j];
 						imin = i;
 					}
+				}
 				v[j] = min;
 
 				if (++matches[imin] == 1) {
 					// init assignment if minimum row assigned for first time.
 					rowsol[imin] = j;
 					colsol[j] = imin;
-				} else
+				}
+				else {
 					colsol[j] = -1; // row already assigned, column not assigned.
+				}
 			}
 
 			// REDUCTION TRANSFER
-			for (i = 0; i < dim; i++)
-				if (matches[i] == 0) // fill list of unassigned 'free' rows.
+			for (i = 0; i < dim; i++){
+				if (matches[i] == 0){
 					free[numfree++] = i;
-				else if (matches[i] == 1) // transfer reduction from rows that are
+				}else if (matches[i] == 1) // transfer reduction from rows that are
 											// assigned once.
 				{
 					j1 = rowsol[i];
 					min = BIG;
-					for (j = 0; j < dim; j++)
-						if (j != j1)
-							if (assigncost[i][j] - v[j] < min)
+					for (j = 0; j < dim; j++){
+						if (j != j1){
+							if (assigncost[i][j] - v[j] < min){
 								min = assigncost[i][j] - v[j];
+							}
+						}
+					}
 					v[j1] = v[j1] - min;
 				}
+			}
 
 			// AUGMENTING ROW REDUCTION
 			int loopcnt = 0; // do-loop to be done twice.
@@ -125,7 +133,7 @@ class VolgenantJonker {
 					usubmin = BIG;
 					for (j = 1; j < dim; j++) {
 						h = assigncost[i][j] - v[j];
-						if (h < usubmin)
+						if (h < usubmin){
 							if (h >= umin) {
 								usubmin = h;
 								j2 = j;
@@ -135,15 +143,16 @@ class VolgenantJonker {
 								j2 = j1;
 								j1 = j;
 							}
+						}
 					}
 
 					i0 = colsol[j1];
-					if (umin < usubmin)
+					if (umin < usubmin){
 						// change the reduction of the minimum column to increase
 						// the minimum
 						// reduced cost in the row to the subminimum.
 						v[j1] = v[j1] - (usubmin - umin);
-					else // minimum and subminimum equal.
+					}else // minimum and subminimum equal.
 					if (i0 >= 0) // minimum column j1 is assigned.
 					{
 						// swap columns j1 and j2, as j2 may be unassigned.
@@ -155,18 +164,20 @@ class VolgenantJonker {
 					rowsol[i] = j1;
 					colsol[j1] = i;
 
-					if (i0 >= 0) // minimum column j1 assigned earlier.
+					if (i0 >= 0){
 						/*
 						 * BUGFIX: Endless Loop (Fankhauser), right side after && added
 						 */
-						if ((umin < usubmin) && ((umin-usubmin)>2*Float.MIN_VALUE))
+						if ((umin < usubmin) && ((umin-usubmin)>2*Float.MIN_VALUE)){
 							// put in current k, and go back to that k.
 							// continue augmenting path i - j1 with i0.
 							free[--k] = i0;
-						else
+						}else{
 							// no further augmenting reduction possible.
 							// store i0 in list of free rows for next phase.
 							free[numfree++] = i0;
+						}
+					}
 				}
 			} while (loopcnt < 2); // repeat once.
 
@@ -218,12 +229,13 @@ class VolgenantJonker {
 						// check if any of the minimum columns happens to be
 						// unassigned.
 						// if so, we have an augmenting path right away.
-						for (k = low; k < up; k++)
+						for (k = low; k < up; k++){
 							if (colsol[collist[k]] < 0) {
 								endofpath = collist[k];
 								unassignedfound = true;
 								break;
 							}
+						}
 					}
 
 					if (!unassignedfound) {
@@ -239,8 +251,8 @@ class VolgenantJonker {
 							v2 = assigncost[i][j] - v[j] - h;
 							if (v2 < d[j]) {
 								pred[j] = i;
-								if (v2 == min) // new column found at same minimum
-												// value
+								if (v2 == min){
+									// value
 									if (colsol[j] < 0) {
 										// if unassigned, shortest augmenting path
 										// is complete.
@@ -253,6 +265,7 @@ class VolgenantJonker {
 										collist[k] = collist[up];
 										collist[up++] = j;
 									}
+								}
 								d[j] = v2;
 							}
 						}

--- a/src/main/java/edu/isi/karma/modeling/semantictypes/CRFColumnModel.java
+++ b/src/main/java/edu/isi/karma/modeling/semantictypes/CRFColumnModel.java
@@ -93,8 +93,9 @@ public class CRFColumnModel implements Jsonizable {
 			if(label.contains("|")){
 				Label domainURI = ontMgr.getUriLabel(label.split("\\|")[0]);
 				Label typeURI = ontMgr.getUriLabel(label.split("\\|")[1]);
-				if(domainURI == null || typeURI == null)
+				if(domainURI == null || typeURI == null){
 					continue;
+				}
 				
 				String clazzLocalNameWithPrefix = domainURI.getDisplayName();
 				
@@ -109,24 +110,28 @@ public class CRFColumnModel implements Jsonizable {
 						if (steinerTreeNodeIds.contains(domainURI.getUri() + (graphLastIndex))) {
 							insertSemanticTypeSuggestion(arr, clazzLocalNameWithPrefix + i, domainURI.getUri() + i, 
 									typeURI.getDisplayName(), label.split("\\|")[1], probability);
-							if (i == graphLastIndex)
+							if (i == graphLastIndex){
 								hasLastNodeFromSteinerTree = true;
+							}
 						} else {
 							Node graphNode = alignment.getNodeById(domainURI.getUri() + i);
-							if (graphNode != null)
+							if (graphNode != null){
 								insertSemanticTypeSuggestion(arr, clazzLocalNameWithPrefix + i + " (add)", graphNode.getId(), 
 									typeURI.getDisplayName(), label.split("\\|")[1], probability);
+							}
 						}
 					}
 					// Add an option to add one more node for the domain
-					if (hasLastNodeFromSteinerTree)
+					if (hasLastNodeFromSteinerTree){
 						insertSemanticTypeSuggestion(arr, clazzLocalNameWithPrefix + (graphLastIndex+1) + " (add)", domainURI.getUri(), 
 							typeURI.getDisplayName(), label.split("\\|")[1], probability);
+					}
 				}
 			} else {
 				Label typeURI = ontMgr.getUriLabel(label);
-				if(typeURI == null)
+				if(typeURI == null){
 					continue;
+				}
 				
 				String clazzLocalNameWithPrefix = typeURI.getDisplayName();
 				
@@ -140,13 +145,15 @@ public class CRFColumnModel implements Jsonizable {
 							insertSemanticTypeSuggestion(arr, "", "", clazzLocalNameWithPrefix + i, typeURI.getUri() + i, probability);
 						} else {
 							Node graphNode = alignment.getNodeById(typeURI.getUri() + i);
-							if (graphNode != null)
+							if (graphNode != null){
 								insertSemanticTypeSuggestion(arr, "", "", clazzLocalNameWithPrefix + i + " (add)", graphNode.getId(), probability);
+							}
 						}
 					}
 					// Add an option to add one more node for the domain
-					if (hasLastNodeFromSteinerTree)
+					if (hasLastNodeFromSteinerTree){
 						insertSemanticTypeSuggestion(arr, "", "", clazzLocalNameWithPrefix + (graphLastIndex+1) + " (add)", typeURI.getUri(), probability);
+					}
 				}
 			}
 		}

--- a/src/main/java/edu/isi/karma/modeling/semantictypes/SemanticTypeUtil.java
+++ b/src/main/java/edu/isi/karma/modeling/semantictypes/SemanticTypeUtil.java
@@ -83,8 +83,9 @@ public class SemanticTypeUtil {
 		ArrayList<String> nodeValues = new ArrayList<String>();
 		for (Node n : nodes) {
 			String nodeValue = n.getValue().asString();
-			if (nodeValue != null && !nodeValue.equals(""))
+			if (nodeValue != null && !nodeValue.equals("")){
 				nodeValues.add(nodeValue);
+			}
 		}
 
 		// Shuffling the values so that we get randomly chosen values to train
@@ -93,8 +94,9 @@ public class SemanticTypeUtil {
 		if (nodeValues.size() > TRAINING_EXAMPLE_MAX_COUNT) {
 			ArrayList<String> subset = new ArrayList<String>();
 			// SubList method of ArrayList causes ClassCast exception
-			for (int i = 0; i < TRAINING_EXAMPLE_MAX_COUNT; i++)
+			for (int i = 0; i < TRAINING_EXAMPLE_MAX_COUNT; i++){
 				subset.add(nodeValues.get(i));
+			}
 			return subset;
 		}
 		return nodeValues;
@@ -131,8 +133,9 @@ public class SemanticTypeUtil {
 			boolean semanticTypeAdded = false;
 			ArrayList<String> trainingExamples = getTrainingExamples(worksheet,
 					path);
-			if (trainingExamples.size() == 0)
+			if (trainingExamples.size() == 0){
 				continue;
+			}
 
 			Map<ColumnFeature, Collection<String>> columnFeatures = new HashMap<ColumnFeature, Collection<String>>();
 
@@ -182,8 +185,9 @@ public class SemanticTypeUtil {
 				continue;
 			}
 			Label domainURI = null;
-			if (!domain.equals(""))
+			if (!domain.equals("")){
 				domainURI = ontMgr.getUriLabel(domain);
+			}
 			SemanticType semtype = new SemanticType(path.getLeaf().getId(),typeURI, domainURI, SemanticType.Origin.CRFModel,scores.get(0), false);
 
 			// Check if the user already provided a semantic type manually
@@ -204,8 +208,9 @@ public class SemanticTypeUtil {
 					// older one
 					if (!existingType.getType().equals(semtype.getType())
 							|| !existingType.getDomain().equals(
-									semtype.getDomain()))
+									semtype.getDomain())){
 						semanticTypesChangedOrAdded = true;
+					}
 				}
 			}
 
@@ -305,10 +310,11 @@ public class SemanticTypeUtil {
 	 * @return URI string with namespace removed
 	 */
 	public static String removeNamespace(String uri) {
-		if (uri.contains("#"))
+		if (uri.contains("#")){
 			uri = uri.split("#")[1];
-		else if (uri.contains("/"))
+		}else if (uri.contains("/")){
 			uri = uri.substring(uri.lastIndexOf("/") + 1);
+		}
 		return uri;
 	}
 
@@ -394,14 +400,17 @@ public class SemanticTypeUtil {
 	private static boolean existsInSemanticTypesCollection(Label typeLabel, Label domainLabel, SemanticType existingSemanticType) {
 		if (typeLabel.getUri().equals(existingSemanticType.getType().getUri())) {
 			if (domainLabel == null) {
-				if(existingSemanticType.getDomain() == null)
+				if(existingSemanticType.getDomain() == null){
 					return true;
+				}
 				return false;
 			}
-			if (existingSemanticType.getDomain() == null)
+			if (existingSemanticType.getDomain() == null){
 				return false;
-			if (existingSemanticType.getDomain().getUri().equals(domainLabel.getUri()))
+			}
+			if (existingSemanticType.getDomain().getUri().equals(domainLabel.getUri())){
 				return true;
+			}
 			return false;
 		}
 		return false;

--- a/src/main/java/edu/isi/karma/modeling/semantictypes/mycrf/math/LargeNumber.java
+++ b/src/main/java/edu/isi/karma/modeling/semantictypes/mycrf/math/LargeNumber.java
@@ -81,17 +81,19 @@ public class LargeNumber {
 		double m ;
 		int e ;
 
-		if(n1.mantissa == 0.0)
+		if(n1.mantissa == 0.0){
 			return n2 ;
-		else if(n2.mantissa == 0.0)
+		}else if(n2.mantissa == 0.0){
 			return n1 ;
+		}
 
 		if(Math.abs(n1.exp - n2.exp) > 300 && n1.mantissa != 0.0 && n2.mantissa != 0.0) {
 			//Prn.prn("The difference between the exponentials is more than 300. n1 = " + n1 + " and n2 = " + n2) ;
-			if(n1.exp > n2.exp)
+			if(n1.exp > n2.exp){
 				return n1 ;
-			else
+			}else{
 				return n2 ;
+			}
 		}
 
 		if(n1.exp > n2.exp) {
@@ -180,9 +182,9 @@ public class LargeNumber {
 	static public double divide(LargeNumber ln1, LargeNumber ln2) {
 		double m = ln1.mantissa / ln2.mantissa ;
 		int e = ln1.exp - ln2.exp ;
-		if(e <= -300)
+		if(e <= -300){
 			return 0.0 ;
-		else {
+		}else {
 			double d = m * Math.pow(10, e) ;
 			return d ;
 		}
@@ -196,8 +198,9 @@ public class LargeNumber {
 	}
 
 	static public double log(LargeNumber ln) {
-		if(ln.mantissa == 0.0)
+		if(ln.mantissa == 0.0){
 			Prnt.endIt("Zero passed to LargeNumber.log") ;
+		}
 
 		double log = Math.log(ln.mantissa) + ln.exp * Math.log(10) ;
 		return log ;
@@ -206,16 +209,18 @@ public class LargeNumber {
 	static public double log10(LargeNumber ln) {
 		double value = 0.0 ;
 		
-		if(ln.mantissa < 0)
+		if(ln.mantissa < 0){
 			Prnt.endIt("Attemping to take log10 of a negative number. Quiting.") ;
+		}
 		
 		value = Math.log10(ln.mantissa) + ln.exp ;
 		return value ;
 	}
 	
 	private void normalize() {
-		if(mantissa >= 1.0 && mantissa < 10.0)
+		if(mantissa >= 1.0 && mantissa < 10.0){
 			return ;
+		}
 
 		double exp_of_mantissa = Math.log10(mantissa) ;
 		double floor_of_exp_of_mantissa = Math.floor(exp_of_mantissa) ;
@@ -232,14 +237,15 @@ public class LargeNumber {
 			setValue(largeNumber2) ;
 			return ;
 		}
-		else if(largeNumber2.mantissa == 0.0)
+		else if(largeNumber2.mantissa == 0.0){
 			return ;
+		}
 
 		if(Math.abs(this.exp - largeNumber2.exp) > 300 && this.mantissa != 0.0 && largeNumber2.mantissa != 0.0) {
 			//Prn.prn("The difference between the exponentials is more than 300. n1 = " + this + " and n2 = " + largeNumber2) ;
-			if(this.exp > largeNumber2.exp)
+			if(this.exp > largeNumber2.exp){
 				return ;
-			else {
+			}else {
 				setValue(largeNumber2) ;
 				return ;
 			}

--- a/src/main/java/edu/isi/karma/modeling/semantictypes/mycrf/math/Matrix.java
+++ b/src/main/java/edu/isi/karma/modeling/semantictypes/mycrf/math/Matrix.java
@@ -98,8 +98,9 @@ public class Matrix {
 	}
 	
 	public Matrix add(Matrix otherMatrix) {
-		if(numOfRows != otherMatrix.numOfRows || numOfCols != otherMatrix.numOfCols)
+		if(numOfRows != otherMatrix.numOfRows || numOfCols != otherMatrix.numOfCols){
 			Prnt.endIt("dims dont match") ;
+		}
 		Matrix resultMatrix = new Matrix(numOfRows, numOfCols) ;
 		for(int row = 0 ; row < numOfRows ; row++) {
 			for(int col = 0 ; col < numOfCols ; col++) {
@@ -110,8 +111,9 @@ public class Matrix {
 	}
 	
 	public Matrix subtract(Matrix otherMatrix) {
-		if(numOfRows != otherMatrix.numOfRows || numOfCols != otherMatrix.numOfCols)
+		if(numOfRows != otherMatrix.numOfRows || numOfCols != otherMatrix.numOfCols){
 			Prnt.endIt("dims dont match") ;
+		}
 		Matrix resultMatrix = new Matrix(numOfRows, numOfCols) ;
 		for(int row = 0 ; row < numOfRows ; row++) {
 			for(int col = 0 ; col < numOfCols ; col++) {
@@ -142,8 +144,9 @@ public class Matrix {
 	}
 	
 	public static double norm(Matrix m) {
-		if(m.numOfCols != 1)
+		if(m.numOfCols != 1){
 			Prnt.endIt("Matrix.norm got a non-vector matrix") ;
+		}
 		double sum = 0.0 ;
 		for(int i = 0 ; i < m.numOfRows ; i++) {
 			sum = sum + m.data[i][0] * m.data[i][0] ;
@@ -153,21 +156,24 @@ public class Matrix {
 	}
 	
 	public static void plusEquals(double[] x, double[] y, double m) {
-		for(int i=0;i<x.length;i++)
+		for(int i=0;i<x.length;i++){
 			x[i] = x[i] + m * y[i] ;
+		}
 	}
 	
 	public static double dotProduct(double[] x, double[] y) {
 		double s = 0.0 ;
-		for(int i=0;i<x.length;i++) 
+		for(int i=0;i<x.length;i++){
 			s+=(x[i] * y[i]) ;
+		}
 		return s ;
 	}
 	
 	public static double norm(double[] x) {
 		double s = 0.0 ;
-		for(int i=0;i<x.length;i++)
+		for(int i=0;i<x.length;i++){
 			s+=(x[i]*x[i]) ;
+		}
 		s = Math.sqrt(s) ;
 		return s ;
 	}

--- a/src/main/java/edu/isi/karma/modeling/semantictypes/mycrf/optimization/BacktrackingLineSearch.java
+++ b/src/main/java/edu/isi/karma/modeling/semantictypes/mycrf/optimization/BacktrackingLineSearch.java
@@ -56,8 +56,9 @@ public class BacktrackingLineSearch {
 		double searchDirNorm = Matrix.norm(searchDir) ;
 		if(searchDirNorm > Constants.BACKTRACKINGLINESEARCH_MAX_STEP) {
 			double ratio = Constants.BACKTRACKINGLINESEARCH_MAX_STEP / searchDirNorm ;
-			for(int i=0; i<dim; i++)
+			for(int i=0; i<dim; i++){
 				searchDir[i]*=ratio ;
+			}
 		}
 		
 		slope = Matrix.dotProduct(gradient, searchDir) ;
@@ -66,8 +67,9 @@ public class BacktrackingLineSearch {
 		double tmp = 0.0 ;
 		for(int i=0; i<dim; i++) {
 			tmp = Math.abs(searchDir[i]/Math.max(Math.abs(currWeights[i]), 1.0)) ;
-			if(tmp > test)
+			if(tmp > test){
 				test = tmp ;
+			}
 		}
 		lammin = Constants.TOLX/test ;
 
@@ -76,8 +78,9 @@ public class BacktrackingLineSearch {
 		while(true) {
 //			Prnt.prn("BacktrackingLineSearch iteration #" + iteration + " and lambda = " + lam1) ;
 			
-			for(int i=0;i<dim;i++) 
-				crfModel.weights[i] = currWeights[i] + lam1 * searchDir[i] ; 
+			for(int i=0;i<dim;i++){
+				crfModel.weights[i] = currWeights[i] + lam1 * searchDir[i] ;
+			} 
 
 			for(GraphInterface graph : globalData.trainingGraphs) {
 				graph.computeGraphPotentialAndZ() ;
@@ -96,19 +99,20 @@ public class BacktrackingLineSearch {
 				double rhs2 = f2 - currError - slope*lam2 ;
 				double a = (rhs1/(lam1 * lam1) - rhs2/(lam2 * lam2)) / (lam1 - lam2) ;
 				double b = ((-rhs1 * lam2 / (lam1 * lam1)) + rhs2 * lam1 / (lam2 * lam2)) / (lam1 - lam2) ;
-				if(a == 0.0)
+				if(a == 0.0){
 					tmplam = -slope / (2.0 * b) ;
-				else {
+				}else {
 					double disc = b*b - 3*a*slope ;
 					if(disc < 0) {
 						Prnt.prn("Returning from Backtracking line search because discriminant is negative") ;
 						Prnt.endIt("in backtrackinglinesearch, disc is less than 0. exiting.") ;
-					}
-					else
+					}else{
 						tmplam = (-b + Math.sqrt(disc))/(3*a) ;
+					}
 				}
-				if(tmplam > 0.5 * lam1)
+				if(tmplam > 0.5 * lam1){
 					tmplam = 0.5 * lam1 ;
+				}
 			}
 
 			if(tmplam < lammin) {       // lambda too small. can't move forward

--- a/src/main/java/edu/isi/karma/modeling/semantictypes/myutils/FileOps.java
+++ b/src/main/java/edu/isi/karma/modeling/semantictypes/myutils/FileOps.java
@@ -45,8 +45,9 @@ public class FileOps {
 		ArrayList<String> fileList = new ArrayList<String>() ;
 		File[] files = new File(folder).listFiles() ;
 		for(File f : files) {
-			if(f.getName().endsWith(qualStr))
+			if(f.getName().endsWith(qualStr)){
 				fileList.add(f.getAbsolutePath()) ;
+			}
 		}
 		return fileList ;
 	}

--- a/src/main/java/edu/isi/karma/modeling/semantictypes/myutils/FileSystemOps.java
+++ b/src/main/java/edu/isi/karma/modeling/semantictypes/myutils/FileSystemOps.java
@@ -44,8 +44,9 @@ public class FileSystemOps {
 		ArrayList<String> fileList = new ArrayList<String>() ;
 		File[] files = new File(folder).listFiles() ;
 		for(File f : files) {
-			if(f.getName().endsWith(qualStr))
+			if(f.getName().endsWith(qualStr)){
 				fileList.add(f.getAbsolutePath()) ;
+			}
 		}
 		return fileList ;
 	}

--- a/src/main/java/edu/isi/karma/modeling/semantictypes/sl/Lexer.java
+++ b/src/main/java/edu/isi/karma/modeling/semantictypes/sl/Lexer.java
@@ -48,8 +48,9 @@ public class Lexer {
 		String tmp_field = "" ;
 		for(int i=0;i<field.length();i++) {
 			char c = field.charAt(i) ;
-			if((int) c == 160)
+			if((int) c == 160){
 				c = ' '	;
+			}
 			tmp_field+=c ;
 		}
 		field = tmp_field ;
@@ -79,30 +80,33 @@ public class Lexer {
 				end_index = matcher.end() ;
 				part_list.add(new Part(field.substring(start_index, end_index), Type.pure_alpha)) ;
 				field = field.substring(end_index).trim() ;
-				if(field.equals(""))
+				if(field.equals("")){
 					break ;
-				else
+				}else{
 					continue ;
+				}
 			}
 			matcher = number.matcher(field) ;          // for pure number 
 			if(matcher.find() && (start_index = matcher.start()) == 0) {
 				end_index = matcher.end() ;
 				part_list.add(new Part(field.substring(start_index, end_index), Type.number)) ;
 				field = field.substring(end_index).trim() ;
-				if(field.equals(""))
+				if(field.equals("")){
 					break ;
-				else
+				}else{
 					continue ;
+				}
 			}
 			matcher = pure_symbol.matcher(field) ;      // for symbol
 			if(matcher.find() && (start_index = matcher.start()) == 0) {
 				end_index = matcher.end() ;
 				part_list.add(new Part(field.substring(start_index, end_index), Type.symbol)) ;
 				field = field.substring(end_index).trim() ;
-				if(field.equals(""))
+				if(field.equals("")){
 					break ;
-				else 
+				}else{
 					continue ;
+				}
 			}
 			Prnt.endIt("Can't tokenize since field part not matching either alpha or numeric or symbol") ;
 		}
@@ -201,27 +205,30 @@ public class Lexer {
 	
 	// this func tells if the given char is an alphabet (caps or lowercase)
 	static boolean isAlpha(char c) {
-		if((c >= 'A' && c <= 'Z') || (c>='a' && c<='z'))
+		if((c >= 'A' && c <= 'Z') || (c>='a' && c<='z')){
 			return true ;
-		else
+		}else{
 			return false ;
+		}
 	}
 	
 	// this func tells if the given char is numeric (0-9)
 	static boolean isNum(char c) {
-		if(c >='0' && c<='9')
+		if(c >='0' && c<='9'){
 			return true ;
-		else 
+		}else{
 			return false ;
+		}
 	}
 
 	// this func tells if the given char is a space
 	static boolean isSpace(char c) {
 		int i = (int) c ;
-		if(i == 32 || i==160) // 160 is also a space. It is interpreted as hard space on web pages to force a space.
+		if(i == 32 || i==160){
 			return true ;
-		else
+		}else{
 			return false ;
+		}
 	}
 	
 	

--- a/src/main/java/edu/isi/karma/modeling/semantictypes/sl/RegexFeatureExtractor.java
+++ b/src/main/java/edu/isi/karma/modeling/semantictypes/sl/RegexFeatureExtractor.java
@@ -38,12 +38,14 @@ public class RegexFeatureExtractor {
 	public static ArrayList<String> getFieldFeatures(String field) {
 		ArrayList<String> feature_list = new ArrayList<String>() ;
 		
-		if(field == null)
+		if(field == null){
 			return feature_list ;
+		}
 		
 		field.trim() ;
-		if(field.equals(""))
+		if(field.equals("")){
 			return feature_list ;
+		}
 		
 		ArrayList<Part> parts = Lexer.tokenizeField(field) ;
 		
@@ -72,17 +74,18 @@ public class RegexFeatureExtractor {
 			
 			boolean all_caps = true ;
 			for(int i=0; i<token.length() ; i++) {
-				if(part.string.charAt(i) >= 'A' && part.string.charAt(i) <= 'Z')
+				if(part.string.charAt(i) >= 'A' && part.string.charAt(i) <= 'Z'){
 					continue ;
-				else {
+				}else {
 					all_caps = false ;
 					break ;
 				}
 			}
-			if(all_caps)
+			if(all_caps){
 				feature_list.add(Feature.all_capitalized_token) ;
-			else if(first_character.charAt(0) >= 'A' && first_character.charAt(0) <= 'Z')
+			}else if(first_character.charAt(0) >= 'A' && first_character.charAt(0) <= 'Z'){
 				feature_list.add(Feature.capitalized_token) ;
+			}
 			
 			feature_list.add(Feature.alpha_id_ + token) ;
 		}
@@ -112,14 +115,17 @@ public class RegexFeatureExtractor {
 			
 			feature_list.add(Feature.after_decimal_len_ + decimal_part.length()) ;
 			
-			if(!first_part.equals("")) 
+			if(!first_part.equals("")){
 				feature_list.add(Feature.starting_digit_ + first_part.substring(0,1)) ;
+			}
 			
-			if(!first_part.equals("")) 
+			if(!first_part.equals("")){
 				feature_list.add(Feature.unit_place_digit_ + first_part.substring(first_part.length()-1)) ;
+			}
 			
-			if(!decimal_part.equals(""))
+			if(!decimal_part.equals("")){
 				feature_list.add(Feature.tenth_place_digit_ + decimal_part.substring(0,1)) ;
+			}
 			
 		}
 		else if(part.type == Type.symbol) {

--- a/src/main/java/edu/isi/karma/rdf/OfflineCSVGenerator.java
+++ b/src/main/java/edu/isi/karma/rdf/OfflineCSVGenerator.java
@@ -55,17 +55,19 @@ public class OfflineCSVGenerator {
      */
     public static void main(String[] args) throws ClassNotFoundException,
 	    IOException, MediatorException, KarmaException {
-	if (args.length < 3)
-	    throw new IllegalArgumentException(
+	if (args.length < 3){
+		throw new IllegalArgumentException(
 		    "Arguments are: <model file> <data file> <output file> <csv delimiter>");
+	}
 
 	String modelFilePath = args[0];
 	String dataFilePath = args[1];
 	String outputFilePath = args[2];
 	char csvDelimiter = '\t';
 	
-	if(args.length==4)
+	if(args.length==4){
 		csvDelimiter = args[3].charAt(0);
+	}
 
 	//System.out.println("CSV Delimiter:" + csvDelimiter);
 	
@@ -96,9 +98,10 @@ public class OfflineCSVGenerator {
 
 	// Load the model into Jena
 	File file = new File(modelFilePath);
-	if (!file.exists())
-	    throw new FileNotFoundException("Model file not found: "
+	if (!file.exists()){
+		throw new FileNotFoundException("Model file not found: "
 		    + file.getAbsolutePath());
+	}
 	Model model = ModelFactory.createDefaultModel();
 	InputStream s = new FileInputStream(file);
 	model.read(s, null, "N3");
@@ -109,8 +112,9 @@ public class OfflineCSVGenerator {
 		"hasSourceDescription");
 	ResIterator itr = model.listResourcesWithProperty(hasSourceDesc);
 	List<Resource> sourceList = itr.toList();
-	if (sourceList.size() == 0)
-	    throw new KarmaException("No source found in the model file.");
+	if (sourceList.size() == 0){
+		throw new KarmaException("No source found in the model file.");
+	}
 	Resource resource = sourceList.get(0);
 	Statement stmt = model.getProperty(resource, hasSourceDesc);
 	String domainStr = stmt.getObject().toString();

--- a/src/main/java/edu/isi/karma/rdf/OfflineDbRdfGenerator.java
+++ b/src/main/java/edu/isi/karma/rdf/OfflineDbRdfGenerator.java
@@ -67,8 +67,9 @@ public class OfflineDbRdfGenerator {
 	 * @param args
 	 */
 	public static void main(String[] args) {
-		if(args.length != 3)
+		if(args.length != 3){
 			throw new IllegalArgumentException("Illegal arguments! Please specify the model file path, the output file path and the database password as arguments.");
+		}
 		
 		OfflineDbRdfGenerator rdfGen = new OfflineDbRdfGenerator(args[0], args[1], args[2]);
 		
@@ -112,8 +113,9 @@ public class OfflineDbRdfGenerator {
 
 	private void loadModelFile() throws IOException {
 		File file = new File(modelFilePath);
-		if(!file.exists())
+		if(!file.exists()){
 			throw new FileNotFoundException("Model file not found. Constructed path: " + file.getAbsolutePath());
+		}
 		
 		jenaModel = ModelFactory.createDefaultModel();
 		InputStream s = new FileInputStream(file);
@@ -129,8 +131,9 @@ public class OfflineDbRdfGenerator {
 		ResIterator itr = jenaModel.listResourcesWithProperty(hasSourceDesc);
 		List<Resource> sourceList = itr.toList();
 		
-		if(sourceList.size() == 0)
+		if(sourceList.size() == 0){
 			throw new KarmaException("No source found in the model file.");
+		}
 		Resource source = sourceList.get(0);
 		
 		/** Loop through the database properties to get the required information **/
@@ -138,8 +141,9 @@ public class OfflineDbRdfGenerator {
 		for (InfoAttribute attr : dbAttributeList) {
 			Property prop = jenaModel.createProperty(Namespaces.KARMA, "hasSourceInfo_" + attr.name());
 			Statement stmt = jenaModel.getProperty(source, prop);
-			if (stmt == null)
+			if (stmt == null){
 				throw new KarmaException("RDF statement for the " + prop.getURI() + " property of source not found!");
+			}
 			
 			if(attr == InfoAttribute.dbType) {
 				dbType = DBType.valueOf(stmt.getString());

--- a/src/main/java/edu/isi/karma/rdf/OfflineRdfGenerator.java
+++ b/src/main/java/edu/isi/karma/rdf/OfflineRdfGenerator.java
@@ -237,8 +237,9 @@ public class OfflineRdfGenerator {
 		Property hasSourceDesc = model.createProperty(Namespaces.KARMA, "hasSourceDescription");
 		ResIterator itr = model.listResourcesWithProperty(hasSourceDesc);
 		List<Resource> sourceList = itr.toList();
-		if (sourceList.size() == 0)
-		    throw new KarmaException("No source found in the model file.");
+		if (sourceList.size() == 0){
+			throw new KarmaException("No source found in the model file.");
+		}
 		Resource resource = sourceList.get(0);
 		Statement stmt = model.getProperty(resource, hasSourceDesc);
 		return stmt.getObject().toString();

--- a/src/main/java/edu/isi/karma/rdf/SourceDescription.java
+++ b/src/main/java/edu/isi/karma/rdf/SourceDescription.java
@@ -195,13 +195,16 @@ public class SourceDescription {
 		this.worksheet=worksheet;
 		
 		//add source prefix
-		if(rdfSourceNamespace==null)
+		if(rdfSourceNamespace==null){
 			rdfSourceNamespace = "http://localhost:8080/";
-		if(rdfSourcePrefix==null)
+		}
+		if(rdfSourcePrefix==null){
 			rdfSourcePrefix = "s";
+		}
 		//add a delimiter if it doesn't exist, otherwise the URIs will not be well formed
-		if(!rdfSourceNamespace.endsWith("/") && !rdfSourceNamespace.endsWith("#"))
+		if(!rdfSourceNamespace.endsWith("/") && !rdfSourceNamespace.endsWith("#")){
 			rdfSourceNamespace += "/";
+		}
 		seenPrefixNamespaceCombination.put(rdfSourcePrefix+ ":"+rdfSourceNamespace,rdfSourcePrefix);
 		assignedPrefixes.add(rdfSourcePrefix);
 		allNamespaces.add(RDFDomainModel.SOURCE_PREFIX + rdfSourcePrefix+ ":'"+rdfSourceNamespace+"'");
@@ -227,13 +230,16 @@ public class SourceDescription {
 		//generate statements for synonym sem types
 		//do this only at the end, so I make sure that I already have all keys computed
 		String stmt = generateSynonymStatements();
-		if(stmt!=null)
+		if(stmt!=null){
 			s.append(stmt);
+		}
 		
 		String rule =  "SourceDescription(";
 		int i=0;
 		for(String attr:ruleAttributes){
-			if(i++>0) rule +=",";
+			if(i++>0){
+				rule +=",";
+			}
 			rule += addBacktick(attr);
 		}
 		rule += ") -> \n" + s.toString();
@@ -267,7 +273,9 @@ public class SourceDescription {
 		}
 		if(v.getType()==NodeType.InternalNode){
 			String stmt = generateClassStatement(v);
-			if(s.length()!=0) s.append(" ^ ");
+			if(s.length()!=0){
+				s.append(" ^ ");
+			}
 			s.append(stmt);
 			Set<Link> edges = steinerTree.outgoingEdgesOf(v);
 			for(Link e:edges){
@@ -400,8 +408,9 @@ public class SourceDescription {
 		}
 		ruleAttributes.add(dataAttribute);
 		String propertyName = "expand@" + propertyAttribute;
-		if (rdfLiteralType != null && !rdfLiteralType.equals(""))
-			propertyName += "@@" + rdfLiteralType; 
+		if (rdfLiteralType != null && !rdfLiteralType.equals("")){
+			propertyName += "@@" + rdfLiteralType;
+		} 
 		if(reversedLinkIds.contains(e.getId())){
 			throw new KarmaException("A data property cannot be an inverse_of:" + e.getLabel().getUri());
 		}
@@ -518,8 +527,9 @@ public class SourceDescription {
 		String propertyName = getPrefix(e.getLabel().getPrefix(), e.getLabel().getNs()) + ":" + e.getLabel().getLocalName();
 
 		String s = "`" + propertyName + "`(uri(" + key1 + "),uri(" + key2 + "))";
-		if(generateInverse)
+		if(generateInverse){
 			s += addInverseProperty(e.getLabel().getUri(), key1,key2);
+		}
 		
 		if(reversedLinkIds.contains(e.getId())){
 			//propertyName = TableRDFGenerator.inverseProperty + propertyName;
@@ -553,14 +563,17 @@ public class SourceDescription {
 				List<SemanticType> semT = synonyms.getSynonyms();
 				for(SemanticType st: semT){
 					String stmt = generateSynonymStatement(child,st);
-					if(stmt!=null)
+					if(stmt!=null){
 						s += "\n ^ " + stmt;
+					}
 				}
 			}
 		}
-		if(s.trim().isEmpty())
+		if(s.trim().isEmpty()){
 			return null;
-		else return s;
+		}else{
+			return s;
+		}
 	}
 
 
@@ -582,10 +595,11 @@ public class SourceDescription {
 			String key = findKey(child);
 			//logger.info("Sem Type is a class:"+st.getType());
 			String className = getPropertyWithPrefix(st.getType());
-			if (rdfLiteralType != null && !rdfLiteralType.equals(""))
+			if (rdfLiteralType != null && !rdfLiteralType.equals("")){
 				s = "`" + className + "@@" + rdfLiteralType + "`(uri(" + key + "))";
-			else
+			}else{
 				s = "`" + className + "`(uri(" + key + "))";
+			}
 			return s;
 		}
 		else{
@@ -615,10 +629,11 @@ public class SourceDescription {
 			}
 			ruleAttributes.add(dataAttribute);
 			String propertyName = getPropertyWithPrefix(st.getType());
-			if (rdfLiteralType != null && !rdfLiteralType.equals(""))
+			if (rdfLiteralType != null && !rdfLiteralType.equals("")){
 				s = "`" + propertyName + "@@" + rdfLiteralType + "`(uri(" + key + ")," + addBacktick(dataAttribute) + ")";
-			else
+			}else{
 				s = "`" + propertyName + "`(uri(" + key + ")," + addBacktick(dataAttribute) + ")";
+			}
 			return s;
 		}
 	}
@@ -639,8 +654,10 @@ public class SourceDescription {
 		
 		//this can happen if propertyName is not an Object property; it could be a subclass
 		if (!ontMgr.isObjectProperty(propertyName))
+		 {
 			return s;
 		//see if this property has an inverse property, and if it does add it to the SD
+		}
 
 		//one or the other will be null
 		Label inversePropLabel = ontMgr.getInverseProperty(propertyName);
@@ -669,8 +686,9 @@ public class SourceDescription {
 	 * @return
 	 */
 	private String getPropertyWithPrefix(Label label){
-		if(label==null)
+		if(label==null){
 			return null;
+		}
 		String namespace = label.getNs();
 		String prefix = label.getPrefix();
 		String propWithPrefix = getPrefix(prefix, namespace) + ":" + label.getLocalName();
@@ -759,7 +777,9 @@ public class SourceDescription {
 				//I have more than 1 key, so I have to construct a concat statement that will be the key
 				key = "";
 				for(int i=0; i<keys.size();i++){
-					if(i>0) key+=",";
+					if(i>0){
+						key+=",";
+					}
 					key += addBacktick(keys.get(i));
 				}
 				isCompoundKey=true;
@@ -775,8 +795,9 @@ public class SourceDescription {
 			ruleAttributes.add(key);
 		}
 		//I have to do it here because I don't want backticks for the gensyms
-		if(!isGensym && !isCompoundKey)
+		if(!isGensym && !isCompoundKey){
 			key = addBacktick(key);
+		}
 		
 		classNameToId.put(v.getLabel().getUri(), v.getId());
 		uriMap.put(v.getId(), key);
@@ -842,17 +863,20 @@ public class SourceDescription {
 				allNamespaces.add(prefix+":'"+namespace+"'");
 				return prefix;
 			}
+		}else{
+			return givenPrefix;
 		}
-		else return givenPrefix;
 
 	}
 
 	private String addBacktick(String s){
 		//this method has to be enhanced to add backtick if we have columns with
 		//"strange" chars
-		if(!useColumnNames)
+		if(!useColumnNames){
 			return MediatorUtil.addBacktick(s);
-		else return s;
+		}else{
+			return s;
+		}
 	}
 	
 }

--- a/src/main/java/edu/isi/karma/rdf/TableRDFGenerator.java
+++ b/src/main/java/edu/isi/karma/rdf/TableRDFGenerator.java
@@ -316,8 +316,9 @@ public class TableRDFGenerator {
 		//see if there are any unary predicates ex: Person(uri(N))
 		Predicate p = findUnaryPredicate(v, preds);
 		if(p!=null){
-			if(!consequent.contains(p))
-				consequent.add(p.clone());				
+			if(!consequent.contains(p)){
+				consequent.add(p.clone());
+			}				
 		}
 		//////////////////
 		
@@ -355,15 +356,16 @@ public class TableRDFGenerator {
 			ArrayList<Predicate> preds, RelationPredicate antecedent,
 			ArrayList<Predicate> consequent) throws MediatorException {
 
-		if(term instanceof VarTerm)
+		if(term instanceof VarTerm){
 			return;
-		else if(term instanceof FunctionTerm){
+		}else if(term instanceof FunctionTerm){
 			//it is a uri();
 			//find the unary predicate for this URI
 			Predicate p2 = findUnaryPredicate(term, preds);
 			//System.out.println("Unary Pred ...="+p2);
-			if(!consequent.contains(p2))
+			if(!consequent.contains(p2)){
 				consequent.add(p2.clone());
+			}
 			if(gensymPredicate(p2)){
 				//if it is a gensym see if you can find other related 
 				ArrayList<Predicate> binaryP = findAllBinaryPredicates(p2.getTerms().get(0),preds);
@@ -435,8 +437,9 @@ public class TableRDFGenerator {
 		for(Predicate p:preds){
 			if(p.getTerms().size()==1){
 				Term t = p.getTerms().get(0);
-				if(t.equals(term))
+				if(t.equals(term)){
 					return p;
+				}
 			}
 		}
 		return null;
@@ -459,8 +462,9 @@ public class TableRDFGenerator {
 				if(t instanceof FunctionTerm){
 					for(Term term: t.getFunction().getTerms()){
 						String var = term.getVar();
-						if(var!=null && var.equals(v))
+						if(var!=null && var.equals(v)){
 							return p;
+						}
 					}
 				}
 			}
@@ -482,8 +486,9 @@ public class TableRDFGenerator {
 			if(p.getTerms().size()==2){
 				//get second term
 				Term t = p.getTerms().get(1);
-				if(t.equals(term))
+				if(t.equals(term)){
 					binaryP.add(p);
+				}
 			}
 		}
 		return binaryP;
@@ -509,14 +514,16 @@ public class TableRDFGenerator {
 				String var=null;
 				if(t instanceof VarTerm){
 					var = t.getVar();
-					if(var.equals(v))
+					if(var.equals(v)){
 						binaryP.add(p);
+					}
 				}
 				else if(t instanceof FunctionTerm){
 					for(Term term: t.getFunction().getTerms()){
 						String termVar = term.getVar();
-						if(termVar!=null && termVar.equals(v))
+						if(termVar!=null && termVar.equals(v)){
 							binaryP.add(p);
+						}
 					}
 				}
 			}
@@ -536,14 +543,16 @@ public class TableRDFGenerator {
 	 */
 	private boolean gensymPredicate(Predicate p){
 		Term t = p.getTerms().get(0);
-		if(!(t instanceof FunctionTerm))
+		if(!(t instanceof FunctionTerm)){
 			return false;
+		}
 		String varName = t.getFunction().getTerms().get(0).getVar();
 		if(varName==null){
 			//it is a gensym
 			return true;
+		}else{
+			return false;
 		}
-		else return false;
 	}
 	
 	/**
@@ -556,9 +565,9 @@ public class TableRDFGenerator {
 	private List<String> getAllVariableNames(Predicate p){
 		List<String> vars = new ArrayList<String>();
 		for(Term t: p.getTerms()){
-			if(t instanceof VarTerm)
+			if(t instanceof VarTerm){
 				vars.add(t.getVar());
-			else if(t instanceof FunctionTerm){
+			}else if(t instanceof FunctionTerm){
 				vars.addAll(t.getFunction().getVars());
 			}
 		}

--- a/src/main/java/edu/isi/karma/rdf/WorksheetRDFGenerator.java
+++ b/src/main/java/edu/isi/karma/rdf/WorksheetRDFGenerator.java
@@ -127,10 +127,11 @@ public class WorksheetRDFGenerator extends TableRDFGenerator{
 		for(Row r:rows){
 			//construct the values map
 			Map<String,String> values;
-			if(useInternalColumnNames)
+			if(useInternalColumnNames){
 				values = getValueMap(r);
-			else
+			}else{
 				values = getValueMapColumnName(r);
+			}
 			logger.debug("Values=" + values);
 			generateTriples(values);
 		}
@@ -162,16 +163,18 @@ public class WorksheetRDFGenerator extends TableRDFGenerator{
 		for(Row r:rows){
 			//construct the values map
 			Map<String,String> values;
-			if(useInternalColumnNames)
+			if(useInternalColumnNames){
 				values = getValueMap(r);
-			else
+			}else{
 				values = getValueMapColumnName(r);
+			}
 			logger.debug("Values=" + values);
 			generateTriples(values);
 		}
 		//all triples written, so close the writer
-		if(!appendToWriter)
+		if(!appendToWriter){
 			closeWriter();
+		}
 	}
 	
 	//used for testing
@@ -224,8 +227,9 @@ public class WorksheetRDFGenerator extends TableRDFGenerator{
 	public void generateTriplesCell(Worksheet w, boolean useInternalColumnNames, boolean appendToWriter) throws MediatorException, IOException, KarmaException{
 		generateTriplesCell(w.getDataTable(), useInternalColumnNames);
 		//all triples written, so close the writer
-		if(!appendToWriter)
-			closeWriter();		
+		if(!appendToWriter){
+			closeWriter();
+		}		
 	}
 	//used for testing; generate only for first 3 rows
 	public void generateTriplesCellLimit(Worksheet w) throws MediatorException, IOException, KarmaException{
@@ -325,11 +329,14 @@ public class WorksheetRDFGenerator extends TableRDFGenerator{
 		String val = n.getValue().asString();
 		//get the column name of this node
 		String columnName = factory.getHNode(n.getHNodeId()).getHNodePath(factory).toColumnNamePath();
-		if(!useInternalColumnNames)
+		if(!useInternalColumnNames){
 			columnName = factory.getHNode(n.getHNodeId()).getColumnName();
+		}
 		//logger.info("Generate triples for node:"+columnName +" with value=" + val);
 		//transform the null to "", so that I can handle it as ""; basically it will not be added as a triple to RDF
-		if(val==null) val="";
+		if(val==null){
+			val="";
+		}
 		values.put(columnName, val);
 		
 		//get other columns used in the RDF rule associated with columnName
@@ -412,8 +419,9 @@ public class WorksheetRDFGenerator extends TableRDFGenerator{
 			//get HNodePtah for this node
 			//logger.info("hnodepath="+factory.getHNode(n.getHNodeId()).getHNodePath(factory));
 			String columnName = factory.getHNode(n.getHNodeId()).getHNodePath(factory).toColumnNamePath();
-			if(!useInternalColumnNames)
+			if(!useInternalColumnNames){
 				columnName = factory.getHNode(n.getHNodeId()).getColumnName();
+			}
 			//logger.info("Path="+nodePath + "col name:" + columnName);
 			//logger.info("Row for this node="+n.getBelongsToRow().hashCode());			
 			if(columnName.equals(nodePath)){
@@ -454,7 +462,9 @@ public class WorksheetRDFGenerator extends TableRDFGenerator{
 			String columnName = factory.getHNode(node.getKey()).getHNodePath(factory).toColumnNamePath();
 			//System.out.println("val for " + columnName + "=" + val + " is it null?" + (val==null));
 			//transform the null to "", so that I can handle it as ""; basically it will not be added as a triple to RDF
-			if(val==null) val="";
+			if(val==null){
+				val="";
+			}
 			values.put(columnName,val);
 		}
 		return values;
@@ -480,7 +490,9 @@ public class WorksheetRDFGenerator extends TableRDFGenerator{
 			String columnName = factory.getHNode(node.getKey()).getColumnName();
 			//System.out.println("val for " + columnName + "=" + val);
 			//transform the null to "", so that I can handle it as ""; basically it will not be added as a triple to RDF
-			if(val==null) val="";
+			if(val==null){
+				val="";
+			}
 			values.put(columnName,val);
 		}
 		return values;

--- a/src/main/java/edu/isi/karma/rep/HTable.java
+++ b/src/main/java/edu/isi/karma/rep/HTable.java
@@ -111,8 +111,9 @@ public class HTable extends RepEntity {
 			return getNewColumnName(prefix.replaceAll(m.group(1), "")); 
 		}
 		for (int i=1; i<1000; i++) {
-			if (isValidNewColumnName(prefix + "_" + i))
+			if (isValidNewColumnName(prefix + "_" + i)){
 				return prefix + "_" + i;
+			}
 		}
 		// Last resort
 		return "New Column";
@@ -120,8 +121,9 @@ public class HTable extends RepEntity {
 	
 	private boolean isValidNewColumnName (String columnName) {
 		for (HNode node:nodes.values()) {
-			if (node.getColumnName().equalsIgnoreCase(columnName))
+			if (node.getColumnName().equalsIgnoreCase(columnName)){
 				return false;
+			}
 		}
 		return true;
 	}
@@ -149,8 +151,9 @@ public class HTable extends RepEntity {
 	 */
 	public boolean hasNestedTables() {
 		for (HNode n : getHNodes()) {
-			if (n.hasNestedTable())
+			if (n.hasNestedTable()){
 				return true;
+			}
 		}
 		return false;
 	}
@@ -208,10 +211,11 @@ public class HTable extends RepEntity {
 			nodes.put(newNode.getId(), newNode);
 			int index = orderedNodeIds.indexOf(hNodeId);
 
-			if (index == orderedNodeIds.size() - 1)
+			if (index == orderedNodeIds.size() - 1){
 				orderedNodeIds.add(newNode.getId());
-			else
+			}else{
 				orderedNodeIds.add(index + 1, newNode.getId());
+			}
 			worksheet.addNodeToDataTable(newNode, factory);
 		}
 	}
@@ -235,11 +239,12 @@ public class HTable extends RepEntity {
 				//node not found; 
 				throw new KarmaException("Node " + hNodeId + " not found in table " + tableName);
 			}
-			else if (index == orderedNodeIds.size() - 1)
+			else if (index == orderedNodeIds.size() - 1){
 				//last node
 				orderedNodeIds.add(hn.getId());
-			else
+			}else{
 				orderedNodeIds.add(index + 1, hn.getId());
+			}
 		}
 		
 		worksheet.addNodeToDataTable(hn, factory);

--- a/src/main/java/edu/isi/karma/rep/Table.java
+++ b/src/main/java/edu/isi/karma/rep/Table.java
@@ -131,8 +131,9 @@ public class Table extends RepEntity {
 		for (Row r : rows) {
 			result.add(r);
 			count++;
-			if (count >= maxNumber)
+			if (count >= maxNumber){
 				return result;
+			}
 		}
 		return result;
 	}
@@ -176,8 +177,9 @@ public class Table extends RepEntity {
 	 *            Collection of nodes that satisfy the path
 	 */
 	public void collectNodes(HNodePath path, Collection<Node> nodes) {
-		if (nodes == null)
+		if (nodes == null){
 			nodes = new ArrayList<Node>();
+		}
 		collectNodes(path, nodes, rows);
 	}
 
@@ -197,14 +199,16 @@ public class Table extends RepEntity {
 					// Check if the node has a nested table
 					if (n.hasNestedTable()) {
 						int numRows = n.getNestedTable().getNumRows();
-						if (numRows == 0)
+						if (numRows == 0){
 							continue RowIterator;
+						}
 
 						List<Row> rowsNestedTable = n.getNestedTable().getRows(
 								0, numRows);
 						if (rowsNestedTable != null
-								&& rowsNestedTable.size() != 0)
+								&& rowsNestedTable.size() != 0){
 							collectNodes(path.getRest(), nodes, rowsNestedTable);
+						}
 					}
 				}
 			}

--- a/src/main/java/edu/isi/karma/rep/Worksheet.java
+++ b/src/main/java/edu/isi/karma/rep/Worksheet.java
@@ -83,8 +83,9 @@ public class Worksheet extends RepEntity {
 	}
 
 	public MetadataContainer getMetadataContainer() {
-		if (metadataContainer == null)
+		if (metadataContainer == null){
 			metadataContainer = new MetadataContainer();
+		}
 		return metadataContainer;
 	}
 
@@ -145,21 +146,25 @@ public class Worksheet extends RepEntity {
 	}
 
 	public boolean containService() {
-		if (this.getMetadataContainer() == null)
+		if (this.getMetadataContainer() == null){
 			return false;
+		}
 
-		if (this.getMetadataContainer().getService() == null)
+		if (this.getMetadataContainer().getService() == null){
 			return false;
+		}
 
 		return true;
 	}
 
 	public boolean containSource() {
-		if (this.getMetadataContainer() == null)
+		if (this.getMetadataContainer() == null){
 			return false;
+		}
 
-		if (this.getMetadataContainer().getSource() == null)
+		if (this.getMetadataContainer().getSource() == null){
 			return false;
+		}
 
 		return true;
 	}

--- a/src/main/java/edu/isi/karma/rep/alignment/Label.java
+++ b/src/main/java/edu/isi/karma/rep/alignment/Label.java
@@ -56,8 +56,9 @@ public class Label implements Serializable {
 	}
 	
 	public Label(Label uri) {
-		if (uri == null) this.init();
-		else {
+		if (uri == null){
+			this.init();
+		}else {
 			this.uri = uri.getUri();
 			this.ns = uri.getNs();
 			this.prefix = uri.getPrefix();
@@ -94,35 +95,40 @@ public class Label implements Serializable {
 	}
 
 	public String getNs() {
-		if (ns == null || ns.trim().length() == 0)
-			return null;		
+		if (ns == null || ns.trim().length() == 0){
+			return null;
+		}		
 		
 		return ns;
 	}
 
 	public String getPrefix() {
-		if (prefix == null || prefix.trim().length() == 0)
+		if (prefix == null || prefix.trim().length() == 0){
 			return null;
+		}
 		
 		return prefix;
 	}
 	
 	public String getLocalName() {
-		if (uri == null)
+		if (uri == null){
 			return null;
+		}
 		
 		String localName = uri;
 		String ns = getNs();
-		if (ns != null && !ns.equalsIgnoreCase(localName))
+		if (ns != null && !ns.equalsIgnoreCase(localName)){
 			localName = localName.replaceFirst(ns, "");
+		}
 		
 		return localName;
 	}
 
 	public String getDisplayName() {
 
-		if (getPrefix() == null)
+		if (getPrefix() == null){
 			return getLocalName();
+		}
 		
 		return prefix + ":" + getLocalName();
 	}

--- a/src/main/java/edu/isi/karma/rep/alignment/Link.java
+++ b/src/main/java/edu/isi/karma/rep/alignment/Link.java
@@ -48,25 +48,40 @@ public abstract class Link extends DefaultWeightedEdge implements Comparable<Lin
 		super();
 
 		this.init();
-		if (id != null && id.trim().length() > 0) this.id = id;
-		if (label != null) this.label = label;
-		if (type != null) this.type = type;
+		if (id != null && id.trim().length() > 0){
+			this.id = id;
+		}
+		if (label != null){
+			this.label = label;
+		}
+		if (type != null){
+			this.type = type;
+		}
 	}
 	
 	public Link(String id, Label label, LinkType type, LinkKeyInfo keyInfo) {
 		super();
 
 		this.init();
-		if (id != null && id.trim().length() > 0) this.id = id;
-		if (label != null) this.label = label;
-		if (type != null) this.type = type;
-		if (keyInfo != null) this.keyInfo = keyInfo;
+		if (id != null && id.trim().length() > 0){
+			this.id = id;
+		}
+		if (label != null){
+			this.label = label;
+		}
+		if (type != null){
+			this.type = type;
+		}
+		if (keyInfo != null){
+			this.keyInfo = keyInfo;
+		}
 	}
 	
 	public Link(Link e) {
 		super();
-		if (e == null) this.init();
-		else {
+		if (e == null){
+			this.init();
+		}else {
 			this.id = e.id;
 			this.label = e.label;
 			this.type = e.type;
@@ -98,16 +113,18 @@ public abstract class Link extends DefaultWeightedEdge implements Comparable<Lin
 		
 		String s = this.id;
 
-		if (this.label.getNs() != null)
+		if (this.label.getNs() != null){
 			s = s.replaceAll(this.label.getNs(), "");
+		}
 		
 		return s;
 	}
 	
 	public String getDisplayId() {
 		
-		if (this.label.getPrefix() == null)
+		if (this.label.getPrefix() == null){
 			return this.getLocalId();
+		}
 		
 		return this.label.getPrefix() + ":" + this.getLocalId();
 	}

--- a/src/main/java/edu/isi/karma/rep/alignment/LinkPriorityComparator.java
+++ b/src/main/java/edu/isi/karma/rep/alignment/LinkPriorityComparator.java
@@ -33,13 +33,21 @@ public class LinkPriorityComparator implements Comparator<Link> {
 	}
 
 	private String getPriority(LinkPriorityType priorityType) {
-		if (priorityType == LinkPriorityType.DirectDataProperty) return "0";
-		else if (priorityType == LinkPriorityType.IndirectObjectProperty) return "1";
-		else if (priorityType == LinkPriorityType.ObjectPropertyWithOnlyDomain) return "2";
-		else if (priorityType == LinkPriorityType.ObjectPropertyWithOnlyRange) return "2";
-		else if (priorityType == LinkPriorityType.SubClassOf) return "3";
-		else if (priorityType == LinkPriorityType.ObjectPropertyWithoutDomainAndRange) return "4";
-		else return "5";
+		if (priorityType == LinkPriorityType.DirectDataProperty){
+			return "0";
+		}else if (priorityType == LinkPriorityType.IndirectObjectProperty){
+			return "1";
+		}else if (priorityType == LinkPriorityType.ObjectPropertyWithOnlyDomain){
+			return "2";
+		}else if (priorityType == LinkPriorityType.ObjectPropertyWithOnlyRange){
+			return "2";
+		}else if (priorityType == LinkPriorityType.SubClassOf){
+			return "3";
+		}else if (priorityType == LinkPriorityType.ObjectPropertyWithoutDomainAndRange){
+			return "4";
+		}else{
+			return "5";
+		}
 	}
 
 }

--- a/src/main/java/edu/isi/karma/rep/alignment/Node.java
+++ b/src/main/java/edu/isi/karma/rep/alignment/Node.java
@@ -47,14 +47,21 @@ public abstract class Node implements Comparable<Node>, Serializable {
 	public Node(String id, Label label, NodeType type) {
 		
 		this.init();
-		if (id != null && id.trim().length() > 0) this.id = id;
-		if (label != null) this.label = label;
-		if (type != null) this.type = type;
+		if (id != null && id.trim().length() > 0){
+			this.id = id;
+		}
+		if (label != null){
+			this.label = label;
+		}
+		if (type != null){
+			this.type = type;
+		}
 	}
 	
 	public Node(Node v) {
-		if (v == null) this.init();
-		else {
+		if (v == null){
+			this.init();
+		}else {
 			this.id = v.id;
 			this.label = v.label;
 			this.type = v.type;
@@ -81,16 +88,18 @@ public abstract class Node implements Comparable<Node>, Serializable {
 		
 		String s = this.id;
 
-		if (this.label.getNs() != null)
+		if (this.label.getNs() != null){
 			s = s.replaceAll(this.label.getNs(), "");
+		}
 		
 		return s;
 	}
 	
 	public String getDisplayId() {
 		
-		if (this.label.getPrefix() == null)
+		if (this.label.getPrefix() == null){
 			return this.getLocalId();
+		}
 		
 		return this.label.getPrefix() + ":" + this.getLocalId();
 	}

--- a/src/main/java/edu/isi/karma/rep/alignment/SemanticType.java
+++ b/src/main/java/edu/isi/karma/rep/alignment/SemanticType.java
@@ -54,12 +54,13 @@ public class SemanticType implements Jsonizable  {
 		this.clazz = domain;
 		this.isPartOfKey = isPartOfKey;
 		
-		if(probability > 0.8)
+		if(probability > 0.8){
 			confidenceLevel = ConfidenceLevel.High;
-		else if (probability < 0.8 && probability > 0.4)
+		}else if (probability < 0.8 && probability > 0.4){
 			confidenceLevel = ConfidenceLevel.Medium;
-		else
+		}else{
 			confidenceLevel = ConfidenceLevel.Low;
+		}
 	}
 
 	public String getHNodeId() {
@@ -80,16 +81,17 @@ public class SemanticType implements Jsonizable  {
 
 	@Override
 	public String toString() {
-		if (isClass())
+		if (isClass()){
 			return "SemanticType [hNodeId=" + hNodeId + ", type=" + type.getUri()
 				+ ", origin=" + origin
 				+ ", isPartOfKey=" + isPartOfKey + ", confidenceLevel="
 				+ confidenceLevel + "]";
-		else
+		}else{
 			return "SemanticType [hNodeId=" + hNodeId + ", type=" + type.getUri()
 					+ ", domain=" + clazz.getUri() + ", origin=" + origin
 					+ ", isPartOfKey=" + isPartOfKey + ", confidenceLevel="
 					+ confidenceLevel + "]";
+		}
 	}
 
 	//mariam
@@ -99,8 +101,9 @@ public class SemanticType implements Jsonizable  {
 	 * 		true if this type is a Class; false if it is a data property.
 	 */
 	public boolean isClass(){
-		if(clazz==null || clazz.getUri().trim().isEmpty())
+		if(clazz==null || clazz.getUri().trim().isEmpty()){
 			return true;
+		}
 		//it is a data property
 		return false;
 	}
@@ -115,10 +118,11 @@ public class SemanticType implements Jsonizable  {
 	public JSONObject getJSONArrayRepresentation() throws JSONException {
 		JSONObject typeObj = new JSONObject();
 		typeObj.put(ClientJsonKeys.FullType.name(), type.getUri());
-		if(isClass())
+		if(isClass()){
 			typeObj.put(ClientJsonKeys.Domain.name(), "");
-		else
+		}else{
 			typeObj.put(ClientJsonKeys.Domain.name(), clazz.getUri());
+		}
 		typeObj.put(ClientJsonKeys.isPrimary.name(), isPartOfKey);
 		return typeObj;
 	}

--- a/src/main/java/edu/isi/karma/rep/cleaning/RamblerTransformation.java
+++ b/src/main/java/edu/isi/karma/rep/cleaning/RamblerTransformation.java
@@ -40,10 +40,11 @@ public class RamblerTransformation implements Transformation {
 	public String transform(String value) {
 		InterpreterType worker = prog.getRuleForValue(value);
 		String s = worker.execute(value);
-		if(s.contains("_FATAL_ERROR_"))
+		if(s.contains("_FATAL_ERROR_")){
 			return value;
-		else
+		}else{
 			return s;
+		}
 	}	
 	public String getId() {
 		// TODO Auto-generated method stub
@@ -69,8 +70,9 @@ public class RamblerTransformation implements Transformation {
 	@Override
 	public String transform_debug(String value) {
 		InterpreterType worker = prog.getRuleForValue(value);
-		if(value.length()==0)
+		if(value.length()==0){
 			return "";
+		}
 		String s = worker.execute_debug(value);
 		return s;
 	}

--- a/src/main/java/edu/isi/karma/rep/cleaning/RamblerTransformationOutput.java
+++ b/src/main/java/edu/isi/karma/rep/cleaning/RamblerTransformationOutput.java
@@ -94,10 +94,11 @@ public class RamblerTransformationOutput implements TransformationOutput {
 		{
 			String k = iter.next();
 			String val = v.getValue(k);
-			if(val.length() >0)
+			if(val.length() >0){
 				val = t.transform(val);
-			else
+			}else{
 				val = "";
+			}
 			vo.setValue(k, val);
 			//System.out.println(k+","+val);
 		}

--- a/src/main/java/edu/isi/karma/rep/cleaning/RamblerValueCollection.java
+++ b/src/main/java/edu/isi/karma/rep/cleaning/RamblerValueCollection.java
@@ -68,9 +68,9 @@ public class RamblerValueCollection implements ValueCollection {
 		if(data.containsKey(id))
 		{
 			return data.get(id);
-		}
-		else
+		}else{
 			return "";
+		}
 	}
 
 	public Collection<String> getValues() {

--- a/src/main/java/edu/isi/karma/rep/hierarchicalheadings/ColspanMap.java
+++ b/src/main/java/edu/isi/karma/rep/hierarchicalheadings/ColspanMap.java
@@ -20,8 +20,9 @@ public class ColspanMap {
 		spanMap.put(node, span);
 
 		if (!node.isLeaf()) {
-			for (HHTNode child : node.getChildren())
+			for (HHTNode child : node.getChildren()){
 				populateColSpan(child);
+			}
 		}
 	}
 	

--- a/src/main/java/edu/isi/karma/rep/hierarchicalheadings/ColumnCoordinateSet.java
+++ b/src/main/java/edu/isi/karma/rep/hierarchicalheadings/ColumnCoordinateSet.java
@@ -63,10 +63,12 @@ public class ColumnCoordinateSet {
 	public int getCoordinatesCountForIndex (int index) {
 		int count = 0;
 		for(Coordinate c : coordinates) {
-			if(c.getIndex() > index)
+			if(c.getIndex() > index){
 				break;
-			if (c.getIndex() == index)
+			}
+			if (c.getIndex() == index){
 				count++;
+			}
 		}
 		return count;
 	}

--- a/src/main/java/edu/isi/karma/rep/hierarchicalheadings/Coordinate.java
+++ b/src/main/java/edu/isi/karma/rep/hierarchicalheadings/Coordinate.java
@@ -59,10 +59,11 @@ public class Coordinate implements Comparable<Coordinate> {
 					// left and top is always less than right, center, and
 					// bottom
 					if (this.position == Position.left
-							|| this.position == Position.top)
+							|| this.position == Position.top){
 						return -1;
-					else
+					}else{
 						return 1;
+					}
 
 				} else {
 					return this.index - o.index;
@@ -74,10 +75,11 @@ public class Coordinate implements Comparable<Coordinate> {
 					// left and top is always less than right, center, and
 					// bottom
 					if (o.position == Position.left
-							|| o.position == Position.top)
+							|| o.position == Position.top){
 						return 1;
-					else
+					}else{
 						return -1;
+					}
 
 				} else {
 					return this.index - o.index;
@@ -88,19 +90,20 @@ public class Coordinate implements Comparable<Coordinate> {
 					// if the position is same, use the depth
 					if (this.position == o.position) {
 						if (this.position == Position.left
-								|| this.position == Position.top)
+								|| this.position == Position.top){
 							return this.depth - o.depth;
-						else if (this.position == Position.right
+						}else if (this.position == Position.right
 								|| this.position == Position.bottom) {
 							return o.depth - this.depth;
 						}
 					}
 					// top is always less then bottom and center
 					if (this.position == Position.left
-							|| this.position == Position.top)
+							|| this.position == Position.top){
 						return -1;
-					else
+					}else{
 						return 1;
+					}
 
 				} else {
 					return this.index - o.index;
@@ -111,16 +114,18 @@ public class Coordinate implements Comparable<Coordinate> {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj == null)
+		if (obj == null){
 			return false;
+		}
 		if (obj.getClass() != getClass()) {
 			return false;
 		}
 		
 		Coordinate cr = (Coordinate) obj;
 		if(cr.type == this.type && cr.depth == this.depth 
-				&& cr.index == this.index && cr.position == this.position)
+				&& cr.index == this.index && cr.position == this.position){
 			return true;
+		}
 		return false;
 	}
 
@@ -151,11 +156,13 @@ public class Coordinate implements Comparable<Coordinate> {
 		c.add(new Coordinate(1, Position.right, 1));
 		c.add(new Coordinate(1, Position.left, 1));
 
-		for(Coordinate cr:c)
+		for(Coordinate cr:c){
 			System.out.println(cr);
+		}
 		System.out.println("SORTING ***************");
 		Collections.sort(c);
-		for(Coordinate cr:c)
+		for(Coordinate cr:c){
 			System.out.println(cr);
+		}
 	}
 }

--- a/src/main/java/edu/isi/karma/rep/hierarchicalheadings/HHCell.java
+++ b/src/main/java/edu/isi/karma/rep/hierarchicalheadings/HHCell.java
@@ -113,10 +113,11 @@ public class HHCell {
 	}
 
 	public boolean hasTNode() {
-		if (tNode != null)
+		if (tNode != null){
 			return true;
-		else
+		}else{
 			return false;
+		}
 	}
 	
 	public boolean isDummy() {
@@ -125,12 +126,14 @@ public class HHCell {
 
 	public boolean hasLeafTNode() {
 		if (hasTNode()) {
-			if (tNode.getChildren() != null && tNode.getChildren().size() != 0)
+			if (tNode.getChildren() != null && tNode.getChildren().size() != 0){
 				return false;
-			else
+			}else{
 				return true;
+			}
 
-		} else
+		}else{
 			return false;
+		}
 	}
 }

--- a/src/main/java/edu/isi/karma/rep/hierarchicalheadings/HHTNode.java
+++ b/src/main/java/edu/isi/karma/rep/hierarchicalheadings/HHTNode.java
@@ -48,10 +48,11 @@ public class HHTNode {
 	}
 
 	public boolean isLeaf() {
-		if(children == null || children.size() == 0)
+		if(children == null || children.size() == 0){
 			return true;
-		else
+		}else{
 			return false;
+		}
 	}
 
 	public int getStartCol() {
@@ -162,7 +163,8 @@ public class HHTNode {
 			for(HHTNode node: children) {
 				node.prettyprint(prefix +"    ");
 			}
-		} else
+		}else{
 			System.out.println();
+		}
 	}
 }

--- a/src/main/java/edu/isi/karma/rep/hierarchicalheadings/HHTable.java
+++ b/src/main/java/edu/isi/karma/rep/hierarchicalheadings/HHTable.java
@@ -110,8 +110,9 @@ public class HHTable {
 			// Copy the HHCell info to the HHCells below in the same column
 			copyToHHCellsBelow(cell, rowIndex, colIndex);
 
-			if (!node.isLeaf())
+			if (!node.isLeaf()){
 				populateHHCells(node.getChildren(), rowIndex + 1);
+			}
 		}
 	}
 
@@ -218,9 +219,10 @@ public class HHTable {
 					translator.getCssTag("", cell.getDepth()));
 
 			// Populate with the content (if not dummy)
-			if (!cell.isDummy())
+			if (!cell.isDummy()){
 				cellObj.put(CellJsonKeys.contentCell.name(), cell.gettNode()
 						.generateJsonObject());
+			}
 
 			// Fill the left and right border
 			if (cell.hasLeafTNode() || cell.isDummy()) {
@@ -313,15 +315,17 @@ public class HHTable {
 					HHCell cell = cells[row][col];
 
 					// Print the left borders
-					if(!NO_SEPARATORS_FLAG)
+					if(!NO_SEPARATORS_FLAG){
 						populateLeftBorders(cell, cellArray, translator, row);
+					}
 
 					// Print the content cell (if any)
 					populateContentCell(cell, cellArray, translator);
 
 					// Print the right borders
-					if(!NO_SEPARATORS_FLAG)
+					if(!NO_SEPARATORS_FLAG){
 						populateRightBorders(cell, cellArray, translator, row);
+					}
 
 					col += cell.getColspan();
 				}

--- a/src/main/java/edu/isi/karma/rep/hierarchicalheadings/HHTree.java
+++ b/src/main/java/edu/isi/karma/rep/hierarchicalheadings/HHTree.java
@@ -69,8 +69,9 @@ public class HHTree {
 			root.getRightStrokes().add(root.getRightStroke());
 			
 			// Add the stroke to children (if any)
-			if(!root.isLeaf())
+			if(!root.isLeaf()){
 				calculateLeftAndRightStrokes(root);
+			}
 		}
 	}
 
@@ -154,8 +155,9 @@ public class HHTree {
 	private void calculateDepth(HHTNode node, int depth) {
 		node.setDepth(depth);
 		// Keep account of the maximum depth in the HHTree
-		if(depth > maxDepth)
+		if(depth > maxDepth){
 			maxDepth = depth;
+		}
 		
 		if (!node.isLeaf()) {
 			for (HHTNode child : node.getChildren()) {
@@ -208,17 +210,19 @@ public class HHTree {
 		for (TNode child : children) {
 			HHTNode childNode = new HHTNode(child);
 			childrenList.add(childNode);
-			if (!isTNodeLeaf(child))
+			if (!isTNodeLeaf(child)){
 				populateChildren(child, childNode);
+			}
 		}
 		rootNode.setChildren(childrenList);
 	}
 
 	private boolean isTNodeLeaf(TNode node) {
-		if (node.getChildren() == null || node.getChildren().size() == 0)
+		if (node.getChildren() == null || node.getChildren().size() == 0){
 			return true;
-		else
+		}else{
 			return false;
+		}
 	}
 
 	public int getMaxDepth() {
@@ -265,8 +269,9 @@ public class HHTree {
 				int htmlColSpan = ccMap.getCoordinatesCountForIndex(colIndex);
 				node.setHtmlColSpan(htmlColSpan);
 				return htmlColSpan;
-			} else 
+			}else{
 				return 0;
+			}
 		} else {
 			int htmlColSpan = 0;
 			List<HHTNode> children = node.getChildren();

--- a/src/main/java/edu/isi/karma/rep/metadata/TagsContainer.java
+++ b/src/main/java/edu/isi/karma/rep/metadata/TagsContainer.java
@@ -48,8 +48,9 @@ public class TagsContainer {
 
 	public Tag getTag(TagName tagName) {
 		for (Tag tag : tags) {
-			if(tag.getLabel().name().equals(tagName.name()))
+			if(tag.getLabel().name().equals(tagName.name())){
 				return tag;
+			}
 		}
 		return null;
 	}

--- a/src/main/java/edu/isi/karma/rep/model/Model.java
+++ b/src/main/java/edu/isi/karma/rep/model/Model.java
@@ -86,8 +86,12 @@ public class Model {
 
 	public String getUri() {
 		String uri = "";
-		if (getBaseUri() != null) uri += getBaseUri();
-		if (getId() != null) uri += getId();
+		if (getBaseUri() != null){
+			uri += getBaseUri();
+		}
+		if (getId() != null){
+			uri += getId();
+		}
 		return uri;
 	}
 
@@ -103,8 +107,9 @@ public class Model {
 		
 		com.hp.hpl.jena.rdf.model.Model model = ModelFactory.createDefaultModel();
 		
-		if (this.baseUri != null)
+		if (this.baseUri != null){
 			model.setNsPrefix("", this.baseUri);
+		}
 		
 		model.setNsPrefix(Prefixes.KARMA, Namespaces.KARMA);
 		model.setNsPrefix(Prefixes.RDF, Namespaces.RDF);
@@ -138,8 +143,9 @@ public class Model {
 				r = model.createResource();
 				r.addProperty(rdf_type, class_atom_resource);
 				
-				if (classAtom.getClassPredicate().getPrefix() != null && classAtom.getClassPredicate().getNs() != null)
+				if (classAtom.getClassPredicate().getPrefix() != null && classAtom.getClassPredicate().getNs() != null){
 					model.setNsPrefix(classAtom.getClassPredicate().getPrefix(), classAtom.getClassPredicate().getNs());
+				}
 				Resource className = model.createResource(classAtom.getClassPredicate().getUri());
 				r.addProperty(class_predicate, className);
 				
@@ -154,8 +160,9 @@ public class Model {
 				r = model.createResource();
 				r.addProperty(rdf_type, individual_property_atom_resource);
 				
-				if (propertyAtom.getPropertyPredicate().getPrefix() != null && propertyAtom.getPropertyPredicate().getNs() != null)
+				if (propertyAtom.getPropertyPredicate().getPrefix() != null && propertyAtom.getPropertyPredicate().getNs() != null){
 					model.setNsPrefix(propertyAtom.getPropertyPredicate().getPrefix(), propertyAtom.getPropertyPredicate().getNs());
+				}
 				Resource propertyName = model.createResource(propertyAtom.getPropertyPredicate().getUri());
 				r.addProperty(property_predicate, propertyName);
 				
@@ -199,12 +206,13 @@ public class Model {
 		
 		List<String> argList = new ArrayList<String>();
 		String queryString = "";
-		if (ioType.equalsIgnoreCase(IOType.INPUT)) 
+		if (ioType.equalsIgnoreCase(IOType.INPUT)){
 			queryString = this.getSparqlToMatchServiceInputs(argList);
-		else if (ioType.equalsIgnoreCase(IOType.OUTPUT)) 
+		}else if (ioType.equalsIgnoreCase(IOType.OUTPUT)){
 			queryString = this.getSparqlToMatchServiceOutputs(argList);
-		else 
+		}else{
 			queryString = this.getSparql(argList);
+		}
 
 		if (limit != null) {
 			queryString += "LIMIT " + String.valueOf(limit.intValue() + "\n");
@@ -332,8 +340,9 @@ public class Model {
 		
 		for (String ns : nsToPrefixMapping.keySet()) {
 			String prefix = nsToPrefixMapping.get(ns);
-			if (prefix != null)
+			if (prefix != null){
 				prefixHeader += "PREFIX " + prefix + ": <" + ns + "> \n";
+			}
 		}
 
 		return prefixHeader;
@@ -357,8 +366,9 @@ public class Model {
 		String argument1Var = "";
 		String argument2Var = "";
 
-		if (argList == null) 
+		if (argList == null){
 			argList = new ArrayList<String>();
+		}
 		
 		for (int i = 0; i < this.getAtoms().size(); i++) {
 			Atom atom = this.getAtoms().get(i);
@@ -453,8 +463,9 @@ public class Model {
 		String argument1Var = "";
 		String argument2Var = "";
 
-		if (argList == null) 
+		if (argList == null){
 			argList = new ArrayList<String>();
+		}
 		
 		for (int i = 0; i < this.getAtoms().size(); i++) {
 			Atom atom = this.getAtoms().get(i);
@@ -476,8 +487,9 @@ public class Model {
 					argument1 = classAtom.getArgument1().getId();
 					argument1Var = "?" + argument1;
 					
-					if (argList.indexOf(argument1) == -1) 
+					if (argList.indexOf(argument1) == -1){
 						argList.add(argument1);
+					}
 
 					construct_header += 
 						"      " + argument1Var + " rdf:type " + predicateUri + " . \n";
@@ -504,10 +516,12 @@ public class Model {
 					argument1Var = "?" + argument1;
 					argument2Var = "?" + argument2;
 					
-					if (argList.indexOf(argument1) == -1) 
+					if (argList.indexOf(argument1) == -1){
 						argList.add(argument1);
-					if (argList.indexOf(argument2) == -1) 
+					}
+					if (argList.indexOf(argument2) == -1){
 						argList.add(argument2);
+					}
 					
 					construct_header += 
 						"      " + argument1Var + " " + predicateUri + " " + argument2Var + " . \n";
@@ -553,10 +567,11 @@ public class Model {
 		nsToPrefixMapping.put(Namespaces.HRESTS, Prefixes.HRESTS);
 		
 		String io_class = "";
-		if (ioType.equalsIgnoreCase(IOType.OUTPUT))
+		if (ioType.equalsIgnoreCase(IOType.OUTPUT)){
 			io_class = "Output";
-		else if (ioType.equalsIgnoreCase(IOType.INPUT))
+		}else if (ioType.equalsIgnoreCase(IOType.INPUT)){
 			io_class =  "Input";
+		}
 
 		String select_header = "SELECT ?model ";
 		String select_where =
@@ -577,8 +592,9 @@ public class Model {
 		String argument1Var = "";
 		String argument2Var = "";
 
-		if (argList == null) 
+		if (argList == null){
 			argList = new ArrayList<String>();
+		}
 
 		for (int i = 0; i < m.getAtoms().size(); i++) {
 			Atom atom = m.getAtoms().get(i);
@@ -666,8 +682,9 @@ public class Model {
 			}
 		}		
 		int index = logicalForm.lastIndexOf(separator);
-		if (index != -1)
+		if (index != -1){
 			logicalForm = logicalForm.substring(0, index);
+		}
 		
 		return logicalForm;
 	}

--- a/src/main/java/edu/isi/karma/rep/sources/Attribute.java
+++ b/src/main/java/edu/isi/karma/rep/sources/Attribute.java
@@ -106,8 +106,12 @@ public class Attribute {
 
 	public String getUri() {
 		String uri = "";
-		if (getBaseUri() != null) uri += getBaseUri();
-		if (getId() != null) uri += getId();
+		if (getBaseUri() != null){
+			uri += getBaseUri();
+		}
+		if (getId() != null){
+			uri += getId();
+		}
 		return uri;
 	}
 	public String gethNodeId() {

--- a/src/main/java/edu/isi/karma/rep/sources/DataSource.java
+++ b/src/main/java/edu/isi/karma/rep/sources/DataSource.java
@@ -96,13 +96,16 @@ public class DataSource extends Source {
 	
 	public void setAttributes(List<Attribute> attributes) {
 		
-		if (this.attributes != null)
+		if (this.attributes != null){
 			this.attributes.clear();
+		}
 		
-		for (Attribute att : attributes)
+		for (Attribute att : attributes){
 			att.setBaseUri(this.getUri());
-		for (Attribute att : attributes)
+		}
+		for (Attribute att : attributes){
 			attIdToAttMap.put(att.getId(), att);
+		}
 		
 		this.attributes = attributes;
 	}
@@ -112,8 +115,9 @@ public class DataSource extends Source {
 	}
 
 	public void setModel(Model model) {
-		if (model != null)
+		if (model != null){
 			model.setBaseUri(this.getUri());
+		}
 		this.model = model;
 	}
 
@@ -127,8 +131,9 @@ public class DataSource extends Source {
 	
 	private void updateModel(DirectedWeightedMultigraph<Node, Link> treeModel) {
 		
-		if (treeModel == null)
+		if (treeModel == null){
 			return;
+		}
 		
 		Model m = new Model("model");
 		
@@ -158,11 +163,13 @@ public class DataSource extends Source {
 
 		for (Node n : treeModel.vertexSet()) {
 			
-			if (n instanceof ColumnNode || n instanceof LiteralNode)
+			if (n instanceof ColumnNode || n instanceof LiteralNode){
 				continue;
+			}
 			
-			if (vertexIdToArgument.get(n.getId()) == null)
+			if (vertexIdToArgument.get(n.getId()) == null){
 				continue;
+			}
 			
 			Label classPredicate = new Label(n.getLabel().getUri(), n.getLabel().getNs(), n.getLabel().getPrefix());
 
@@ -173,8 +180,9 @@ public class DataSource extends Source {
 		for (Link e : treeModel.edgeSet()) {
 			
 			if (vertexIdToArgument.get(e.getSource().getId()) == null || 
-					vertexIdToArgument.get(e.getTarget().getId()) == null)
+					vertexIdToArgument.get(e.getTarget().getId()) == null){
 				continue;
+			}
 
 			Label propertyPredicate = new Label(e.getLabel().getUri(), e.getLabel().getNs(), e.getLabel().getPrefix());
 			IndividualPropertyAtom propertyAtom = null;
@@ -213,8 +221,9 @@ public class DataSource extends Source {
 		System.out.println("Source: " + getInfo());
 		System.out.println("********************************************");
 		System.out.println("Attributes: ");
-		for (Attribute p : getAttributes())
+		for (Attribute p : getAttributes()){
 			p.print();
+		}
 		System.out.print("Model: ");
 		if (this.model != null) {
 			System.out.println(model.getUri());

--- a/src/main/java/edu/isi/karma/rep/sources/Invocation.java
+++ b/src/main/java/edu/isi/karma/rep/sources/Invocation.java
@@ -77,8 +77,9 @@ public class Invocation {
 
 	public Table getJointInputAndOutput() {
 		joinInputAndOutput();
-		for (int i = 0; i < this.jointInputAndOutput.getValues().size(); i++)
+		for (int i = 0; i < this.jointInputAndOutput.getValues().size(); i++){
 			this.jointInputAndOutput.getRowIds().add(this.requestId);
+		}
 		return jointInputAndOutput;
 	}
 
@@ -89,8 +90,9 @@ public class Invocation {
 	}
 	
 	private static String getId(String name, HashMap<String, Integer> nameCounter) {
-		if (nameCounter == null)
+		if (nameCounter == null){
 			return null;
+		}
 
 		Integer count = nameCounter.get(name);
 		if (count == null) {
@@ -221,17 +223,20 @@ public class Invocation {
 		jointInputAndOutput = new Table(this.response.getTable());
 		
 		List<String> inputValues = new ArrayList<String>();
-		if (this.request.getAttributes() != null)
-		for (int j = this.request.getAttributes().size() - 1; j >= 0; j--) {
-			
-			Attribute p = this.request.getAttributes().get(j);
-			if (p != null && p.getName() != null && p.getName().toString().trim().length() == 0)
-				continue;
+		if (this.request.getAttributes() != null){
+			for (int j = this.request.getAttributes().size() - 1; j >= 0; j--) {
 				
-				jointInputAndOutput.getHeaders().add(0, p);
-				inputValues.add(0, p.getValue());
-				for (int k = 0; k < this.response.getTable().getValues().size(); k++)
-					this.response.getTable().getValues().get(k).add(0, p.getValue());
+				Attribute p = this.request.getAttributes().get(j);
+				if (p != null && p.getName() != null && p.getName().toString().trim().length() == 0){
+					continue;
+				}
+					
+					jointInputAndOutput.getHeaders().add(0, p);
+					inputValues.add(0, p.getValue());
+					for (int k = 0; k < this.response.getTable().getValues().size(); k++){
+						this.response.getTable().getValues().get(k).add(0, p.getValue());
+					}
+			}
 		}
 		
 		// there is no output
@@ -242,8 +247,9 @@ public class Invocation {
 
 		// Include the request URLs in the invocation table
 		jointInputAndOutput.getHeaders().add(0, new Attribute(REQUEST_COLUMN_NAME, REQUEST_COLUMN_NAME,IOType.NONE));
-		for (int k = 0; k < jointInputAndOutput.getValues().size(); k++)
+		for (int k = 0; k < jointInputAndOutput.getValues().size(); k++){
 			jointInputAndOutput.getValues().get(k).add(0, this.request.getUrl().toString());
+		}
 		
 	}
 }

--- a/src/main/java/edu/isi/karma/rep/sources/InvocationManager.java
+++ b/src/main/java/edu/isi/karma/rep/sources/InvocationManager.java
@@ -63,8 +63,9 @@ public class InvocationManager {
 		this.urlColumnName = (urlColumnName == null || urlColumnName.trim().length() == 0) ? "url" : urlColumnName;
 		this.idList = idList;
 		requestURLs = URLManager.getURLsFromStrings(requestURLStrings);
-		if (requestURLs == null || requestURLs.size() == 0)
+		if (requestURLs == null || requestURLs.size() == 0){
 			throw new KarmaException("Cannot model a service without any request example.");
+		}
 		
 		this.serviceData = null;
 		this.invocations = new ArrayList<Invocation>();
@@ -88,8 +89,9 @@ public class InvocationManager {
 		List<String> requestURLList = new ArrayList<String>();
 		requestURLList.add(requestURLString);
 		requestURLs = URLManager.getURLsFromStrings(requestURLList);
-		if (requestURLs == null || requestURLs.size() == 0)
+		if (requestURLs == null || requestURLs.size() == 0){
 			throw new KarmaException("Cannot model a service without any request example.");
+		}
 		
 		this.serviceData = null;
 		this.invocations = new ArrayList<Invocation>();
@@ -109,8 +111,9 @@ public class InvocationManager {
 		for (int i = 0; i < requestURLs.size(); i++) {
 			URL url = requestURLs.get(i);
 			String requestId = null;
-			if (idList != null)
+			if (idList != null){
 				requestId = idList.get(i);
+			}
 			Request request = new Request(url);
 			Invocation invocation = new Invocation(requestId, request);
 			logger.info("Invoking the service " + request.getUrl().toString() + " ...");
@@ -145,16 +148,18 @@ public class InvocationManager {
 			this.jsonUrl.add(url);
 			
 			JsonObject in = new JsonObject();
-			for (Attribute att : inv.getRequest().getAttributes()) 
+			for (Attribute att : inv.getRequest().getAttributes()){
 				in.addProperty(att.getName(), att.getValue());
+			}
 //			JsonArray inArray = new JsonArray();
 //			inArray.add(in);
 			this.jsonInputs.add(in);
 			
 			JsonObject urlAndIn = new JsonObject();
 			urlAndIn.addProperty(this.urlColumnName, inv.getRequest().getUrl().toString());
-			for (Attribute att : inv.getRequest().getAttributes()) 
+			for (Attribute att : inv.getRequest().getAttributes()){
 				urlAndIn.addProperty(att.getName(), att.getValue());
+			}
 			this.jsonUrlAndInputs.add(urlAndIn);
 			
 			JsonArray urlAndOut = new JsonArray();
@@ -179,28 +184,30 @@ public class InvocationManager {
 	}
 	
 	public String getServiceJson(boolean includeURL, boolean includeInputAttributes, boolean includeOutputAttributes) {
-		if (includeURL && includeInputAttributes && includeOutputAttributes)		
+		if (includeURL && includeInputAttributes && includeOutputAttributes){
 			return this.json.toString();
-		else if (includeURL && includeInputAttributes)
+		}else if (includeURL && includeInputAttributes){
 			return this.jsonUrlAndInputs.toString();
-		else if (includeURL && includeOutputAttributes)
+		}else if (includeURL && includeOutputAttributes){
 			return this.jsonUrlAndOutputs.toString();
-		else if (includeInputAttributes && includeOutputAttributes)
+		}else if (includeInputAttributes && includeOutputAttributes){
 			return this.jsonInputsAndOutputs.toString();
-		else if (includeURL)
+		}else if (includeURL){
 			return this.jsonUrl.toString();
-		else if (includeInputAttributes)
+		}else if (includeInputAttributes){
 			return this.jsonInputs.toString();
-		else if (includeOutputAttributes)
+		}else if (includeOutputAttributes){
 			return this.jsonOutputs.toString();
-		else 
+		}else{
 			return "";
+		}
 	}
 	
 	public Table getServiceData(boolean includeURL, boolean includeInputAttributes, boolean includeOutputAttributes) {
 
-		if (includeURL && includeInputAttributes && includeOutputAttributes)
+		if (includeURL && includeInputAttributes && includeOutputAttributes){
 			return this.serviceData;
+		}
 		
 		List<Attribute> headers = this.serviceData.getHeaders();
 		List<List<String>> values = this.serviceData.getValues();
@@ -213,14 +220,17 @@ public class InvocationManager {
 		List<Integer> includingColumns = new ArrayList<Integer>();
 		
 		if (headers != null) {
-			if (includeURL && headers.size() > 0)
+			if (includeURL && headers.size() > 0){
 				includingColumns.add(0);
+			}
 			
 			for (int i = 1; i < this.serviceData.getHeaders().size(); i++) {
-				if (includeInputAttributes && headers.get(i).getIOType() == IOType.INPUT)
+				if (includeInputAttributes && headers.get(i).getIOType() == IOType.INPUT){
 					includingColumns.add(i);
-				if (includeOutputAttributes && headers.get(i).getIOType() == IOType.OUTPUT)
+				}
+				if (includeOutputAttributes && headers.get(i).getIOType() == IOType.OUTPUT){
 					includingColumns.add(i);
+				}
 			}
 		}
 		
@@ -229,8 +239,9 @@ public class InvocationManager {
 		}
 		for (List<String> vals : values) {
 			List<String> rowVals = new ArrayList<String>();
-			for (Integer colIndex : includingColumns)
+			for (Integer colIndex : includingColumns){
 				rowVals.add(vals.get(colIndex));
+			}
 			newValues.add(rowVals);
 		}
 		
@@ -246,8 +257,9 @@ public class InvocationManager {
 	}
 	
 	public String getServiceJson(boolean includeInputAttributes) {
-		if (includeInputAttributes)
+		if (includeInputAttributes){
 			return getServiceJson(true, true, true);
+		}
 		return getServiceJson(false, false, true);
 	}
 	
@@ -269,8 +281,9 @@ public class InvocationManager {
 		
 		Table serviceTable = getServiceData();
 		for (Attribute p : serviceTable.getHeaders()) {
-			if (p.getIOType().equalsIgnoreCase(IOType.OUTPUT))
+			if (p.getIOType().equalsIgnoreCase(IOType.OUTPUT)){
 				outAttributes.add(p);
+			}
 		}
 
 		return outAttributes;
@@ -287,14 +300,16 @@ public class InvocationManager {
 //		guid = "E9C3F8D3-F778-5C4B-E089-C1749D50AE1F";
 		URL sampleUrl = requestURLs.get(0);
 		
-		if (sampleUrl == null)
+		if (sampleUrl == null){
 			return null;
+		}
 
 		WebService service = null;
-		if (serviceName == null || serviceName.trim().length() == 0)
+		if (serviceName == null || serviceName.trim().length() == 0){
 			service = new WebService(guid, sampleUrl);
-		else
+		}else{
 			service = new WebService(guid, serviceName, sampleUrl);
+		}
 
 		service.setMethod(HttpMethods.GET);
 

--- a/src/main/java/edu/isi/karma/rep/sources/Response.java
+++ b/src/main/java/edu/isi/karma/rep/sources/Response.java
@@ -62,8 +62,9 @@ public class Response {
 	}
 	private void buildAttributeListFromTable() {
 		this.attributes = new ArrayList<Attribute>();
-		if (table == null)
+		if (table == null){
 			return;
+		}
 		for (Attribute p : table.getHeaders()) {
 			this.attributes.add(new Attribute(p));
 		}

--- a/src/main/java/edu/isi/karma/rep/sources/Table.java
+++ b/src/main/java/edu/isi/karma/rep/sources/Table.java
@@ -48,12 +48,16 @@ public class Table {
 	}
 	
 	public int getRowsCount() {
-		if (this.values == null) return 0;
+		if (this.values == null){
+			return 0;
+		}
 		return this.values.size();
 	}
 	
 	public int getColumnsCount() {
-		if (this.headers == null) return 0;
+		if (this.headers == null){
+			return 0;
+		}
 		return this.headers.size();
 	}
 	
@@ -135,26 +139,32 @@ public class Table {
 	}
 
 	private boolean sameHeaders(Table t) {
-		if (t == null)
+		if (t == null){
 			return false;
+		}
 		
-		if (this.getColumnsCount() == 0 || t.getColumnsCount() == 0)
+		if (this.getColumnsCount() == 0 || t.getColumnsCount() == 0){
 			return false;
+		}
 		
-		if (this.getColumnsCount() != t.getColumnsCount())
+		if (this.getColumnsCount() != t.getColumnsCount()){
 			return false;
+		}
 		
 		List<String> attNames = new ArrayList<String>();
 		List<String> tAttNames = new ArrayList<String>();
 		
-		for (Attribute att : this.getHeaders()) 
+		for (Attribute att : this.getHeaders()){
 			attNames.add(att.getName());
+		}
 		
-		for (Attribute att : t.getHeaders()) 
+		for (Attribute att : t.getHeaders()){
 			tAttNames.add(att.getName());
+		}
 		
-		if (attNames.containsAll(tAttNames) && tAttNames.containsAll(attNames))
+		if (attNames.containsAll(tAttNames) && tAttNames.containsAll(attNames)){
 			return true;
+		}
 		
 		return false;
 	}
@@ -164,24 +174,29 @@ public class Table {
     	int t1Cols = this.getColumnsCount();
     	int t2Cols = t.getColumnsCount();
     	
-    	if (t2Cols == 0)
-    		return;
-    	
-    	else if (t1Cols == 0) {
+    	if (t2Cols == 0){
+			return;
+		}else if (t1Cols == 0) {
     		
-    		if (this.headers == null)
-    			this.headers = new ArrayList<Attribute>();
+    		if (this.headers == null){
+				this.headers = new ArrayList<Attribute>();
+			}
     		
-    		for (Attribute att : t.getHeaders())
-    			this.headers.add(new Attribute(att));
+    		for (Attribute att : t.getHeaders()){
+				this.headers.add(new Attribute(att));
+			}
 
-    		if (this.values == null)
-    			this.values = new ArrayList<List<String>>();
+    		if (this.values == null){
+				this.values = new ArrayList<List<String>>();
+			}
 
-    		if (t.getValues() != null)
-    			for (List<String> v : t.getValues())
-    				if (v != null)
-    					values.add(new ArrayList<String>(v));
+    		if (t.getValues() != null){
+				for (List<String> v : t.getValues()){
+					if (v != null){
+						values.add(new ArrayList<String>(v));
+					}
+				}
+			}
     	} else {
     		
     		if (sameHeaders(t)) {
@@ -194,8 +209,9 @@ public class Table {
     			return;
     		}
     		
-    		for (Attribute att : t.getHeaders())
-    			headers.add(new Attribute(att));
+    		for (Attribute att : t.getHeaders()){
+				headers.add(new Attribute(att));
+			}
     		
     		int t1Rows = this.getRowsCount();
         	int t2Rows = t.getRowsCount();
@@ -209,17 +225,19 @@ public class Table {
         		
         		for (int j = 0; j < t1Cols; j++) {
         			int index = t1Rows == 0 ? -1 : i % t1Rows;
-        			if (index == -1 || this.values == null || this.values.get(index) == null)
-        				row.add(null);
-        			else
-        				row.add(this.values.get(index).get(j));
+        			if (index == -1 || this.values == null || this.values.get(index) == null){
+						row.add(null);
+					}else{
+						row.add(this.values.get(index).get(j));
+					}
         		}
         		for (int j = 0; j < t2Cols; j++) {
         			int index = t2Rows == 0 ? -1 : i % t2Rows;
-        			if (index == -1 || t.getValues() == null || t.getValues().get(index) == null)
-        				row.add(null);
-        			else
-        				row.add(t.getValues().get(index).get(j));
+        			if (index == -1 || t.getValues() == null || t.getValues().get(index) == null){
+						row.add(null);
+					}else{
+						row.add(t.getValues().get(index).get(j));
+					}
         		}
         		
         		values.add(row);
@@ -238,8 +256,9 @@ public class Table {
 	
     public static Table union(List<Table> srcTables) {
     	
-    	if (srcTables == null)
-    		return null;
+    	if (srcTables == null){
+			return null;
+		}
     	
     	Table resultTable = new Table();
     	
@@ -279,8 +298,9 @@ public class Table {
 			
 			rawAttributes = srcAttributes.get(i);
 			rawAttributeIDs.clear();
-			for (Attribute p : rawAttributes)
+			for (Attribute p : rawAttributes){
 				rawAttributeIDs.add(p.getId());
+			}
 			
 //			logger.debug("table " + i);
 			for (int j = 0; j < srcValues.get(i).size(); j++) {
@@ -292,18 +312,20 @@ public class Table {
 				for (int k = 0; k < resultAttributes.size(); k++) {
 //					logger.debug("\t\t column " + k);
 					int index = rawAttributeIDs.indexOf(resultAttributes.get(k).getId());
-					if (index == -1)
+					if (index == -1){
 						singleValue = null;
 //						singleValue = "";
-					else
+					}else{
 						singleValue = rawValues.get(index);
+					}
 					populatedValues.add(singleValue);
 				}
 				
 				if (srcRowIds != null && srcRowIds.size() > 0 &&
 						srcRowIds.get(i) != null && srcRowIds.get(i).size() > 0 &&  
-						srcRowIds.get(i).get(j) != null)
+						srcRowIds.get(i).get(j) != null){
 					resultRowIds.add(srcRowIds.get(i).get(j));
+				}
 				resultValues.add(populatedValues);
 			}
 			
@@ -322,16 +344,23 @@ public class Table {
 
 	public String asCSV(Character separator, Character quotechar, Character endlinechar) {
 		String csv = "";
-		if (separator == null) separator = ',';
-		if (quotechar == null) quotechar = '"';
-		if (endlinechar == null) endlinechar = '\n';
+		if (separator == null){
+			separator = ',';
+		}
+		if (quotechar == null){
+			quotechar = '"';
+		}
+		if (endlinechar == null){
+			endlinechar = '\n';
+		}
 		
 		try {
 			
 			if (this.headers != null && this.headers.size() > 0) {
 				for (int i = 0; i < this.headers.size(); i++) {
-					if (i != 0)
+					if (i != 0){
 						csv += separator.charValue();
+					}
 					csv += quotechar + this.headers.get(i).getName() + quotechar;
 				}
 				csv += endlinechar;
@@ -346,8 +375,9 @@ public class Table {
 			
 			for (int i = 0; i < this.values.size(); i++) {
 				for (int j = 0; j < this.values.get(i).size(); j++) {
-					if (j != 0)
+					if (j != 0){
 						csv += separator;
+					}
 					csv += quotechar + values.get(i).get(j) + quotechar;
 				}
 				csv += endlinechar;

--- a/src/main/java/edu/isi/karma/rep/sources/URLManager.java
+++ b/src/main/java/edu/isi/karma/rep/sources/URLManager.java
@@ -72,11 +72,14 @@ public class URLManager {
 			String urlStr = requestURLStrings.get(i).trim();
 			urlStr = urlStr.replaceAll(Pattern.quote(" "), "%20");
 			URL url = new URL(urlStr);
-			if (i == 0) firstEndpoint = getEndPoint(url);
+			if (i == 0){
+				firstEndpoint = getEndPoint(url);
+			}
 			
 			// only urls with the same endpoints will be added to the list.
-			if (!firstEndpoint.equalsIgnoreCase(getEndPoint(url)))
+			if (!firstEndpoint.equalsIgnoreCase(getEndPoint(url))){
 				throw new KarmaException("To model a service, all request examples should have the same endpoint.");
+			}
 			urls.add(url);
 		}
 		
@@ -91,8 +94,9 @@ public class URLManager {
 	 */
 	public static String getEndPoint(URL url) {
 		String endPoint = url.getHost() + url.getPath();
-		if (endPoint.endsWith("/"))
+		if (endPoint.endsWith("/")){
 			endPoint = endPoint.substring(0, endPoint.length() - 1);
+		}
 		return endPoint;
 	}
 	
@@ -121,10 +125,12 @@ public class URLManager {
 	 */
 	public static String getOperationName(URL url) {
 		String operationName = url.getPath();
-		if (operationName.indexOf("/") != -1) 
+		if (operationName.indexOf("/") != -1){
 			operationName = operationName.substring(operationName.lastIndexOf("/") + 1, operationName.length());
-		if (operationName.trim().length() == 0)
+		}
+		if (operationName.trim().length() == 0){
 			operationName = "";
+		}
 		return operationName;
 	}		
 	
@@ -139,19 +145,22 @@ public class URLManager {
 
 		address += getOperationName(url);
 		
-		if (url.getQuery() != null)
+		if (url.getQuery() != null){
 			address += "?" + url.getQuery().trim();
+		}
 		
 		return address;
 	}
 
 	private static boolean verifyAttributeExtraction(URL url, List<Attribute> attributeList) throws UnsupportedEncodingException {
-		if (url.getQuery() == null && (attributeList == null || attributeList.size() == 0))
+		if (url.getQuery() == null && (attributeList == null || attributeList.size() == 0)){
 			return true;
+		}
 		
 		if (url.getQuery() != null && url.getQuery().trim().length() == 0 && 
-				(attributeList == null || attributeList.size() == 0))
+				(attributeList == null || attributeList.size() == 0)){
 			return true;
+		}
 		
 		String originalQuery = URLDecoder.decode(url.getQuery(), "UTF-8");
 		
@@ -162,11 +171,13 @@ public class URLManager {
 			query += p.getValue().trim();
 			query += "&";
 		}
-		if (query.endsWith("&"))
+		if (query.endsWith("&")){
 			query = query.substring(0, query.length()-1);
+		}
 		
-		if (query.equalsIgnoreCase(originalQuery))
+		if (query.equalsIgnoreCase(originalQuery)){
 			return true;
+		}
 		
 		return false;
 	}
@@ -199,7 +210,9 @@ public class URLManager {
 		                String value = "";
 		                if (pair.length > 1) {
 		                	for (int i = 1; i < pair.length; i++) {
-		                		if (i != 1) value += "=";
+		                		if (i != 1){
+									value += "=";
+								}
 		                		value += URLDecoder.decode(pair[i], "UTF-8");
 		                	}
 		                }
@@ -246,8 +259,9 @@ public class URLManager {
 	}
 
 	private static String getId(String name, HashMap<String, Integer> nameCounter) {
-		if (nameCounter == null)
+		if (nameCounter == null){
 			return null;
+		}
 
 		Integer count = nameCounter.get(name);
 		if (count == null) {
@@ -299,16 +313,19 @@ public class URLManager {
 
 			List<Attribute> attributeList = getQueryAttributes(urlList.get(i));
 			
-			for (int j = 0; j < attributeNames.size(); j++)
+			for (int j = 0; j < attributeNames.size(); j++){
 				allAttributes.get(i).add("");
+			}
 			
 			for (int j = 0; j < attributeList.size(); j++) {
 				p = attributeList.get(j);
 				key = p.getName();
 				index = attributeNames.indexOf(key);
-				if (p.getValue() != null && p.getValue().trim().length() > 0)
-					if (index != -1)
+				if (p.getValue() != null && p.getValue().trim().length() > 0){
+					if (index != -1){
 						allAttributes.get(i).set(index, p.getValue().trim());
+					}
+				}
 			}
 		}
 		return allAttributes;
@@ -338,10 +355,13 @@ public class URLManager {
 				p = attributeList.get(j);
 				key = p.getName();
 				index = attributeNames.indexOf(key);
-				if (p.getValue() != null && p.getValue().trim().length() > 0)
-					if (index != -1)
-						if (allAttributes.get(index).indexOf(p.getValue().trim()) == -1)
+				if (p.getValue() != null && p.getValue().trim().length() > 0){
+					if (index != -1){
+						if (allAttributes.get(index).indexOf(p.getValue().trim()) == -1){
 							allAttributes.get(index).add(p.getValue().trim());
+						}
+					}
+				}
 			}
 		}
 		return allAttributes;
@@ -374,16 +394,18 @@ public class URLManager {
 			
 			
 			for (int i = 0; i < attributeNames.size(); i++) {
-				if (i != 0)
+				if (i != 0){
 					csv += ",";
+				}
 				csv += "\"" + attributeNames.get(i) + "\"";
 			}
 			csv += "\n";
 
 			for (int i = 0; i < attributeValues.size(); i++) {
 				for (int j = 0; j < attributeValues.get(i).size(); j++) {
-					if (j != 0)
+					if (j != 0){
 						csv += ",";
+					}
 					csv += "\"" + attributeValues.get(i).get(j) + "\"";
 				}
 				csv += "\n";
@@ -414,17 +436,20 @@ public class URLManager {
 	public static String createApiLink(String apiEndPoint, List<String> attributeNames, List<String> attributeValues) {
 		String invocationURL = apiEndPoint.trim();
 			
-		if (!invocationURL.endsWith("?"))
+		if (!invocationURL.endsWith("?")){
 			invocationURL += "?";
+		}
 
 		String value = "";
 		for (int i = 0; i < attributeNames.size(); i++) {
 			value = attributeValues.get(i).trim();
 			
-			if (value == null || value.length() == 0 || value.equalsIgnoreCase(null))
+			if (value == null || value.length() == 0 || value.equalsIgnoreCase(null)){
 				continue;
-			if (!invocationURL.endsWith("?"))
+			}
+			if (!invocationURL.endsWith("?")){
 				invocationURL += "&";
+			}
 			
 			invocationURL += attributeNames.get(i);
 			invocationURL += "=";

--- a/src/main/java/edu/isi/karma/rep/sources/WebService.java
+++ b/src/main/java/edu/isi/karma/rep/sources/WebService.java
@@ -128,8 +128,9 @@ public class WebService extends Source {
 	}
 
 	public String getOperationName() {
-		if (operationName == null)
+		if (operationName == null){
 			this.operationName = URLManager.getOperationName(this.urlExample);
+		}
 		
 		return operationName;
 	}
@@ -159,8 +160,9 @@ public class WebService extends Source {
 		String address = this.getAddress();
 		String populatedAddress = address;
 		
-		if (missingAttributes == null)
+		if (missingAttributes == null){
 			missingAttributes = new ArrayList<Attribute>();
+		}
 		
 		for (Attribute att : this.inputAttributes) {
 			
@@ -212,12 +214,16 @@ public class WebService extends Source {
 	}
 
 	public void setInputAttributes(List<Attribute> inputAttributes) {
-		if (inputAttributes != null)
-			for (Attribute att : inputAttributes)
+		if (inputAttributes != null){
+			for (Attribute att : inputAttributes){
 				att.setBaseUri(this.getUri());
-		if (inputAttributes != null)
-			for (Attribute att : inputAttributes)
+			}
+		}
+		if (inputAttributes != null){
+			for (Attribute att : inputAttributes){
 				attIdToAttMap.put(att.getId(), att);
+			}
+		}
 		this.inputAttributes = inputAttributes;
 	}
 
@@ -226,12 +232,16 @@ public class WebService extends Source {
 	}
 
 	public void setOutputAttributes(List<Attribute> outputAttributes) {
-		if (outputAttributes != null)
-			for (Attribute att : outputAttributes)
+		if (outputAttributes != null){
+			for (Attribute att : outputAttributes){
 				att.setBaseUri(this.getUri());
-		if (outputAttributes != null)
-			for (Attribute att : outputAttributes)
+			}
+		}
+		if (outputAttributes != null){
+			for (Attribute att : outputAttributes){
 				attIdToAttMap.put(att.getId(), att);
+			}
+		}
 		this.outputAttributes = outputAttributes;
 	}
 
@@ -240,8 +250,9 @@ public class WebService extends Source {
 	}
 
 	public void setInputModel(Model inputModel) {
-		if (inputModel != null)
+		if (inputModel != null){
 			inputModel.setBaseUri(this.getUri());
+		}
 		this.inputModel = inputModel;
 	}
 	
@@ -250,8 +261,9 @@ public class WebService extends Source {
 	}
 
 	public void setOutputModel(Model outputModel) {
-		if (inputModel != null)
+		if (inputModel != null){
 			outputModel.setBaseUri(this.getUri());
+		}
 		this.outputModel = outputModel;
 	}
 	
@@ -264,8 +276,9 @@ public class WebService extends Source {
 	}
 
 	public String getAddress() {
-		if (address == null)
+		if (address == null){
 			doGrounding();
+		}
 		
 		return address;
 	}
@@ -279,23 +292,29 @@ public class WebService extends Source {
 	}
 
 	public Attribute getInputAttributeByName(String name) {
-		if (this.inputAttributes == null)
+		if (this.inputAttributes == null){
 			return null;
+		}
 		
-		for (Attribute att : this.inputAttributes)
-			if (att.getName().equalsIgnoreCase(name))
+		for (Attribute att : this.inputAttributes){
+			if (att.getName().equalsIgnoreCase(name)){
 				return att;
+			}
+		}
 		
 		return null;
 	}
 	
 	public Attribute getOutputAttributeByName(String name) {
-		if (this.outputAttributes == null)
+		if (this.outputAttributes == null){
 			return null;
+		}
 		
-		for (Attribute att : this.outputAttributes)
-			if (att.getName().equalsIgnoreCase(name))
+		for (Attribute att : this.outputAttributes){
+			if (att.getName().equalsIgnoreCase(name)){
 				return att;
+			}
+		}
 		
 		return null;
 	}
@@ -327,7 +346,9 @@ public class WebService extends Source {
 		
 		String params = "";
 		String[] addressParts = str.split("\\?");
-		if (addressParts.length == 2) params = addressParts[1];
+		if (addressParts.length == 2){
+			params = addressParts[1];
+		}
 		
 		// This only works for Web APIs and not RESTful APIs
 		for (int i = 0; i < this.inputAttributes.size(); i++) {
@@ -335,26 +356,30 @@ public class WebService extends Source {
 			String groundVar = "p" + String.valueOf(i+1);
 			int index = params.indexOf(name);
 			String temp = params.substring(index);
-			if (temp.indexOf("&") != -1)
+			if (temp.indexOf("&") != -1){
 				temp = temp.substring(0, temp.indexOf("&"));
-			if (temp.indexOf("=") != -1)
+			}
+			if (temp.indexOf("=") != -1){
 				temp = temp.substring(temp.indexOf("=") + 1);
+			}
 
 			params = params.replaceFirst(Pattern.quote(temp.trim()), "{" + groundVar + "}");
 			this.inputAttributes.get(i).setGroundedIn(groundVar);
 		}
 		
-		if (params.length() > 0)
+		if (params.length() > 0){
 			this.address = addressParts[0] + "?" + params;
-		else
+		}else{
 			this.address = str;
+		}
 
 	}
 	
 	public void updateModel(DirectedWeightedMultigraph<Node, Link> treeModel) {
 		
-		if (treeModel == null)
+		if (treeModel == null){
 			return;
+		}
 		
 		List<Node> inputAttributesNodes = new ArrayList<Node>();
 		List<Node> outputAttributesNodes = new ArrayList<Node>();
@@ -416,8 +441,9 @@ public class WebService extends Source {
 			List<Node> inputNodes, List<String> inputModelVertexes, List<String> inputModelEdges,
 			HashMap<String, Argument> vertexIdToArgument) {
 
-		if (treeModel == null)
+		if (treeModel == null){
 			return null;
+		}
 				
 		logger.debug("compute the steiner tree from the alignment tree with input nodes as steiner nodes ...");
 		UndirectedGraph<Node, Link> undirectedGraph = 
@@ -431,11 +457,13 @@ public class WebService extends Source {
 			
 			inputModelVertexes.add(n.getId());
 			
-			if (n instanceof ColumnNode || n instanceof LiteralNode)
+			if (n instanceof ColumnNode || n instanceof LiteralNode){
 				continue;
+			}
 			
-			if (vertexIdToArgument.get(n.getId()) == null)
+			if (vertexIdToArgument.get(n.getId()) == null){
 				continue;
+			}
 			
 			Label classPredicate = new Label(n.getLabel().getUri(), n.getLabel().getNs(), n.getLabel().getPrefix());
 
@@ -448,8 +476,9 @@ public class WebService extends Source {
 			inputModelEdges.add(e.getId());
 			
 			if (vertexIdToArgument.get(e.getSource().getId()) == null || 
-					vertexIdToArgument.get(e.getTarget().getId()) == null)
+					vertexIdToArgument.get(e.getTarget().getId()) == null){
 				continue;
+			}
 			
 			Label propertyPredicate = new Label(e.getLabel().getUri(), e.getLabel().getNs(), e.getLabel().getPrefix());
 			IndividualPropertyAtom propertyAtom = null;
@@ -475,21 +504,25 @@ public class WebService extends Source {
 			List<String> inputModelVertexes, List<String> inputModelEdges,
 			HashMap<String, Argument> vertexIdToArgument) {
 
-		if (treeModel == null)
+		if (treeModel == null){
 			return null;
+		}
 
 		Model m = new Model("outputModel");
 		
 		for (Node n : treeModel.vertexSet()) {
 			
-			if (inputModelVertexes.indexOf(n.getId()) != -1)
+			if (inputModelVertexes.indexOf(n.getId()) != -1){
 				continue;
+			}
 			
-			if (n instanceof ColumnNode || n instanceof LiteralNode)
+			if (n instanceof ColumnNode || n instanceof LiteralNode){
 				continue;
+			}
 			
-			if (vertexIdToArgument.get(n.getId()) == null)
+			if (vertexIdToArgument.get(n.getId()) == null){
 				continue;
+			}
 			
 			
 			Label classPredicate = new Label(n.getLabel().getUri(), n.getLabel().getNs(), n.getLabel().getPrefix());
@@ -500,12 +533,14 @@ public class WebService extends Source {
 		
 		for (Link e : treeModel.edgeSet()) {
 			
-			if (inputModelEdges.indexOf(e.getId()) != -1)
+			if (inputModelEdges.indexOf(e.getId()) != -1){
 				continue;
+			}
 			
 			if (vertexIdToArgument.get(e.getSource().getId()) == null || 
-					vertexIdToArgument.get(e.getTarget().getId()) == null)
+					vertexIdToArgument.get(e.getTarget().getId()) == null){
 				continue;
+			}
 			
 			Label propertyPredicate = new Label(e.getLabel().getUri(), e.getLabel().getNs(), e.getLabel().getPrefix());
 			IndividualPropertyAtom propertyAtom = null;
@@ -529,12 +564,16 @@ public class WebService extends Source {
 	}
 
 	public void buildHNodeId2AttributeMapping() {
-		for (Attribute att : getInputAttributes()) 
-			if (att.gethNodeId() != null)
+		for (Attribute att : getInputAttributes()){
+			if (att.gethNodeId() != null){
 				this.hNodeIdToAttribute.put(att.gethNodeId(), att);
-		for (Attribute att : getOutputAttributes()) 
-			if (att.gethNodeId() != null)
+			}
+		}
+		for (Attribute att : getOutputAttributes()){
+			if (att.gethNodeId() != null){
 				this.hNodeIdToAttribute.put(att.gethNodeId(), att);
+			}
+		}
 	}
 	
 	public String getInfo() {
@@ -556,15 +595,18 @@ public class WebService extends Source {
 		System.out.println("********************************************");
 		System.out.println("Variables: ");
 		if (this.variables != null) {
-			for (String v : this.variables)
+			for (String v : this.variables){
 				System.out.print(v + ", ");
+			}
 			System.out.println();
 		}
 		System.out.println("********************************************");
 		System.out.println("Input Attributes: ");
-		if (this.inputAttributes != null)
-			for (Attribute p : this.inputAttributes)
+		if (this.inputAttributes != null){
+			for (Attribute p : this.inputAttributes){
 				p.print();
+			}
+		}
 		System.out.println("********************************************");
 		System.out.println("Input Model: ");
 		if (this.inputModel != null) {
@@ -573,9 +615,11 @@ public class WebService extends Source {
 		}
 		System.out.println("********************************************");
 		System.out.println("Output Attributes: ");
-		if (this.outputAttributes != null)
-			for (Attribute p : getOutputAttributes())
+		if (this.outputAttributes != null){
+			for (Attribute p : getOutputAttributes()){
 				p.print();
+			}
+		}
 		System.out.println("********************************************");
 		System.out.println("Output Model: ");
 		if (this.outputModel != null) {

--- a/src/main/java/edu/isi/karma/service/json/Element.java
+++ b/src/main/java/edu/isi/karma/service/json/Element.java
@@ -42,8 +42,9 @@ public class Element {
 	}
 	public String getLocalName(int depth) {
 		String result = "";
-		if (valueType == ValueType.SINGLE)
+		if (valueType == ValueType.SINGLE){
 			result += "d=" + depth + ",k=" + getKey() + ",v=" + ((SingleValue)getValue()).getValueString();
+		}
 		return result;
 	}
 	public String getFullPath() {
@@ -54,8 +55,9 @@ public class Element {
 	}
 	public String getKey() {
 		// to remove @ in front of keys in process of converting xml to json
-		if (key.startsWith("@"))
+		if (key.startsWith("@")){
 			key = key.substring(1);
+		}
 		return key.trim();
 	}
 	public void setKey(String key) {
@@ -80,8 +82,9 @@ public class Element {
     
     private void print(Element root, int depth) {
     	String tabs = "";
-    	for (int i = 0; i < depth; i++)
-    		tabs += "\t";
+    	for (int i = 0; i < depth; i++){
+			tabs += "\t";
+		}
     	System.out.println(tabs + "name:" + root.key);
     	System.out.print(tabs + "value:");
 
@@ -90,8 +93,9 @@ public class Element {
     		System.out.println();
     	} else {
     		System.out.println();
-    		for (int i = 0; i < ((ArrayValue)root.value).getElements().size(); i++)
-    			print(((ArrayValue)root.value).getElements().get(i), depth + 1);
+    		for (int i = 0; i < ((ArrayValue)root.value).getElements().size(); i++){
+				print(((ArrayValue)root.value).getElements().get(i), depth + 1);
+			}
     	}
     }
 
@@ -100,12 +104,14 @@ public class Element {
     }
     
     private void computeFullPaths(Element root, List<String> result) {
-    	if (root.getFullPath().length() > 0) 
-    		result.add(root.getFullPath());
+    	if (root.getFullPath().length() > 0){
+			result.add(root.getFullPath());
+		}
     	if (root.valueType == ValueType.SINGLE) {
     	} else {
-    		for (int i = 0; i < ((ArrayValue)root.value).getElements().size(); i++)
-    			computeFullPaths(((ArrayValue)root.value).getElements().get(i), result);
+    		for (int i = 0; i < ((ArrayValue)root.value).getElements().size(); i++){
+				computeFullPaths(((ArrayValue)root.value).getElements().get(i), result);
+			}
     	}
     }
 
@@ -115,16 +121,18 @@ public class Element {
     
     private void updateHeaders(Element root, String prefix) {
     	if (prefix.trim().length() > 0) {
-    		if (root.key.trim().length() > 0)
-    			root.key = prefix + ":" + root.key;
-    		else
-    			root.key = prefix;
+    		if (root.key.trim().length() > 0){
+				root.key = prefix + ":" + root.key;
+			}else{
+				root.key = prefix;
+			}
     	}
     	if (root.valueType == ValueType.SINGLE) {
     		return;
     	} else {
-			for (Element children : ((ArrayValue)root.getValue()).getElements()) 
+			for (Element children : ((ArrayValue)root.getValue()).getElements()){
 				updateHeaders(children, root.key);
+			}
     	}
     }
     
@@ -168,8 +176,9 @@ public class Element {
 		    		unionT.cartesianProductOrUnionIfSameHeaders(innerT);
 				}
 			}
-			if (unionT.getColumnsCount() > 0)
+			if (unionT.getColumnsCount() > 0){
 				t.cartesianProductOrUnionIfSameHeaders(unionT);
+			}
 		}
     }
     
@@ -182,8 +191,9 @@ public class Element {
     	if (root.valueType == ValueType.ARRAY && ((ArrayValue)root.getValue()).getElements().size() <= 1) {
     		while (true) {
 	    		
-    			if (((ArrayValue)root.getValue()).getElements().size() > 1) 
-	    			break;
+    			if (((ArrayValue)root.getValue()).getElements().size() > 1){
+					break;
+				}
 	    		
     			if (((ArrayValue)root.getValue()).getElements().size() == 0) {
 //    				if (root.getParent() != null)
@@ -196,12 +206,14 @@ public class Element {
 				root.setValue(e.getValue());
 				root.setValueType(e.getValueType());
 				root.setKey(e.getKey());
-				if (e.valueType == ValueType.SINGLE) 
+				if (e.valueType == ValueType.SINGLE){
 					return;
+				}
     		}
     	}
-    	if (root.valueType == ValueType.SINGLE)
-    		return;
+    	if (root.valueType == ValueType.SINGLE){
+			return;
+		}
     	
     	for (int i = 0; i < ((ArrayValue)root.value).getElements().size(); i++) { 
 			moveUpOneValueElements(((ArrayValue)root.value).getElements().get(i));

--- a/src/main/java/edu/isi/karma/service/json/JsonManager.java
+++ b/src/main/java/edu/isi/karma/service/json/JsonManager.java
@@ -337,8 +337,9 @@ public class JsonManager {
 			for (int j = 0; j < srcColumns.get(i).size(); j++)
 			{
 				colName = srcColumns.get(i).get(j).toString();
-				if (columns.indexOf(colName) == -1)
+				if (columns.indexOf(colName) == -1){
 					columns.add(colName);
+				}
 			}
 		}
 		
@@ -354,10 +355,11 @@ public class JsonManager {
 				
 				for (int k = 0; k < columns.size(); k++) {
 					int index = rawNames.indexOf(columns.get(k).toString());
-					if (index == -1)
+					if (index == -1){
 						singleValue = null;
-					else
+					}else{
 						singleValue = rawValues.get(index);
+					}
 					populatedValues.add(singleValue);
 				}
 				
@@ -394,11 +396,12 @@ public class JsonManager {
 				
 				for (int k = 0; k < columns.size(); k++) {
 					int index = rawNames.indexOf(columns.get(k).toString());
-					if (index == -1)
-//						singleValue = null;
+					if (index == -1){
+						//						singleValue = null;
 						singleValue = "";
-					else
+					}else{
 						singleValue = rawValues.get(index);
+					}
 					populatedValues.add(singleValue);
 				}
 				
@@ -414,19 +417,24 @@ public class JsonManager {
     	element.updateHeaders();
     	Table t = element.getFlatTable();
 
-    	if (columns == null)
-    		columns = new ArrayList<String>();
+    	if (columns == null){
+			columns = new ArrayList<String>();
+		}
     	
-    	if (values == null)
-    		values = new ArrayList<List<String>>();
+    	if (values == null){
+			values = new ArrayList<List<String>>();
+		}
     	
     	if (t.getColumnsCount() > 0) {
-	    	for (Attribute att : t.getHeaders())
-	    		columns.add(att.getName());
+	    	for (Attribute att : t.getHeaders()){
+				columns.add(att.getName());
+			}
 	    	
-	    	for (List<String> v : t.getValues()) 
-	    		if (v != null)
-	    			values.add(v);
+	    	for (List<String> v : t.getValues()){
+				if (v != null){
+					values.add(v);
+				}
+			}
     	}
     	
 //    	t.print();
@@ -486,34 +494,44 @@ public class JsonManager {
         getJsonFlat(json, columns, values);
         
 		String csv = "";
-		if (separator == null) separator = ',';
-		if (quotechar == null) quotechar = '"';
-		if (endlinechar == null) endlinechar = '\n';
+		if (separator == null){
+			separator = ',';
+		}
+		if (quotechar == null){
+			quotechar = '"';
+		}
+		if (endlinechar == null){
+			endlinechar = '\n';
+		}
 		
 		try {
 			
 			if (columns != null && columns.size() > 0) {
 				for (int i = 0; i < columns.size(); i++) {
-					if (i != 0)
+					if (i != 0){
 						csv += separator.charValue();
+					}
 					csv += quotechar + columns.get(i) + quotechar;
 				}
 				csv += endlinechar;
-			} else
+			}else{
 				System.out.println("Json does not have any header.");
+			}
 
 			
 			if (values != null && values.size() > 0) {
 				for (int i = 0; i < values.size(); i++) {
 					for (int j = 0; j < values.get(i).size(); j++) {
-						if (j != 0)
+						if (j != 0){
 							csv += separator;
+						}
 						csv += quotechar + values.get(i).get(j) + quotechar;
 					}
 					csv += endlinechar;
 				}
-			} else
+			}else{
 				System.out.println("Json does not have any value.");
+			}
 
 			return csv;
 			

--- a/src/main/java/edu/isi/karma/service/json/SingleValue.java
+++ b/src/main/java/edu/isi/karma/service/json/SingleValue.java
@@ -30,10 +30,12 @@ public class SingleValue extends Value{
 	
 	public String getValueString() {
 		valueString = valueString.trim();
-		if (this.valueString.startsWith("\""))
+		if (this.valueString.startsWith("\"")){
 			valueString = valueString.substring(1);
-		if (this.valueString.endsWith("\""))
+		}
+		if (this.valueString.endsWith("\"")){
 			valueString = valueString.substring(0, valueString.length() - 1);
+		}
 		return this.valueString;
 	}
 }

--- a/src/main/java/edu/isi/karma/transformation/PythonTransformationHelper.java
+++ b/src/main/java/edu/isi/karma/transformation/PythonTransformationHelper.java
@@ -34,13 +34,15 @@ import edu.isi.karma.rep.Worksheet;
 
 public class PythonTransformationHelper {
 	public String getPyObjectValueAsString(PyObject obj) {
-		if (obj == null)
+		if (obj == null){
 			return "";
+		}
 		PyType type = obj.getType();
-		if (type.getName().equals("long"))
+		if (type.getName().equals("long")){
 			return Long.toString(obj.asLong());
-		else if (type.getName().equals("int"))
+		}else if (type.getName().equals("int")){
 			return Integer.toString(obj.asInt());
+		}
 		
 		return obj.asString();
 	}
@@ -60,8 +62,9 @@ public class PythonTransformationHelper {
 		Collection<HNode> hNodes = worksheet.getHeaders().getHNodes();
 		List<String> propertyNames = new ArrayList<String>();
 		for (HNode hNode: hNodes) {
-			if (hNode.hasNestedTable())
+			if (hNode.hasNestedTable()){
 				continue;
+			}
 			String propertyName = normalizeString(hNode.getColumnName());
 			normalizedColumnNamesMap.put(hNode.getColumnName(), propertyName);
 			pyClass.append("," + propertyName);
@@ -95,8 +98,9 @@ public class PythonTransformationHelper {
 		dictStmt.append("columnNameMap = {");
 		int counter = 0;
 		for (String columnName:columnNameMap.keySet()) {
-			if (counter != 0)
+			if (counter != 0){
 				dictStmt.append(",");
+			}
 			dictStmt.append("\"" + columnName + "\":\"" + columnNameMap.get(columnName) + "\"");
 			counter++;
 		}

--- a/src/main/java/edu/isi/karma/util/AbstractJDBCUtil.java
+++ b/src/main/java/edu/isi/karma/util/AbstractJDBCUtil.java
@@ -176,8 +176,9 @@ public abstract class AbstractJDBCUtil {
 	public ArrayList<String> getColumnNames(String tableName, Connection conn) throws SQLException {
 		ArrayList<String> columnNames = new ArrayList<String>();
 		String query = "select * from " + tableName;
-		if (conn == null)
+		if (conn == null){
 			return columnNames;
+		}
 		try {
 			Statement s = conn.createStatement();
 			ResultSet r = s.executeQuery(query);
@@ -216,8 +217,9 @@ public abstract class AbstractJDBCUtil {
 		// String res = executeQuery(connectString, query);
 		// logger.debug("RES="+res);
 
-		if (conn == null)
+		if (conn == null){
 			return columnTypes;
+		}
 		try {
 			Statement s = conn.createStatement();
 			ResultSet r = s.executeQuery(query);

--- a/src/main/java/edu/isi/karma/util/CommandInputJSONUtil.java
+++ b/src/main/java/edu/isi/karma/util/CommandInputJSONUtil.java
@@ -28,18 +28,20 @@ public class CommandInputJSONUtil {
 	
 	public static String getStringValue(String arg, JSONArray json) throws JSONException {
 		JSONObject obj = getJSONObjectWithName(arg, json);
-		if (obj == null)
+		if (obj == null){
 			return null;
-		else
+		}else{
 			return obj.getString(JsonKeys.value.name());
+		}
 	}
 
 	public static JSONArray getJSONArrayValue(String name, JSONArray json) throws JSONException {
 		JSONObject obj = getJSONObjectWithName(name, json);
-		if (obj == null)
+		if (obj == null){
 			return null;
-		else
+		}else{
 			return obj.getJSONArray(JsonKeys.value.name());
+		}
 	}
 	
 	public static JSONObject createJsonObject(String name, Object value, ParameterType type) throws JSONException {

--- a/src/main/java/edu/isi/karma/util/FileUtil.java
+++ b/src/main/java/edu/isi/karma/util/FileUtil.java
@@ -103,8 +103,9 @@ public class FileUtil {
 	}
 
 	public static void copyFiles(File destination, File source) throws FileNotFoundException, IOException{
-		if(!destination.exists())
+		if(!destination.exists()){
 			destination.createNewFile();
+		}
 		InputStream in = new FileInputStream(source);
 		OutputStream out = new FileOutputStream(destination);
 

--- a/src/main/java/edu/isi/karma/util/JDBCUtilFactory.java
+++ b/src/main/java/edu/isi/karma/util/JDBCUtilFactory.java
@@ -22,15 +22,17 @@ package edu.isi.karma.util;
 
 public class JDBCUtilFactory {
 	public static AbstractJDBCUtil getInstance(AbstractJDBCUtil.DBType dbType) {
-		if(dbType == AbstractJDBCUtil.DBType.MySQL)
+		if(dbType == AbstractJDBCUtil.DBType.MySQL){
 			return new MySQLUtil();
-		else if(dbType == AbstractJDBCUtil.DBType.Oracle)
+		}else if(dbType == AbstractJDBCUtil.DBType.Oracle){
 			return new OracleUtil();
-		else if(dbType == AbstractJDBCUtil.DBType.SQLServer)
+		}else if(dbType == AbstractJDBCUtil.DBType.SQLServer){
 			return new SQLServerUtil();
-		else if(dbType == AbstractJDBCUtil.DBType.PostGIS)
+		}else if(dbType == AbstractJDBCUtil.DBType.PostGIS){
 			return new PostGISUtil();
-		else return null;
+		}else{
+			return null;
+		}
 	}
 
 }

--- a/src/main/java/edu/isi/karma/util/JSONUtil.java
+++ b/src/main/java/edu/isi/karma/util/JSONUtil.java
@@ -179,23 +179,26 @@ public class JSONUtil {
 			JSONArray a1 = (JSONArray) obj1;
 			JSONArray a2 = (JSONArray) obj2;
 			
-			if(a1.length() != a2.length())
+			if(a1.length() != a2.length()){
 				return false;
+			}
 			
 			for (int i=0; i<a1.length(); i++) {
 				Object a = a1.get(i);
 				Object b = a2.get(i);
 				
-				if(!compareJSONObjects(a, b))
+				if(!compareJSONObjects(a, b)){
 					return false;
+				}
 			}
 			
 		} else if (obj1 instanceof JSONObject && obj2 instanceof JSONObject) {
 			JSONObject a1 = (JSONObject) obj1;
 			JSONObject a2 = (JSONObject) obj2;
 			
-			if(a1.length() != a2.length())
+			if(a1.length() != a2.length()){
 				return false;
+			}
 			
 			@SuppressWarnings("rawtypes")
 			Iterator keys = a1.keys();
@@ -208,8 +211,9 @@ public class JSONUtil {
 				} catch (JSONException e) {
 					return false;
 				}
-				if(!compareJSONObjects(val1, val2))
+				if(!compareJSONObjects(val1, val2)){
 					return false;
+				}
 			}
 			
 		} else if (obj1 instanceof String && obj2 instanceof String) {
@@ -224,9 +228,9 @@ public class JSONUtil {
 			return (Boolean)obj1 == (Boolean)obj2;
 		} else if (obj1 == JSONObject.NULL && obj2 == JSONObject.NULL) {
 			return true;
-		}
-		else
+		}else{
 			return false;
+		}
 		
 		return true;
 	}

--- a/src/main/java/edu/isi/karma/util/LogStackTrace.java
+++ b/src/main/java/edu/isi/karma/util/LogStackTrace.java
@@ -7,7 +7,8 @@ public class LogStackTrace {
 	public LogStackTrace(Exception e, Logger logger)
 	{
 		logger.debug(e.getMessage());
-		for(int i=0; i<e.getStackTrace().length; i++)
+		for(int i=0; i<e.getStackTrace().length; i++){
 			logger.error(e.getStackTrace()[i].toString());
+		}
 	}
 }

--- a/src/main/java/edu/isi/karma/util/MySQLUtil.java
+++ b/src/main/java/edu/isi/karma/util/MySQLUtil.java
@@ -47,8 +47,9 @@ public class MySQLUtil extends AbstractJDBCUtil {
 		ArrayList<String> tableNames = new ArrayList<String>();
 		DatabaseMetaData dmd = conn.getMetaData();
 		ResultSet rs = dmd.getTables(null, null, null, new String[] {"TABLE","VIEW"});
-		while (rs.next())
+		while (rs.next()){
 			tableNames.add(rs.getString(3));
+		}
 		Collections.sort(tableNames);
 		return tableNames;
 	}

--- a/src/main/java/edu/isi/karma/util/PostGISUtil.java
+++ b/src/main/java/edu/isi/karma/util/PostGISUtil.java
@@ -47,8 +47,9 @@ public class PostGISUtil extends AbstractJDBCUtil {
 		ArrayList<String> tableNames = new ArrayList<String>();
 		DatabaseMetaData dmd = conn.getMetaData();
 		ResultSet rs = dmd.getTables(null, null, null, new String[] {"TABLE"});
-		while (rs.next())
+		while (rs.next()){
 			tableNames.add(rs.getString(3));
+		}
 		Collections.sort(tableNames);
 		return tableNames;
 	}

--- a/src/main/java/edu/isi/karma/util/RandomGUID.java
+++ b/src/main/java/edu/isi/karma/util/RandomGUID.java
@@ -192,7 +192,9 @@ public class RandomGUID extends Object {
             StringBuffer sb = new StringBuffer();
             for (int j = 0; j < array.length; ++j) {
                 int b = array[j] & 0xFF;
-                if (b < 0x10) sb.append('0');
+                if (b < 0x10){
+					sb.append('0');
+				}
                 sb.append(Integer.toHexString(b));
             }
 

--- a/src/main/java/edu/isi/karma/util/SQLServerUtil.java
+++ b/src/main/java/edu/isi/karma/util/SQLServerUtil.java
@@ -49,8 +49,9 @@ public class SQLServerUtil extends AbstractJDBCUtil {
 		//Pedro: 2012/12/03 comment out to enable loading Views in Karma (on behalf of Maria)
 		//ResultSet rs = dmd.getTables(null, null, null, new String[] {"TABLE"});
 		ResultSet rs = dmd.getTables(null, null, null, new String[] {"TABLE","VIEW"});
-		while (rs.next())
+		while (rs.next()){
 			tableNames.add(rs.getString(3));
+		}
 		Collections.sort(tableNames);
 		return tableNames;
 	}

--- a/src/main/java/edu/isi/karma/view/VTable.java
+++ b/src/main/java/edu/isi/karma/view/VTable.java
@@ -99,8 +99,9 @@ public class VTable {
 				// Define the VRowEntry for this column.
 				String tag = viewFactory.getTableCssTags().getCssTag(
 						path.getLeaf().getHTableId(), 0);
-				if (tag == null)
+				if (tag == null){
 					tag = VTableCssTags.CSS_TOP_LEVEL_TABLE_CELL;
+				}
 				// System.err.println("VTable.addRows.TAG=" + tag + "%%");
 				VRowEntry re = new VRowEntry(path.toString(), tag);
 				vr.addRowEntry(re);

--- a/src/main/java/edu/isi/karma/view/VTableCssTags.java
+++ b/src/main/java/edu/isi/karma/view/VTableCssTags.java
@@ -63,8 +63,9 @@ public class VTableCssTags {
 	}
 	
 	public String getCssTag(String hTableId, int depth) {
-		if(useDepthBasedCSSTags)
+		if(useDepthBasedCSSTags){
 			return depthCssMap.get(depth%5);
+		}
 		String result = tagMap.get(hTableId);
 		if (result == null){
 			result = CSS_TOP_LEVEL_TABLE_CELL;

--- a/src/main/java/edu/isi/karma/view/ViewPreferences.java
+++ b/src/main/java/edu/isi/karma/view/ViewPreferences.java
@@ -150,8 +150,9 @@ public class ViewPreferences {
 			
 			// Check if the Commands element exists
 			commArray = json.optJSONArray("Commands");
-			if(commArray==null)	
+			if(commArray==null){
 				commArray = new JSONArray();
+			}
 			
 			// Check if the command already exists. In that case, we overwrite the values
 			for(int i=0; i<commArray.length(); i++) {

--- a/src/main/java/edu/isi/karma/view/alignmentHeadings/AlignmentForest.java
+++ b/src/main/java/edu/isi/karma/view/alignmentHeadings/AlignmentForest.java
@@ -92,8 +92,9 @@ public class AlignmentForest implements TForest {
 			List<TNode> nodes, Collection<TNode> columnTnodes) {
 		for (TNode node : nodes) {
 			AlignmentNode alNode = (AlignmentNode) node;
-			if (columnTnodes.contains(node))
+			if (columnTnodes.contains(node)){
 				finalOrder.add(TNodeToHNodeMap.get(node));
+			}
 
 			if (alNode.hasChildren()) {
 				addToFinalOrderFromChildren(finalOrder, alNode.getChildren(),
@@ -186,8 +187,9 @@ public class AlignmentForest implements TForest {
 			int seqIndex = nodeIndexMap.get(child);
 			logger.debug("Working on " + child.getId() + " Index:" + seqIndex);
 
-			if (seqIndex < minSeqIndex)
+			if (seqIndex < minSeqIndex){
 				minSeqIndex = seqIndex;
+			}
 
 			for (int j = i - 1; j >= 0; j--) {
 				TNode currChild = children.get(j);
@@ -251,8 +253,9 @@ public class AlignmentForest implements TForest {
 			if (alNode.hasChildren()) {
 				TNode nodeC = getAlignmentNodeWithHNodeId(alNode.getChildren(),
 						hNodeId);
-				if (nodeC != null)
+				if (nodeC != null){
 					return nodeC;
+				}
 			}
 		}
 		return null;

--- a/src/main/java/edu/isi/karma/view/alignmentHeadings/AlignmentNode.java
+++ b/src/main/java/edu/isi/karma/view/alignmentHeadings/AlignmentNode.java
@@ -64,22 +64,25 @@ public class AlignmentNode implements TNode {
 	}
 	
 	public boolean hasSemanticType() {
-		if(semanticType != null)
+		if(semanticType != null){
 			return true;
+		}
 		return false;
 	}
 	
 	public boolean hasChildren() {
-		if(children != null && children.size() != 0)
+		if(children != null && children.size() != 0){
 			return true;
+		}
 		return false;
 	}
 	
 	public String getSemanticTypeHNodeId() {
 		if(semanticType != null) {
 			return semanticType.getHNodeId();
-		} else
+		}else{
 			return null;
+		}
 	}
 
 	public void generateContentJson(PrintWriter pw) {

--- a/src/main/java/edu/isi/karma/view/tabledata/VDTableCells.java
+++ b/src/main/java/edu/isi/karma/view/tabledata/VDTableCells.java
@@ -551,10 +551,11 @@ public class VDTableCells {
 			strokeStyles.setStrokeStyle(Position.left, leftStrokeStyle);
 			strokeStyles.setStrokeStyle(Position.right, rightStrokeStyle);
 
-			if (separatorDepth >= columnDepth)
+			if (separatorDepth >= columnDepth){
 				cssDepth = columnDepth;
-			else
+			}else{
 				cssDepth = separatorDepth;
+			}
 
 			String attributes = encodeForJson(CellType.rowSpace,
 					strokeTB.getHTableId(),

--- a/src/main/java/edu/isi/karma/view/tableheadings/VTHNode.java
+++ b/src/main/java/edu/isi/karma/view/tableheadings/VTHNode.java
@@ -85,7 +85,8 @@ public class VTHNode implements TNode {
 	}
 
 	void addChild(VTHNode childNode) {
-		if(!children.contains(childNode))
+		if(!children.contains(childNode)){
 			children.add(childNode);
+		}
 	}
 }

--- a/src/main/java/edu/isi/karma/view/tableheadings/VTHeaderForest.java
+++ b/src/main/java/edu/isi/karma/view/tableheadings/VTHeaderForest.java
@@ -52,8 +52,9 @@ public class VTHeaderForest implements TForest {
 				rootNode = new VTHNode(rootId, root.getColumnName());
 				nodeMap.put(rootId, rootNode);
 			}
-			if (!roots.contains(rootNode))
+			if (!roots.contains(rootNode)){
 				roots.add(rootNode);
+			}
 
 			// Add the children
 			HNodePath rest = path.getRest();

--- a/src/main/java/edu/isi/karma/webserver/ExecutionController.java
+++ b/src/main/java/edu/isi/karma/webserver/ExecutionController.java
@@ -286,8 +286,9 @@ public class ExecutionController {
 					e.printStackTrace();
 					return null;
 				} 
-			} else
+			}else{
 				return cf.createCommand(request, vWorkspace);
+			}
 		} else {
 			logger.error("Command " + request.getParameter("command")
 					+ " not found!");

--- a/src/main/java/edu/isi/karma/webserver/GetExampleJSON.java
+++ b/src/main/java/edu/isi/karma/webserver/GetExampleJSON.java
@@ -81,11 +81,13 @@ public class GetExampleJSON extends HttpServlet {
 					"CRF_Models/"+workspace.getId()+"_CRFModel.txt");
 		}
 		/* Read and populate CRF Model from a file */
-		if(!crfModelFile.exists())
+		if(!crfModelFile.exists()){
 			crfModelFile.createNewFile();
+		}
 		boolean result = workspace.getCrfModelHandler().readModelFromFile(crfModelFile.getAbsolutePath());
-		if (!result)
+		if (!result){
 			logger.error("Error occured while reading CRF Model!");
+		}
 		
 		WorkspaceRegistry.getInstance().register(new ExecutionController(vwsp));
 		

--- a/src/main/java/edu/isi/karma/webserver/KMLFileTransferHandler.java
+++ b/src/main/java/edu/isi/karma/webserver/KMLFileTransferHandler.java
@@ -50,8 +50,9 @@ public class KMLFileTransferHandler extends HttpServlet {
 		// Move the file to the webapp directory so that it is public
 		File dir = new File(ServletContextParameterMap.getParameterValue(ContextParameter.USER_DIRECTORY_PATH) + 
 				"KML/"+file.getName());
-		if(dir.exists())
+		if(dir.exists()){
 			dir.delete();
+		}
 		file.renameTo(dir);
 		try {
 			Writer writer = response.getWriter();

--- a/src/main/java/edu/isi/karma/webserver/LinkedApiServiceHandler.java
+++ b/src/main/java/edu/isi/karma/webserver/LinkedApiServiceHandler.java
@@ -51,8 +51,9 @@ public class LinkedApiServiceHandler extends HttpServlet {
 			// regex parse pathInfo
 			
 			Matcher matcher;
-			if (pathInfo == null || pathInfo.trim().length() == 0)
+			if (pathInfo == null || pathInfo.trim().length() == 0){
 				return;
+			}
 			
 			if (method == HttpMethods.GET) {
 				matcher = getInputOrOutputWithFormatPattern.matcher(pathInfo);
@@ -101,8 +102,9 @@ public class LinkedApiServiceHandler extends HttpServlet {
 		}
 		public String getFormat() {
 			// I don't know why Jena gives error for turtle.
-			if (format.equalsIgnoreCase("TTL") || format.equalsIgnoreCase("TURTLE"))
+			if (format.equalsIgnoreCase("TTL") || format.equalsIgnoreCase("TURTLE")){
 				format = DEFAULT_FORMAT;
+			}
 			return format.toUpperCase();
 		}
 		public String getResource() {
@@ -120,7 +122,9 @@ public class LinkedApiServiceHandler extends HttpServlet {
 		RestRequest restRequest = null;
 		try {
 			String url = request.getPathInfo();
-			if (request.getQueryString() != null) url += "?" + request.getQueryString();
+			if (request.getQueryString() != null){
+				url += "?" + request.getQueryString();
+			}
 			restRequest = new RestRequest(url , HttpMethods.GET);
 		} catch (ServletException e) {
 			response.setContentType(MimeType.TEXT_PLAIN);
@@ -137,10 +141,12 @@ public class LinkedApiServiceHandler extends HttpServlet {
 		logger.debug("Resource: " + resource);
 
 		ResourceType resourceType = ResourceType.Service;
-		if (resource != null && resource.trim().toString().equalsIgnoreCase("input"))
+		if (resource != null && resource.trim().toString().equalsIgnoreCase("input")){
 			resourceType = ResourceType.Input;
-		if (resource != null && resource.trim().toString().equalsIgnoreCase("output"))
+		}
+		if (resource != null && resource.trim().toString().equalsIgnoreCase("output")){
 			resourceType = ResourceType.Output;
+		}
 
 		new GetRequestManager(serviceId, resourceType, format, response).HandleRequest();
 		
@@ -156,7 +162,9 @@ public class LinkedApiServiceHandler extends HttpServlet {
 		RestRequest restRequest = null;
 		try {
 			String url = request.getPathInfo();
-			if (request.getQueryString() != null) url += "?" + request.getQueryString();
+			if (request.getQueryString() != null){
+				url += "?" + request.getQueryString();
+			}
 			restRequest = new RestRequest(url, HttpMethods.POST);
 		} catch (ServletException e) {
 			response.setContentType(MimeType.TEXT_PLAIN);
@@ -177,14 +185,16 @@ public class LinkedApiServiceHandler extends HttpServlet {
 		
 		String formData = null;
 		String inputLang = "";
-		if (request.getContentType().startsWith(MimeType.APPLICATION_RDF_XML))
+		if (request.getContentType().startsWith(MimeType.APPLICATION_RDF_XML)){
 			inputLang = SerializationLang.XML;
-		if (request.getContentType().startsWith(MimeType.TEXT_XML))
+		}
+		if (request.getContentType().startsWith(MimeType.TEXT_XML)){
 			inputLang = SerializationLang.XML;
-		else if (request.getContentType().startsWith(MimeType.APPLICATION_XML))
+		}else if (request.getContentType().startsWith(MimeType.APPLICATION_XML)){
 			inputLang = SerializationLang.XML;
-		else if (request.getContentType().startsWith(MimeType.APPLICATION_RDF_N3))
+		}else if (request.getContentType().startsWith(MimeType.APPLICATION_RDF_N3)){
 			inputLang = SerializationLang.N3;
+		}
 		if (request.getContentType().startsWith(MimeType.APPLICATION_FORM_URLENCODED)) {
 			inputLang = SerializationLang.N3; // default for html forms
 			formData = request.getParameter("rdf");

--- a/src/main/java/edu/isi/karma/webserver/RequestController.java
+++ b/src/main/java/edu/isi/karma/webserver/RequestController.java
@@ -73,16 +73,18 @@ public class RequestController extends HttpServlet{
 					} catch (CommandException e) {
 						logger.error("Error occured while executing command: " + currentCommand.getCommandName(), e);
 					}
-				} else
+				}else{
 					responseString = ((CommandWithPreview) currentCommand).handleUserActions(request)
 							.generateJson(ctrl.getvWorkspace());
+				}
 			}
 		} else {
 			Command command = ctrl.getCommand(request);
-			if(command != null)
+			if(command != null){
 				responseString = ctrl.invokeCommand(command);
-			else
+			}else{
 				logger.error("Error occured while creating command (Could not create Command object): " + request.getParameter("command"));
+			}
 		}
 		
 		response.setCharacterEncoding("UTF-8");

--- a/src/main/java/edu/isi/karma/webserver/ServletContextParameterMap.java
+++ b/src/main/java/edu/isi/karma/webserver/ServletContextParameterMap.java
@@ -47,8 +47,9 @@ public class ServletContextParameterMap {
 	}
 
 	public static String getParameterValue(ContextParameter param) {
-		if (valuesMap.containsKey(param))
+		if (valuesMap.containsKey(param)){
 			return valuesMap.get(param);
+		}
 		logger.error("Parameter value does not exist! " + param);
 
 		return "";

--- a/src/main/java/edu/isi/mediator/domain/DomainAttribute.java
+++ b/src/main/java/edu/isi/mediator/domain/DomainAttribute.java
@@ -63,12 +63,13 @@ public class DomainAttribute{
 		if(name.contains(MediatorInstance.ILLEGAR_CHARS))
 			hasIllegalChars=true;
 */
-		if(type.equals("STRING"))
+		if(type.equals("STRING")){
 			this.type=AttrType.STRING;
-		else if(type.equals("NUMBER"))
+		}else if(type.equals("NUMBER")){
 			this.type=AttrType.NUMBER;
-		else
+		}else{
 			this.type=AttrType.OTHER;
+		}
 	}
 
 	/**
@@ -85,9 +86,9 @@ public class DomainAttribute{
 	public String getSQLName(){
 		if(hasIllegalChars){
 			return "`" + name.replaceAll(MediatorConstants.ILLEGAR_CHARS," ") + "`";
-		}
-		else
+		}else{
 			return name;
+		}
 	}
 
 	/**
@@ -98,8 +99,9 @@ public class DomainAttribute{
 	public boolean isNumber(){
 		if(type.equals(AttrType.NUMBER)){
 			return true;
+		}else{
+			return false;
 		}
-		else return false;
 	}
 	
 	/* (non-Javadoc)

--- a/src/main/java/edu/isi/mediator/domain/DomainModel.java
+++ b/src/main/java/edu/isi/mediator/domain/DomainModel.java
@@ -170,8 +170,9 @@ public class DomainModel{
 	public LAVRule getLAVRule(String name){
 		for(int i=0; i<lavRules.size(); i++){
 			LAVRule r = lavRules.get(i);
-			if(r.getHead().getName().equals(name))
+			if(r.getHead().getName().equals(name)){
 				return r;
+			}
 		}
 		return null;
 	}
@@ -185,8 +186,9 @@ public class DomainModel{
 	public GAVRule getGAVRule(String name){
 		for(int i=0; i<gavRules.size(); i++){
 			GAVRule r = gavRules.get(i);
-			if(r.getHead().getName().equals(name))
+			if(r.getHead().getName().equals(name)){
 				return r;
+			}
 		}
 		return null;
 	}
@@ -201,8 +203,9 @@ public class DomainModel{
 	public SourceSchema getSourceSchema(String name){
 		for(int i=0; i<sourceSchemas.size(); i++){
 			SourceSchema s = sourceSchemas.get(i);
-			if(s.getName().equals(name))
+			if(s.getName().equals(name)){
 				return s;
+			}
 		}
 		return null;
 	}
@@ -217,8 +220,9 @@ public class DomainModel{
 	public DomainSchema getDomainSchema(String name){
 		for(int i=0; i<domainSchemas.size(); i++){
 			DomainSchema s = domainSchemas.get(i);
-			if(s.getName().equals(name))
+			if(s.getName().equals(name)){
 				return s;
+			}
 		}
 		return null;
 	}
@@ -254,11 +258,13 @@ public class DomainModel{
 			return true;
 		}
 		DomainSchema ds = getDomainSchema(domainTable);
-		if(ds==null)
+		if(ds==null){
 			throw new MediatorException("Domain concept " +  domainTable + " does not exist.");
+		}
 		
-		if(ds.hasAttribute(domainAttr))
+		if(ds.hasAttribute(domainAttr)){
 			return true;
+		}
 		return false;
 	}
 

--- a/src/main/java/edu/isi/mediator/domain/DomainSchema.java
+++ b/src/main/java/edu/isi/mediator/domain/DomainSchema.java
@@ -68,9 +68,9 @@ public class DomainSchema{
 	public String getSQLName(){
 		if(hasIllegalChars){
 			return "`" + name.replaceAll(MediatorConstants.ILLEGAR_CHARS," ") + "`";
-		}
-		else
+		}else{
 			return name;
+		}
 	}
 
 	/**
@@ -112,8 +112,9 @@ public class DomainSchema{
 	public boolean hasAttribute(String name){
 		for(int i=0; i<attrs.size(); i++){
 			DomainAttribute da = attrs.get(i);
-			if(da.name.equals(name))
+			if(da.name.equals(name)){
 				return true;
+			}
 		}
 		return false;
 	}
@@ -125,7 +126,9 @@ public class DomainSchema{
 		String s = "";
 		s += name + "(";
 		for(int i=0; i<attrs.size(); i++){
-			if(i>0) s += ",";
+			if(i>0){
+				s += ",";
+			}
 			s += attrs.get(i).toString();
 		}
 		s+= ")";

--- a/src/main/java/edu/isi/mediator/domain/SourceAttribute.java
+++ b/src/main/java/edu/isi/mediator/domain/SourceAttribute.java
@@ -30,10 +30,11 @@ public class SourceAttribute extends DomainAttribute{
 	public SourceAttribute(String name, String type, String bound){
 		super(name, type);
 
-		if(bound.equals("B"))
+		if(bound.equals("B")){
 			this.needsBinding=true;
-		else
+		}else{
 			this.needsBinding=false;
+		}
 	}
 
 	public boolean needsBinding(){
@@ -43,9 +44,11 @@ public class SourceAttribute extends DomainAttribute{
 	public String toString(){
 		String s = "";
 		s += name + ":" + type + ":";
-		if(needsBinding)
+		if(needsBinding){
 			s += MediatorConstants.BOUND;
-		else s +=MediatorConstants.FREE;
+		}else{
+			s +=MediatorConstants.FREE;
+		}
 		return s;
 	}
 

--- a/src/main/java/edu/isi/mediator/domain/SourceSchema.java
+++ b/src/main/java/edu/isi/mediator/domain/SourceSchema.java
@@ -49,8 +49,9 @@ public class SourceSchema{
 	
 	public void addAttribute(SourceAttribute sa){
 		attrs.add(sa);
-		if(sa.needsBinding())
+		if(sa.needsBinding()){
 			needsBinding=true;
+		}
 	}
 	
 	public String getName(){
@@ -60,9 +61,9 @@ public class SourceSchema{
 	public String getSQLName(){
 		if(hasIllegalChars){
 			return "`" + name.replaceAll(MediatorConstants.ILLEGAR_CHARS," ") + "`";
-		}
-		else
+		}else{
 			return name;
+		}
 	}
 
 	public ArrayList<SourceAttribute> getAttrs(){
@@ -70,9 +71,11 @@ public class SourceSchema{
 	}
 	
 	public void setType(String type){
-		if(type.equals("function"))
+		if(type.equals("function")){
 			this.type=MediatorConstants.FUNCTION;
-		else this.type=MediatorConstants.OGSADQP;
+		}else{
+			this.type=MediatorConstants.OGSADQP;
+		}
 	}
 	
 	public String getType(){
@@ -90,8 +93,9 @@ public class SourceSchema{
 	public String getFirstFreeAttr(){
 		for(int i=0; i<attrs.size(); i++){
 			SourceAttribute a = attrs.get(i);
-			if(!a.needsBinding())
+			if(!a.needsBinding()){
 				return a.getName();
+			}
 		}
 		return null;
 	}
@@ -99,8 +103,9 @@ public class SourceSchema{
 	public int getFirstFreeAttrPosition(){
 		for(int i=0; i<attrs.size(); i++){
 			SourceAttribute a = attrs.get(i);
-			if(!a.needsBinding())
+			if(!a.needsBinding()){
 				return i;
+			}
 		}
 		return -1;
 	}
@@ -109,7 +114,9 @@ public class SourceSchema{
 		String s = "";
 		s += name + "(";
 		for(int i=0; i<attrs.size(); i++){
-			if(i>0) s += ",";
+			if(i>0){
+				s += ",";
+			}
 			s += attrs.get(i).toString();
 		}
 		s+= ")";

--- a/src/main/java/edu/isi/mediator/domain/parser/GAVRuleParser.java
+++ b/src/main/java/edu/isi/mediator/domain/parser/GAVRuleParser.java
@@ -84,9 +84,9 @@ public class GAVRuleParser {
 		if(r.isValid()){
 			// all vars in the head are in the body
 			return r;
-		}
-		else
+		}else{
 			return null;
+		}
 	}	
 
 }

--- a/src/main/java/edu/isi/mediator/domain/parser/GLAVRuleParser.java
+++ b/src/main/java/edu/isi/mediator/domain/parser/GLAVRuleParser.java
@@ -64,8 +64,9 @@ public class GLAVRuleParser{
 	 * @throws MediatorException
 	 */
 	public GLAVRule parseGLAVRule(String rule) throws MediatorException{
-		if(!rule.startsWith("GLAV_RULES:"))
+		if(!rule.startsWith("GLAV_RULES:")){
 			rule = "GLAV_RULES:" + rule;
+		}
 		
 		DomainParser dp = new DomainParser();
 		CommonTree t = dp.parse(rule);
@@ -112,8 +113,8 @@ public class GLAVRuleParser{
 		
 		if(r.isValid()){
 			return r;
-		}
-		else
+		}else{
 			return null;
+		}
 	}	
 }

--- a/src/main/java/edu/isi/mediator/domain/parser/LAVRuleParser.java
+++ b/src/main/java/edu/isi/mediator/domain/parser/LAVRuleParser.java
@@ -57,9 +57,9 @@ public class LAVRuleParser{
 			if(prefix.startsWith(RDFDomainModel.SOURCE_PREFIX)){
 				//will look like sourcePrefix:thePrefix
 				dm.addSourceNamespace(prefix.substring(RDFDomainModel.SOURCE_PREFIX.length()), namespace);
-			}
-			else
+			}else{
 				dm.addOntologyNamespace(prefix, namespace);
+			}
 		}
 	}
 	
@@ -89,8 +89,9 @@ public class LAVRuleParser{
 	 * @throws MediatorException
 	 */
 	public LAVRule parseLAVRule(String rule) throws MediatorException{
-		if(!rule.startsWith("LAV_RULES:"))
+		if(!rule.startsWith("LAV_RULES:")){
 			rule = "LAV_RULES:" + rule;
+		}
 		
 		DomainParser dp = new DomainParser();
 		CommonTree t = dp.parse(rule);
@@ -138,9 +139,9 @@ public class LAVRuleParser{
 		if(r.isValid()){
 			// all vars in the head are in the body
 			return r;
-		}
-		else
+		}else{
 			return null;
+		}
 	}	
 
 }

--- a/src/main/java/edu/isi/mediator/domain/parser/RuleParser.java
+++ b/src/main/java/edu/isi/mediator/domain/parser/RuleParser.java
@@ -68,8 +68,9 @@ public class RuleParser {
 					SourceSchema s = dm.getSourceSchema(p.getName());
 					p.setSource(s);
 				}
-				if(p.getType().equals(MediatorConstants.FUNCTION))
+				if(p.getType().equals(MediatorConstants.FUNCTION)){
 					p= new FunctionPredicate(p);
+				}
 				predicates.add(p);
 			}
 			else if(predicate.getText().equals(MediatorConstants.BUILTIN_PRED)){
@@ -215,10 +216,12 @@ public class RuleParser {
 		String var1 = predicate.getChild(1).getText();
 		String var2 = MediatorConstants.NULL_VALUE;
 		if(predicate.getChild(2)!=null)
+		 {
 			var2 = predicate.getChild(2).getText();
 		//System.out.println("R=" + var1);
 		//System.out.println("R=" + op);
 		//System.out.println("R=" + var2);
+		}
 
 		p.addTerm(var1);
 		p.addTerm(var2);
@@ -255,32 +258,33 @@ public class RuleParser {
 	 */
 	private String getOperator(String op) throws MediatorException{
 		String name;
-		if(op.equals("="))
+		if(op.equals("=")){
 			name=MediatorConstants.EQUALS;
-		else if(op.equals("!="))
+		}else if(op.equals("!=")){
 			name=MediatorConstants.NOT_EQUAL1;
-		else if(op.equals("<>"))
+		}else if(op.equals("<>")){
 			name=MediatorConstants.NOT_EQUAL2;
-		else if(op.equals("<"))
+		}else if(op.equals("<")){
 			name=MediatorConstants.LESS_THAN;
-		else if(op.equals("<="))
+		}else if(op.equals("<=")){
 			name=MediatorConstants.LESS_THAN_EQ;
-		else if(op.equals(">"))
+		}else if(op.equals(">")){
 			name=MediatorConstants.GREATER_THAN;
-		else if(op.equals(">="))
+		}else if(op.equals(">=")){
 			name=MediatorConstants.GREATER_THAN_EQ;
-		else if(op.equals("LIKE"))
+		}else if(op.equals("LIKE")){
 			name=MediatorConstants.LIKE;
-		else if(op.equals("IN"))
+		}else if(op.equals("IN")){
 			name=MediatorConstants.IN;
-		else if(op.equals("NOT_IN"))
+		}else if(op.equals("NOT_IN")){
 			name=MediatorConstants.NOT_IN;
-		else if(op.equals("IS_NULL"))
+		}else if(op.equals("IS_NULL")){
 			name=MediatorConstants.IS_NULL;
-		else if(op.equals("ISNOT_NULL"))
+		}else if(op.equals("ISNOT_NULL")){
 			name=MediatorConstants.ISNOT_NULL;
-		else
-			throw new MediatorException("Operator not supported: " + op);				
+		}else{
+			throw new MediatorException("Operator not supported: " + op);
+		}				
 		return name;
 	}
 }

--- a/src/main/java/edu/isi/mediator/domain/parser/SchemaParser.java
+++ b/src/main/java/edu/isi/mediator/domain/parser/SchemaParser.java
@@ -78,8 +78,9 @@ public class SchemaParser {
 		}
 
 		//check if it is a function
-		if(functions.contains(source.getText()))
+		if(functions.contains(source.getText())){
 			ss.setType(MediatorConstants.FUNCTION);
+		}
 
 		return ss;
 	}
@@ -100,15 +101,17 @@ public class SchemaParser {
 			name=name.substring(1, name.length()-1);
 		}
 		
-		if(attr.getChildCount()!=2)
+		if(attr.getChildCount()!=2){
 			throw(new MediatorException("Attribute definition for SourceSchema is incorrect " + attr.toStringTree()));
+		}
 		String type = attr.getChild(0).getText();
 		String binding = attr.getChild(1).getText();
 		
 		//System.out.println("name=" + name + " type=" + type + " binding=" + binding);
 		
-		if(!binding.toUpperCase().equals(MediatorConstants.BOUND) && !binding.toUpperCase().equals(MediatorConstants.FREE))
+		if(!binding.toUpperCase().equals(MediatorConstants.BOUND) && !binding.toUpperCase().equals(MediatorConstants.FREE)){
 			throw(new MediatorException("Binding can be only b|f " + attr.toStringTree()));
+		}
 		
 		SourceAttribute sa = new SourceAttribute(name, type.toUpperCase(), binding.toUpperCase());
 		return sa;
@@ -163,8 +166,9 @@ public class SchemaParser {
 			name=name.substring(1, name.length()-1);
 		}
 		
-		if(attr.getChildCount()!=1)
+		if(attr.getChildCount()!=1){
 			throw(new MediatorException("Attribute definition for DomainSchema is incorrect " + attr.toStringTree()));
+		}
 		String type = attr.getChild(0).getText();
 		
 		DomainAttribute sa = new DomainAttribute(name, type.toUpperCase());

--- a/src/main/java/edu/isi/mediator/domain/parser/grammar/DomainModelLexer.java
+++ b/src/main/java/edu/isi/mediator/domain/parser/grammar/DomainModelLexer.java
@@ -1061,7 +1061,9 @@ public class DomainModelLexer extends Lexer {
             	    break;
 
             	default :
-            	    if ( cnt4 >= 1 ) break loop4;
+            	    if ( cnt4 >= 1 ){
+						break loop4;
+					}
                         EarlyExitException eee =
                             new EarlyExitException(4, input);
                         throw eee;
@@ -1092,7 +1094,9 @@ public class DomainModelLexer extends Lexer {
             	    break;
 
             	default :
-            	    if ( cnt5 >= 1 ) break loop5;
+            	    if ( cnt5 >= 1 ){
+						break loop5;
+					}
                         EarlyExitException eee =
                             new EarlyExitException(5, input);
                         throw eee;
@@ -1141,7 +1145,9 @@ public class DomainModelLexer extends Lexer {
             	    break;
 
             	default :
-            	    if ( cnt6 >= 1 ) break loop6;
+            	    if ( cnt6 >= 1 ){
+						break loop6;
+					}
                         EarlyExitException eee =
                             new EarlyExitException(6, input);
                         throw eee;

--- a/src/main/java/edu/isi/mediator/domain/parser/grammar/DomainModelParser.java
+++ b/src/main/java/edu/isi/mediator/domain/parser/grammar/DomainModelParser.java
@@ -184,8 +184,12 @@ public class DomainModelParser extends Parser {
             	    section1=section();
 
             	    state._fsp--;
-            	    if (state.failed) return retval;
-            	    if ( state.backtracking==0 ) stream_section.add(section1.getTree());
+            	    if (state.failed){
+						return retval;
+					}
+            	    if ( state.backtracking==0 ){
+						stream_section.add(section1.getTree());
+					}
 
             	    }
             	    break;
@@ -323,8 +327,12 @@ public class DomainModelParser extends Parser {
                     schema2=schema();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) adaptor.addChild(root_0, schema2.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						adaptor.addChild(root_0, schema2.getTree());
+					}
 
                     }
                     break;
@@ -337,8 +345,12 @@ public class DomainModelParser extends Parser {
                     functions3=functions();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) adaptor.addChild(root_0, functions3.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						adaptor.addChild(root_0, functions3.getTree());
+					}
 
                     }
                     break;
@@ -351,8 +363,12 @@ public class DomainModelParser extends Parser {
                     rules4=rules();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) adaptor.addChild(root_0, rules4.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						adaptor.addChild(root_0, rules4.getTree());
+					}
 
                     }
                     break;
@@ -365,8 +381,12 @@ public class DomainModelParser extends Parser {
                     namespaces5=namespaces();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) adaptor.addChild(root_0, namespaces5.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						adaptor.addChild(root_0, namespaces5.getTree());
+					}
 
                     }
                     break;
@@ -420,8 +440,12 @@ public class DomainModelParser extends Parser {
             schema_name6=schema_name();
 
             state._fsp--;
-            if (state.failed) return retval;
-            if ( state.backtracking==0 ) stream_schema_name.add(schema_name6.getTree());
+            if (state.failed){
+				return retval;
+			}
+            if ( state.backtracking==0 ){
+				stream_schema_name.add(schema_name6.getTree());
+			}
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:87:16: ( schema_exp )*
             loop3:
             do {
@@ -441,8 +465,12 @@ public class DomainModelParser extends Parser {
             	    schema_exp7=schema_exp();
 
             	    state._fsp--;
-            	    if (state.failed) return retval;
-            	    if ( state.backtracking==0 ) stream_schema_exp.add(schema_exp7.getTree());
+            	    if (state.failed){
+						return retval;
+					}
+            	    if ( state.backtracking==0 ){
+						stream_schema_exp.add(schema_exp7.getTree());
+					}
 
             	    }
             	    break;
@@ -551,8 +579,12 @@ public class DomainModelParser extends Parser {
                 case 1 :
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:90:4: 'SOURCE_SCHEMA:'
                     {
-                    string_literal8=(Token)match(input,31,FOLLOW_31_in_schema_name222); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_31.add(string_literal8);
+                    string_literal8=(Token)match(input,31,FOLLOW_31_in_schema_name222); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_31.add(string_literal8);
+					}
 
 
 
@@ -586,8 +618,12 @@ public class DomainModelParser extends Parser {
                 case 2 :
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:91:4: 'DOMAIN_SCHEMA:'
                     {
-                    string_literal9=(Token)match(input,32,FOLLOW_32_in_schema_name233); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_32.add(string_literal9);
+                    string_literal9=(Token)match(input,32,FOLLOW_32_in_schema_name233); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_32.add(string_literal9);
+					}
 
 
 
@@ -664,8 +700,12 @@ public class DomainModelParser extends Parser {
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:94:2: ( 'FUNCTIONS:' ( function_name )* -> ^( FUNCTIONS ( function_name )* ) )
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:94:4: 'FUNCTIONS:' ( function_name )*
             {
-            string_literal10=(Token)match(input,33,FOLLOW_33_in_functions249); if (state.failed) return retval; 
-            if ( state.backtracking==0 ) stream_33.add(string_literal10);
+            string_literal10=(Token)match(input,33,FOLLOW_33_in_functions249); if (state.failed){
+				return retval;
+			} 
+            if ( state.backtracking==0 ){
+				stream_33.add(string_literal10);
+			}
 
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:94:17: ( function_name )*
             loop5:
@@ -686,8 +726,12 @@ public class DomainModelParser extends Parser {
             	    function_name11=function_name();
 
             	    state._fsp--;
-            	    if (state.failed) return retval;
-            	    if ( state.backtracking==0 ) stream_function_name.add(function_name11.getTree());
+            	    if (state.failed){
+						return retval;
+					}
+            	    if ( state.backtracking==0 ){
+						stream_function_name.add(function_name11.getTree());
+					}
 
             	    }
             	    break;
@@ -777,8 +821,12 @@ public class DomainModelParser extends Parser {
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:97:2: ( 'NAMESPACES:' ( namespace )* -> ^( NAMESPACES ( namespace )* ) )
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:97:4: 'NAMESPACES:' ( namespace )*
             {
-            string_literal12=(Token)match(input,34,FOLLOW_34_in_namespaces273); if (state.failed) return retval; 
-            if ( state.backtracking==0 ) stream_34.add(string_literal12);
+            string_literal12=(Token)match(input,34,FOLLOW_34_in_namespaces273); if (state.failed){
+				return retval;
+			} 
+            if ( state.backtracking==0 ){
+				stream_34.add(string_literal12);
+			}
 
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:97:18: ( namespace )*
             loop6:
@@ -799,8 +847,12 @@ public class DomainModelParser extends Parser {
             	    namespace13=namespace();
 
             	    state._fsp--;
-            	    if (state.failed) return retval;
-            	    if ( state.backtracking==0 ) stream_namespace.add(namespace13.getTree());
+            	    if (state.failed){
+						return retval;
+					}
+            	    if ( state.backtracking==0 ){
+						stream_namespace.add(namespace13.getTree());
+					}
 
             	    }
             	    break;
@@ -897,17 +949,29 @@ public class DomainModelParser extends Parser {
             namespace_prefix14=namespace_prefix();
 
             state._fsp--;
-            if (state.failed) return retval;
-            if ( state.backtracking==0 ) stream_namespace_prefix.add(namespace_prefix14.getTree());
-            char_literal15=(Token)match(input,35,FOLLOW_35_in_namespace299); if (state.failed) return retval; 
-            if ( state.backtracking==0 ) stream_35.add(char_literal15);
+            if (state.failed){
+				return retval;
+			}
+            if ( state.backtracking==0 ){
+				stream_namespace_prefix.add(namespace_prefix14.getTree());
+			}
+            char_literal15=(Token)match(input,35,FOLLOW_35_in_namespace299); if (state.failed){
+				return retval;
+			} 
+            if ( state.backtracking==0 ){
+				stream_35.add(char_literal15);
+			}
 
             pushFollow(FOLLOW_namespace_uri_in_namespace301);
             namespace_uri16=namespace_uri();
 
             state._fsp--;
-            if (state.failed) return retval;
-            if ( state.backtracking==0 ) stream_namespace_uri.add(namespace_uri16.getTree());
+            if (state.failed){
+				return retval;
+			}
+            if ( state.backtracking==0 ){
+				stream_namespace_uri.add(namespace_uri16.getTree());
+			}
 
 
             // AST REWRITE
@@ -998,17 +1062,29 @@ public class DomainModelParser extends Parser {
             table_name17=table_name();
 
             state._fsp--;
-            if (state.failed) return retval;
-            if ( state.backtracking==0 ) stream_table_name.add(table_name17.getTree());
-            char_literal18=(Token)match(input,36,FOLLOW_36_in_schema_exp320); if (state.failed) return retval; 
-            if ( state.backtracking==0 ) stream_36.add(char_literal18);
+            if (state.failed){
+				return retval;
+			}
+            if ( state.backtracking==0 ){
+				stream_table_name.add(table_name17.getTree());
+			}
+            char_literal18=(Token)match(input,36,FOLLOW_36_in_schema_exp320); if (state.failed){
+				return retval;
+			} 
+            if ( state.backtracking==0 ){
+				stream_36.add(char_literal18);
+			}
 
             pushFollow(FOLLOW_column_identifier_in_schema_exp322);
             column_identifier19=column_identifier();
 
             state._fsp--;
-            if (state.failed) return retval;
-            if ( state.backtracking==0 ) stream_column_identifier.add(column_identifier19.getTree());
+            if (state.failed){
+				return retval;
+			}
+            if ( state.backtracking==0 ){
+				stream_column_identifier.add(column_identifier19.getTree());
+			}
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:103:37: ( ',' column_identifier )*
             loop7:
             do {
@@ -1024,15 +1100,23 @@ public class DomainModelParser extends Parser {
             	case 1 :
             	    // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:103:38: ',' column_identifier
             	    {
-            	    char_literal20=(Token)match(input,37,FOLLOW_37_in_schema_exp325); if (state.failed) return retval; 
-            	    if ( state.backtracking==0 ) stream_37.add(char_literal20);
+            	    char_literal20=(Token)match(input,37,FOLLOW_37_in_schema_exp325); if (state.failed){
+						return retval;
+					} 
+            	    if ( state.backtracking==0 ){
+						stream_37.add(char_literal20);
+					}
 
             	    pushFollow(FOLLOW_column_identifier_in_schema_exp327);
             	    column_identifier21=column_identifier();
 
             	    state._fsp--;
-            	    if (state.failed) return retval;
-            	    if ( state.backtracking==0 ) stream_column_identifier.add(column_identifier21.getTree());
+            	    if (state.failed){
+						return retval;
+					}
+            	    if ( state.backtracking==0 ){
+						stream_column_identifier.add(column_identifier21.getTree());
+					}
 
             	    }
             	    break;
@@ -1042,8 +1126,12 @@ public class DomainModelParser extends Parser {
                 }
             } while (true);
 
-            char_literal22=(Token)match(input,38,FOLLOW_38_in_schema_exp331); if (state.failed) return retval; 
-            if ( state.backtracking==0 ) stream_38.add(char_literal22);
+            char_literal22=(Token)match(input,38,FOLLOW_38_in_schema_exp331); if (state.failed){
+				return retval;
+			} 
+            if ( state.backtracking==0 ){
+				stream_38.add(char_literal22);
+			}
 
 
 
@@ -1139,17 +1227,29 @@ public class DomainModelParser extends Parser {
             column_name23=column_name();
 
             state._fsp--;
-            if (state.failed) return retval;
-            if ( state.backtracking==0 ) stream_column_name.add(column_name23.getTree());
-            char_literal24=(Token)match(input,35,FOLLOW_35_in_column_identifier352); if (state.failed) return retval; 
-            if ( state.backtracking==0 ) stream_35.add(char_literal24);
+            if (state.failed){
+				return retval;
+			}
+            if ( state.backtracking==0 ){
+				stream_column_name.add(column_name23.getTree());
+			}
+            char_literal24=(Token)match(input,35,FOLLOW_35_in_column_identifier352); if (state.failed){
+				return retval;
+			} 
+            if ( state.backtracking==0 ){
+				stream_35.add(char_literal24);
+			}
 
             pushFollow(FOLLOW_column_type_in_column_identifier354);
             column_type25=column_type();
 
             state._fsp--;
-            if (state.failed) return retval;
-            if ( state.backtracking==0 ) stream_column_type.add(column_type25.getTree());
+            if (state.failed){
+				return retval;
+			}
+            if ( state.backtracking==0 ){
+				stream_column_type.add(column_type25.getTree());
+			}
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:106:33: ( ':' column_binding )?
             int alt8=2;
             int LA8_0 = input.LA(1);
@@ -1161,15 +1261,23 @@ public class DomainModelParser extends Parser {
                 case 1 :
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:106:34: ':' column_binding
                     {
-                    char_literal26=(Token)match(input,35,FOLLOW_35_in_column_identifier357); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_35.add(char_literal26);
+                    char_literal26=(Token)match(input,35,FOLLOW_35_in_column_identifier357); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_35.add(char_literal26);
+					}
 
                     pushFollow(FOLLOW_column_binding_in_column_identifier359);
                     column_binding27=column_binding();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) stream_column_binding.add(column_binding27.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						stream_column_binding.add(column_binding27.getTree());
+					}
 
                     }
                     break;
@@ -1302,8 +1410,12 @@ public class DomainModelParser extends Parser {
                     rule_name28=rule_name();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) stream_rule_name.add(rule_name28.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						stream_rule_name.add(rule_name28.getTree());
+					}
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:109:14: ( rule )*
                     loop9:
                     do {
@@ -1323,8 +1435,12 @@ public class DomainModelParser extends Parser {
                     	    rule29=rule();
 
                     	    state._fsp--;
-                    	    if (state.failed) return retval;
-                    	    if ( state.backtracking==0 ) stream_rule.add(rule29.getTree());
+                    	    if (state.failed){
+								return retval;
+							}
+                    	    if ( state.backtracking==0 ){
+								stream_rule.add(rule29.getTree());
+							}
 
                     	    }
                     	    break;
@@ -1375,8 +1491,12 @@ public class DomainModelParser extends Parser {
                 case 2 :
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:110:4: 'LAV_RULES:' ( lav_rule )*
                     {
-                    string_literal30=(Token)match(input,39,FOLLOW_39_in_rules403); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_39.add(string_literal30);
+                    string_literal30=(Token)match(input,39,FOLLOW_39_in_rules403); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_39.add(string_literal30);
+					}
 
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:110:17: ( lav_rule )*
                     loop10:
@@ -1397,8 +1517,12 @@ public class DomainModelParser extends Parser {
                     	    lav_rule31=lav_rule();
 
                     	    state._fsp--;
-                    	    if (state.failed) return retval;
-                    	    if ( state.backtracking==0 ) stream_lav_rule.add(lav_rule31.getTree());
+                    	    if (state.failed){
+								return retval;
+							}
+                    	    if ( state.backtracking==0 ){
+								stream_lav_rule.add(lav_rule31.getTree());
+							}
 
                     	    }
                     	    break;
@@ -1449,8 +1573,12 @@ public class DomainModelParser extends Parser {
                 case 3 :
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:111:4: 'GLAV_RULES:' ( glav_rule )*
                     {
-                    string_literal32=(Token)match(input,40,FOLLOW_40_in_rules422); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_40.add(string_literal32);
+                    string_literal32=(Token)match(input,40,FOLLOW_40_in_rules422); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_40.add(string_literal32);
+					}
 
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:111:18: ( glav_rule )*
                     loop11:
@@ -1471,8 +1599,12 @@ public class DomainModelParser extends Parser {
                     	    glav_rule33=glav_rule();
 
                     	    state._fsp--;
-                    	    if (state.failed) return retval;
-                    	    if ( state.backtracking==0 ) stream_glav_rule.add(glav_rule33.getTree());
+                    	    if (state.failed){
+								return retval;
+							}
+                    	    if ( state.backtracking==0 ){
+								stream_glav_rule.add(glav_rule33.getTree());
+							}
 
                     	    }
                     	    break;
@@ -1597,8 +1729,12 @@ public class DomainModelParser extends Parser {
                 case 1 :
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:114:4: 'GAV_RULES:'
                     {
-                    string_literal34=(Token)match(input,41,FOLLOW_41_in_rule_name446); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_41.add(string_literal34);
+                    string_literal34=(Token)match(input,41,FOLLOW_41_in_rule_name446); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_41.add(string_literal34);
+					}
 
 
 
@@ -1632,8 +1768,12 @@ public class DomainModelParser extends Parser {
                 case 2 :
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:115:4: 'UAC_RULES:'
                     {
-                    string_literal35=(Token)match(input,42,FOLLOW_42_in_rule_name457); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_42.add(string_literal35);
+                    string_literal35=(Token)match(input,42,FOLLOW_42_in_rule_name457); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_42.add(string_literal35);
+					}
 
 
 
@@ -1667,8 +1807,12 @@ public class DomainModelParser extends Parser {
                 case 3 :
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:116:4: 'QUERIES:'
                     {
-                    string_literal36=(Token)match(input,43,FOLLOW_43_in_rule_name468); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_43.add(string_literal36);
+                    string_literal36=(Token)match(input,43,FOLLOW_43_in_rule_name468); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_43.add(string_literal36);
+					}
 
 
 
@@ -1789,8 +1933,12 @@ public class DomainModelParser extends Parser {
                     relation_predicate37=relation_predicate();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) stream_relation_predicate.add(relation_predicate37.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						stream_relation_predicate.add(relation_predicate37.getTree());
+					}
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:119:23: ( '<-' | '::' )
                     int alt14=2;
                     int LA14_0 = input.LA(1);
@@ -1812,8 +1960,12 @@ public class DomainModelParser extends Parser {
                         case 1 :
                             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:119:24: '<-'
                             {
-                            string_literal38=(Token)match(input,44,FOLLOW_44_in_rule486); if (state.failed) return retval; 
-                            if ( state.backtracking==0 ) stream_44.add(string_literal38);
+                            string_literal38=(Token)match(input,44,FOLLOW_44_in_rule486); if (state.failed){
+								return retval;
+							} 
+                            if ( state.backtracking==0 ){
+								stream_44.add(string_literal38);
+							}
 
 
                             }
@@ -1821,8 +1973,12 @@ public class DomainModelParser extends Parser {
                         case 2 :
                             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:119:31: '::'
                             {
-                            string_literal39=(Token)match(input,45,FOLLOW_45_in_rule490); if (state.failed) return retval; 
-                            if ( state.backtracking==0 ) stream_45.add(string_literal39);
+                            string_literal39=(Token)match(input,45,FOLLOW_45_in_rule490); if (state.failed){
+								return retval;
+							} 
+                            if ( state.backtracking==0 ){
+								stream_45.add(string_literal39);
+							}
 
 
                             }
@@ -1834,8 +1990,12 @@ public class DomainModelParser extends Parser {
                     rule_body40=rule_body();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) stream_rule_body.add(rule_body40.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						stream_rule_body.add(rule_body40.getTree());
+					}
 
 
                     // AST REWRITE
@@ -1891,10 +2051,18 @@ public class DomainModelParser extends Parser {
                     relation_predicate41=relation_predicate();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) stream_relation_predicate.add(relation_predicate41.getTree());
-                    string_literal42=(Token)match(input,46,FOLLOW_46_in_rule518); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_46.add(string_literal42);
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						stream_relation_predicate.add(relation_predicate41.getTree());
+					}
+                    string_literal42=(Token)match(input,46,FOLLOW_46_in_rule518); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_46.add(string_literal42);
+					}
 
 
 
@@ -1988,13 +2156,21 @@ public class DomainModelParser extends Parser {
             relation_predicate43=relation_predicate();
 
             state._fsp--;
-            if (state.failed) return retval;
-            if ( state.backtracking==0 ) stream_relation_predicate.add(relation_predicate43.getTree());
+            if (state.failed){
+				return retval;
+			}
+            if ( state.backtracking==0 ){
+				stream_relation_predicate.add(relation_predicate43.getTree());
+			}
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:123:23: ( '->' )
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:123:24: '->'
             {
-            string_literal44=(Token)match(input,47,FOLLOW_47_in_lav_rule543); if (state.failed) return retval; 
-            if ( state.backtracking==0 ) stream_47.add(string_literal44);
+            string_literal44=(Token)match(input,47,FOLLOW_47_in_lav_rule543); if (state.failed){
+				return retval;
+			} 
+            if ( state.backtracking==0 ){
+				stream_47.add(string_literal44);
+			}
 
 
             }
@@ -2003,8 +2179,12 @@ public class DomainModelParser extends Parser {
             rule_body45=rule_body();
 
             state._fsp--;
-            if (state.failed) return retval;
-            if ( state.backtracking==0 ) stream_rule_body.add(rule_body45.getTree());
+            if (state.failed){
+				return retval;
+			}
+            if ( state.backtracking==0 ){
+				stream_rule_body.add(rule_body45.getTree());
+			}
 
 
             // AST REWRITE
@@ -2103,13 +2283,21 @@ public class DomainModelParser extends Parser {
             v1=rule_body();
 
             state._fsp--;
-            if (state.failed) return retval;
-            if ( state.backtracking==0 ) stream_rule_body.add(v1.getTree());
+            if (state.failed){
+				return retval;
+			}
+            if ( state.backtracking==0 ){
+				stream_rule_body.add(v1.getTree());
+			}
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:126:17: ( '->' )
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:126:18: '->'
             {
-            string_literal46=(Token)match(input,47,FOLLOW_47_in_glav_rule579); if (state.failed) return retval; 
-            if ( state.backtracking==0 ) stream_47.add(string_literal46);
+            string_literal46=(Token)match(input,47,FOLLOW_47_in_glav_rule579); if (state.failed){
+				return retval;
+			} 
+            if ( state.backtracking==0 ){
+				stream_47.add(string_literal46);
+			}
 
 
             }
@@ -2118,8 +2306,12 @@ public class DomainModelParser extends Parser {
             v2=rule_body();
 
             state._fsp--;
-            if (state.failed) return retval;
-            if ( state.backtracking==0 ) stream_rule_body.add(v2.getTree());
+            if (state.failed){
+				return retval;
+			}
+            if ( state.backtracking==0 ){
+				stream_rule_body.add(v2.getTree());
+			}
 
 
             // AST REWRITE
@@ -2220,8 +2412,12 @@ public class DomainModelParser extends Parser {
             predicate47=predicate();
 
             state._fsp--;
-            if (state.failed) return retval;
-            if ( state.backtracking==0 ) stream_predicate.add(predicate47.getTree());
+            if (state.failed){
+				return retval;
+			}
+            if ( state.backtracking==0 ){
+				stream_predicate.add(predicate47.getTree());
+			}
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:129:14: ( '^' predicate )*
             loop16:
             do {
@@ -2237,15 +2433,23 @@ public class DomainModelParser extends Parser {
             	case 1 :
             	    // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:129:15: '^' predicate
             	    {
-            	    char_literal48=(Token)match(input,48,FOLLOW_48_in_rule_body616); if (state.failed) return retval; 
-            	    if ( state.backtracking==0 ) stream_48.add(char_literal48);
+            	    char_literal48=(Token)match(input,48,FOLLOW_48_in_rule_body616); if (state.failed){
+						return retval;
+					} 
+            	    if ( state.backtracking==0 ){
+						stream_48.add(char_literal48);
+					}
 
             	    pushFollow(FOLLOW_predicate_in_rule_body618);
             	    predicate49=predicate();
 
             	    state._fsp--;
-            	    if (state.failed) return retval;
-            	    if ( state.backtracking==0 ) stream_predicate.add(predicate49.getTree());
+            	    if (state.failed){
+						return retval;
+					}
+            	    if ( state.backtracking==0 ){
+						stream_predicate.add(predicate49.getTree());
+					}
 
             	    }
             	    break;
@@ -2358,8 +2562,12 @@ public class DomainModelParser extends Parser {
                     relation_predicate50=relation_predicate();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) adaptor.addChild(root_0, relation_predicate50.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						adaptor.addChild(root_0, relation_predicate50.getTree());
+					}
 
                     }
                     break;
@@ -2372,8 +2580,12 @@ public class DomainModelParser extends Parser {
                     builtin_predicate51=builtin_predicate();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) adaptor.addChild(root_0, builtin_predicate51.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						adaptor.addChild(root_0, builtin_predicate51.getTree());
+					}
 
                     }
                     break;
@@ -2438,17 +2650,29 @@ public class DomainModelParser extends Parser {
             table_name52=table_name();
 
             state._fsp--;
-            if (state.failed) return retval;
-            if ( state.backtracking==0 ) stream_table_name.add(table_name52.getTree());
-            char_literal53=(Token)match(input,36,FOLLOW_36_in_relation_predicate652); if (state.failed) return retval; 
-            if ( state.backtracking==0 ) stream_36.add(char_literal53);
+            if (state.failed){
+				return retval;
+			}
+            if ( state.backtracking==0 ){
+				stream_table_name.add(table_name52.getTree());
+			}
+            char_literal53=(Token)match(input,36,FOLLOW_36_in_relation_predicate652); if (state.failed){
+				return retval;
+			} 
+            if ( state.backtracking==0 ){
+				stream_36.add(char_literal53);
+			}
 
             pushFollow(FOLLOW_column_value_in_relation_predicate654);
             column_value54=column_value();
 
             state._fsp--;
-            if (state.failed) return retval;
-            if ( state.backtracking==0 ) stream_column_value.add(column_value54.getTree());
+            if (state.failed){
+				return retval;
+			}
+            if ( state.backtracking==0 ){
+				stream_column_value.add(column_value54.getTree());
+			}
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:135:32: ( ',' column_value )*
             loop18:
             do {
@@ -2464,15 +2688,23 @@ public class DomainModelParser extends Parser {
             	case 1 :
             	    // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:135:33: ',' column_value
             	    {
-            	    char_literal55=(Token)match(input,37,FOLLOW_37_in_relation_predicate657); if (state.failed) return retval; 
-            	    if ( state.backtracking==0 ) stream_37.add(char_literal55);
+            	    char_literal55=(Token)match(input,37,FOLLOW_37_in_relation_predicate657); if (state.failed){
+						return retval;
+					} 
+            	    if ( state.backtracking==0 ){
+						stream_37.add(char_literal55);
+					}
 
             	    pushFollow(FOLLOW_column_value_in_relation_predicate659);
             	    column_value56=column_value();
 
             	    state._fsp--;
-            	    if (state.failed) return retval;
-            	    if ( state.backtracking==0 ) stream_column_value.add(column_value56.getTree());
+            	    if (state.failed){
+						return retval;
+					}
+            	    if ( state.backtracking==0 ){
+						stream_column_value.add(column_value56.getTree());
+					}
 
             	    }
             	    break;
@@ -2482,8 +2714,12 @@ public class DomainModelParser extends Parser {
                 }
             } while (true);
 
-            char_literal57=(Token)match(input,38,FOLLOW_38_in_relation_predicate663); if (state.failed) return retval; 
-            if ( state.backtracking==0 ) stream_38.add(char_literal57);
+            char_literal57=(Token)match(input,38,FOLLOW_38_in_relation_predicate663); if (state.failed){
+				return retval;
+			} 
+            if ( state.backtracking==0 ){
+				stream_38.add(char_literal57);
+			}
 
 
 
@@ -2629,17 +2865,29 @@ public class DomainModelParser extends Parser {
                     function_name58=function_name();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) stream_function_name.add(function_name58.getTree());
-                    char_literal59=(Token)match(input,36,FOLLOW_36_in_function_predicate685); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_36.add(char_literal59);
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						stream_function_name.add(function_name58.getTree());
+					}
+                    char_literal59=(Token)match(input,36,FOLLOW_36_in_function_predicate685); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_36.add(char_literal59);
+					}
 
                     pushFollow(FOLLOW_column_value_in_function_predicate687);
                     column_value60=column_value();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) stream_column_value.add(column_value60.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						stream_column_value.add(column_value60.getTree());
+					}
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:138:35: ( ',' column_value )*
                     loop19:
                     do {
@@ -2655,15 +2903,23 @@ public class DomainModelParser extends Parser {
                     	case 1 :
                     	    // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:138:36: ',' column_value
                     	    {
-                    	    char_literal61=(Token)match(input,37,FOLLOW_37_in_function_predicate690); if (state.failed) return retval; 
-                    	    if ( state.backtracking==0 ) stream_37.add(char_literal61);
+                    	    char_literal61=(Token)match(input,37,FOLLOW_37_in_function_predicate690); if (state.failed){
+								return retval;
+							} 
+                    	    if ( state.backtracking==0 ){
+								stream_37.add(char_literal61);
+							}
 
                     	    pushFollow(FOLLOW_column_value_in_function_predicate692);
                     	    column_value62=column_value();
 
                     	    state._fsp--;
-                    	    if (state.failed) return retval;
-                    	    if ( state.backtracking==0 ) stream_column_value.add(column_value62.getTree());
+                    	    if (state.failed){
+								return retval;
+							}
+                    	    if ( state.backtracking==0 ){
+								stream_column_value.add(column_value62.getTree());
+							}
 
                     	    }
                     	    break;
@@ -2673,8 +2929,12 @@ public class DomainModelParser extends Parser {
                         }
                     } while (true);
 
-                    char_literal63=(Token)match(input,38,FOLLOW_38_in_function_predicate696); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_38.add(char_literal63);
+                    char_literal63=(Token)match(input,38,FOLLOW_38_in_function_predicate696); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_38.add(char_literal63);
+					}
 
 
 
@@ -2722,13 +2982,25 @@ public class DomainModelParser extends Parser {
                     function_name64=function_name();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) stream_function_name.add(function_name64.getTree());
-                    char_literal65=(Token)match(input,36,FOLLOW_36_in_function_predicate714); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_36.add(char_literal65);
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						stream_function_name.add(function_name64.getTree());
+					}
+                    char_literal65=(Token)match(input,36,FOLLOW_36_in_function_predicate714); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_36.add(char_literal65);
+					}
 
-                    char_literal66=(Token)match(input,38,FOLLOW_38_in_function_predicate715); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_38.add(char_literal66);
+                    char_literal66=(Token)match(input,38,FOLLOW_38_in_function_predicate715); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_38.add(char_literal66);
+					}
 
 
 
@@ -2854,21 +3126,33 @@ public class DomainModelParser extends Parser {
                 case 1 :
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:142:4: '(' v1= column_value comparison (v2= column_value )? ')'
                     {
-                    char_literal67=(Token)match(input,36,FOLLOW_36_in_builtin_predicate732); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_36.add(char_literal67);
+                    char_literal67=(Token)match(input,36,FOLLOW_36_in_builtin_predicate732); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_36.add(char_literal67);
+					}
 
                     pushFollow(FOLLOW_column_value_in_builtin_predicate736);
                     v1=column_value();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) stream_column_value.add(v1.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						stream_column_value.add(v1.getTree());
+					}
                     pushFollow(FOLLOW_comparison_in_builtin_predicate738);
                     comparison68=comparison();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) stream_comparison.add(comparison68.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						stream_comparison.add(comparison68.getTree());
+					}
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:142:37: (v2= column_value )?
                     int alt21=2;
                     int LA21_0 = input.LA(1);
@@ -2884,16 +3168,24 @@ public class DomainModelParser extends Parser {
                             v2=column_value();
 
                             state._fsp--;
-                            if (state.failed) return retval;
-                            if ( state.backtracking==0 ) stream_column_value.add(v2.getTree());
+                            if (state.failed){
+								return retval;
+							}
+                            if ( state.backtracking==0 ){
+								stream_column_value.add(v2.getTree());
+							}
 
                             }
                             break;
 
                     }
 
-                    char_literal69=(Token)match(input,38,FOLLOW_38_in_builtin_predicate745); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_38.add(char_literal69);
+                    char_literal69=(Token)match(input,38,FOLLOW_38_in_builtin_predicate745); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_38.add(char_literal69);
+					}
 
 
 
@@ -2938,29 +3230,49 @@ public class DomainModelParser extends Parser {
                 case 2 :
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:143:4: '(' v1= column_value in_comparison v3= value_list ')'
                     {
-                    char_literal70=(Token)match(input,36,FOLLOW_36_in_builtin_predicate765); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_36.add(char_literal70);
+                    char_literal70=(Token)match(input,36,FOLLOW_36_in_builtin_predicate765); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_36.add(char_literal70);
+					}
 
                     pushFollow(FOLLOW_column_value_in_builtin_predicate769);
                     v1=column_value();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) stream_column_value.add(v1.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						stream_column_value.add(v1.getTree());
+					}
                     pushFollow(FOLLOW_in_comparison_in_builtin_predicate771);
                     in_comparison71=in_comparison();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) stream_in_comparison.add(in_comparison71.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						stream_in_comparison.add(in_comparison71.getTree());
+					}
                     pushFollow(FOLLOW_value_list_in_builtin_predicate775);
                     v3=value_list();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) stream_value_list.add(v3.getTree());
-                    char_literal72=(Token)match(input,38,FOLLOW_38_in_builtin_predicate777); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_38.add(char_literal72);
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						stream_value_list.add(v3.getTree());
+					}
+                    char_literal72=(Token)match(input,38,FOLLOW_38_in_builtin_predicate777); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_38.add(char_literal72);
+					}
 
 
 
@@ -3082,8 +3394,12 @@ public class DomainModelParser extends Parser {
                     column_name73=column_name();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) adaptor.addChild(root_0, column_name73.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						adaptor.addChild(root_0, column_name73.getTree());
+					}
 
                     }
                     break;
@@ -3096,8 +3412,12 @@ public class DomainModelParser extends Parser {
                     constant74=constant();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) adaptor.addChild(root_0, constant74.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						adaptor.addChild(root_0, constant74.getTree());
+					}
 
                     }
                     break;
@@ -3110,8 +3430,12 @@ public class DomainModelParser extends Parser {
                     function_predicate75=function_predicate();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) adaptor.addChild(root_0, function_predicate75.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						adaptor.addChild(root_0, function_predicate75.getTree());
+					}
 
                     }
                     break;
@@ -3163,7 +3487,9 @@ public class DomainModelParser extends Parser {
             set76=(Token)input.LT(1);
             if ( (input.LA(1)>=STRING && input.LA(1)<=FLOAT)||input.LA(1)==49 ) {
                 input.consume();
-                if ( state.backtracking==0 ) adaptor.addChild(root_0, (CommonTree)adaptor.create(set76));
+                if ( state.backtracking==0 ){
+					adaptor.addChild(root_0, (CommonTree)adaptor.create(set76));
+				}
                 state.errorRecovery=false;state.failed=false;
             }
             else {
@@ -3227,15 +3553,23 @@ public class DomainModelParser extends Parser {
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:152:2: ( '[' constant ( ',' constant )* ']' -> ( constant )+ )
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:152:4: '[' constant ( ',' constant )* ']'
             {
-            char_literal77=(Token)match(input,50,FOLLOW_50_in_value_list841); if (state.failed) return retval; 
-            if ( state.backtracking==0 ) stream_50.add(char_literal77);
+            char_literal77=(Token)match(input,50,FOLLOW_50_in_value_list841); if (state.failed){
+				return retval;
+			} 
+            if ( state.backtracking==0 ){
+				stream_50.add(char_literal77);
+			}
 
             pushFollow(FOLLOW_constant_in_value_list843);
             constant78=constant();
 
             state._fsp--;
-            if (state.failed) return retval;
-            if ( state.backtracking==0 ) stream_constant.add(constant78.getTree());
+            if (state.failed){
+				return retval;
+			}
+            if ( state.backtracking==0 ){
+				stream_constant.add(constant78.getTree());
+			}
             // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:152:17: ( ',' constant )*
             loop24:
             do {
@@ -3251,15 +3585,23 @@ public class DomainModelParser extends Parser {
             	case 1 :
             	    // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:152:18: ',' constant
             	    {
-            	    char_literal79=(Token)match(input,37,FOLLOW_37_in_value_list846); if (state.failed) return retval; 
-            	    if ( state.backtracking==0 ) stream_37.add(char_literal79);
+            	    char_literal79=(Token)match(input,37,FOLLOW_37_in_value_list846); if (state.failed){
+						return retval;
+					} 
+            	    if ( state.backtracking==0 ){
+						stream_37.add(char_literal79);
+					}
 
             	    pushFollow(FOLLOW_constant_in_value_list848);
             	    constant80=constant();
 
             	    state._fsp--;
-            	    if (state.failed) return retval;
-            	    if ( state.backtracking==0 ) stream_constant.add(constant80.getTree());
+            	    if (state.failed){
+						return retval;
+					}
+            	    if ( state.backtracking==0 ){
+						stream_constant.add(constant80.getTree());
+					}
 
             	    }
             	    break;
@@ -3269,8 +3611,12 @@ public class DomainModelParser extends Parser {
                 }
             } while (true);
 
-            char_literal81=(Token)match(input,51,FOLLOW_51_in_value_list852); if (state.failed) return retval; 
-            if ( state.backtracking==0 ) stream_51.add(char_literal81);
+            char_literal81=(Token)match(input,51,FOLLOW_51_in_value_list852); if (state.failed){
+				return retval;
+			} 
+            if ( state.backtracking==0 ){
+				stream_51.add(char_literal81);
+			}
 
 
 
@@ -3418,7 +3764,9 @@ public class DomainModelParser extends Parser {
                     {
                     root_0 = (CommonTree)adaptor.nil();
 
-                    char_literal82=(Token)match(input,52,FOLLOW_52_in_comparison867); if (state.failed) return retval;
+                    char_literal82=(Token)match(input,52,FOLLOW_52_in_comparison867); if (state.failed){
+						return retval;
+					}
                     if ( state.backtracking==0 ) {
                     char_literal82_tree = (CommonTree)adaptor.create(char_literal82);
                     adaptor.addChild(root_0, char_literal82_tree);
@@ -3431,7 +3779,9 @@ public class DomainModelParser extends Parser {
                     {
                     root_0 = (CommonTree)adaptor.nil();
 
-                    string_literal83=(Token)match(input,53,FOLLOW_53_in_comparison871); if (state.failed) return retval;
+                    string_literal83=(Token)match(input,53,FOLLOW_53_in_comparison871); if (state.failed){
+						return retval;
+					}
                     if ( state.backtracking==0 ) {
                     string_literal83_tree = (CommonTree)adaptor.create(string_literal83);
                     adaptor.addChild(root_0, string_literal83_tree);
@@ -3444,7 +3794,9 @@ public class DomainModelParser extends Parser {
                     {
                     root_0 = (CommonTree)adaptor.nil();
 
-                    char_literal84=(Token)match(input,54,FOLLOW_54_in_comparison875); if (state.failed) return retval;
+                    char_literal84=(Token)match(input,54,FOLLOW_54_in_comparison875); if (state.failed){
+						return retval;
+					}
                     if ( state.backtracking==0 ) {
                     char_literal84_tree = (CommonTree)adaptor.create(char_literal84);
                     adaptor.addChild(root_0, char_literal84_tree);
@@ -3457,7 +3809,9 @@ public class DomainModelParser extends Parser {
                     {
                     root_0 = (CommonTree)adaptor.nil();
 
-                    char_literal85=(Token)match(input,55,FOLLOW_55_in_comparison879); if (state.failed) return retval;
+                    char_literal85=(Token)match(input,55,FOLLOW_55_in_comparison879); if (state.failed){
+						return retval;
+					}
                     if ( state.backtracking==0 ) {
                     char_literal85_tree = (CommonTree)adaptor.create(char_literal85);
                     adaptor.addChild(root_0, char_literal85_tree);
@@ -3470,7 +3824,9 @@ public class DomainModelParser extends Parser {
                     {
                     root_0 = (CommonTree)adaptor.nil();
 
-                    string_literal86=(Token)match(input,56,FOLLOW_56_in_comparison883); if (state.failed) return retval;
+                    string_literal86=(Token)match(input,56,FOLLOW_56_in_comparison883); if (state.failed){
+						return retval;
+					}
                     if ( state.backtracking==0 ) {
                     string_literal86_tree = (CommonTree)adaptor.create(string_literal86);
                     adaptor.addChild(root_0, string_literal86_tree);
@@ -3483,7 +3839,9 @@ public class DomainModelParser extends Parser {
                     {
                     root_0 = (CommonTree)adaptor.nil();
 
-                    string_literal87=(Token)match(input,57,FOLLOW_57_in_comparison887); if (state.failed) return retval;
+                    string_literal87=(Token)match(input,57,FOLLOW_57_in_comparison887); if (state.failed){
+						return retval;
+					}
                     if ( state.backtracking==0 ) {
                     string_literal87_tree = (CommonTree)adaptor.create(string_literal87);
                     adaptor.addChild(root_0, string_literal87_tree);
@@ -3496,7 +3854,9 @@ public class DomainModelParser extends Parser {
                     {
                     root_0 = (CommonTree)adaptor.nil();
 
-                    string_literal88=(Token)match(input,58,FOLLOW_58_in_comparison891); if (state.failed) return retval;
+                    string_literal88=(Token)match(input,58,FOLLOW_58_in_comparison891); if (state.failed){
+						return retval;
+					}
                     if ( state.backtracking==0 ) {
                     string_literal88_tree = (CommonTree)adaptor.create(string_literal88);
                     adaptor.addChild(root_0, string_literal88_tree);
@@ -3509,7 +3869,9 @@ public class DomainModelParser extends Parser {
                     {
                     root_0 = (CommonTree)adaptor.nil();
 
-                    string_literal89=(Token)match(input,59,FOLLOW_59_in_comparison895); if (state.failed) return retval;
+                    string_literal89=(Token)match(input,59,FOLLOW_59_in_comparison895); if (state.failed){
+						return retval;
+					}
                     if ( state.backtracking==0 ) {
                     string_literal89_tree = (CommonTree)adaptor.create(string_literal89);
                     adaptor.addChild(root_0, string_literal89_tree);
@@ -3526,8 +3888,12 @@ public class DomainModelParser extends Parser {
                     null_comparison90=null_comparison();
 
                     state._fsp--;
-                    if (state.failed) return retval;
-                    if ( state.backtracking==0 ) adaptor.addChild(root_0, null_comparison90.getTree());
+                    if (state.failed){
+						return retval;
+					}
+                    if ( state.backtracking==0 ){
+						adaptor.addChild(root_0, null_comparison90.getTree());
+					}
 
                     }
                     break;
@@ -3614,11 +3980,19 @@ public class DomainModelParser extends Parser {
                 case 1 :
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:158:4: 'IS' 'NULL'
                     {
-                    string_literal91=(Token)match(input,60,FOLLOW_60_in_null_comparison909); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_60.add(string_literal91);
+                    string_literal91=(Token)match(input,60,FOLLOW_60_in_null_comparison909); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_60.add(string_literal91);
+					}
 
-                    string_literal92=(Token)match(input,49,FOLLOW_49_in_null_comparison911); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_49.add(string_literal92);
+                    string_literal92=(Token)match(input,49,FOLLOW_49_in_null_comparison911); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_49.add(string_literal92);
+					}
 
 
 
@@ -3652,14 +4026,26 @@ public class DomainModelParser extends Parser {
                 case 2 :
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:159:5: 'IS' 'NOT' 'NULL'
                     {
-                    string_literal93=(Token)match(input,60,FOLLOW_60_in_null_comparison924); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_60.add(string_literal93);
+                    string_literal93=(Token)match(input,60,FOLLOW_60_in_null_comparison924); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_60.add(string_literal93);
+					}
 
-                    string_literal94=(Token)match(input,61,FOLLOW_61_in_null_comparison926); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_61.add(string_literal94);
+                    string_literal94=(Token)match(input,61,FOLLOW_61_in_null_comparison926); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_61.add(string_literal94);
+					}
 
-                    string_literal95=(Token)match(input,49,FOLLOW_49_in_null_comparison928); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_49.add(string_literal95);
+                    string_literal95=(Token)match(input,49,FOLLOW_49_in_null_comparison928); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_49.add(string_literal95);
+					}
 
 
 
@@ -3757,8 +4143,12 @@ public class DomainModelParser extends Parser {
                 case 1 :
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:162:4: 'IN'
                     {
-                    string_literal96=(Token)match(input,62,FOLLOW_62_in_in_comparison944); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_62.add(string_literal96);
+                    string_literal96=(Token)match(input,62,FOLLOW_62_in_in_comparison944); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_62.add(string_literal96);
+					}
 
 
 
@@ -3792,11 +4182,19 @@ public class DomainModelParser extends Parser {
                 case 2 :
                     // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:163:5: 'NOT' 'IN'
                     {
-                    string_literal97=(Token)match(input,61,FOLLOW_61_in_in_comparison957); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_61.add(string_literal97);
+                    string_literal97=(Token)match(input,61,FOLLOW_61_in_in_comparison957); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_61.add(string_literal97);
+					}
 
-                    string_literal98=(Token)match(input,62,FOLLOW_62_in_in_comparison959); if (state.failed) return retval; 
-                    if ( state.backtracking==0 ) stream_62.add(string_literal98);
+                    string_literal98=(Token)match(input,62,FOLLOW_62_in_in_comparison959); if (state.failed){
+						return retval;
+					} 
+                    if ( state.backtracking==0 ){
+						stream_62.add(string_literal98);
+					}
 
 
 
@@ -3872,7 +4270,9 @@ public class DomainModelParser extends Parser {
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            ID99=(Token)match(input,ID,FOLLOW_ID_in_column_type975); if (state.failed) return retval;
+            ID99=(Token)match(input,ID,FOLLOW_ID_in_column_type975); if (state.failed){
+				return retval;
+			}
             if ( state.backtracking==0 ) {
             ID99_tree = (CommonTree)adaptor.create(ID99);
             adaptor.addChild(root_0, ID99_tree);
@@ -3923,7 +4323,9 @@ public class DomainModelParser extends Parser {
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            ID100=(Token)match(input,ID,FOLLOW_ID_in_column_binding987); if (state.failed) return retval;
+            ID100=(Token)match(input,ID,FOLLOW_ID_in_column_binding987); if (state.failed){
+				return retval;
+			}
             if ( state.backtracking==0 ) {
             ID100_tree = (CommonTree)adaptor.create(ID100);
             adaptor.addChild(root_0, ID100_tree);
@@ -3974,7 +4376,9 @@ public class DomainModelParser extends Parser {
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            ID101=(Token)match(input,ID,FOLLOW_ID_in_table_name999); if (state.failed) return retval;
+            ID101=(Token)match(input,ID,FOLLOW_ID_in_table_name999); if (state.failed){
+				return retval;
+			}
             if ( state.backtracking==0 ) {
             ID101_tree = (CommonTree)adaptor.create(ID101);
             adaptor.addChild(root_0, ID101_tree);
@@ -4025,7 +4429,9 @@ public class DomainModelParser extends Parser {
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            ID102=(Token)match(input,ID,FOLLOW_ID_in_column_name1009); if (state.failed) return retval;
+            ID102=(Token)match(input,ID,FOLLOW_ID_in_column_name1009); if (state.failed){
+				return retval;
+			}
             if ( state.backtracking==0 ) {
             ID102_tree = (CommonTree)adaptor.create(ID102);
             adaptor.addChild(root_0, ID102_tree);
@@ -4076,7 +4482,9 @@ public class DomainModelParser extends Parser {
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            ID103=(Token)match(input,ID,FOLLOW_ID_in_function_name1019); if (state.failed) return retval;
+            ID103=(Token)match(input,ID,FOLLOW_ID_in_function_name1019); if (state.failed){
+				return retval;
+			}
             if ( state.backtracking==0 ) {
             ID103_tree = (CommonTree)adaptor.create(ID103);
             adaptor.addChild(root_0, ID103_tree);
@@ -4127,7 +4535,9 @@ public class DomainModelParser extends Parser {
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            ID104=(Token)match(input,ID,FOLLOW_ID_in_namespace_prefix1028); if (state.failed) return retval;
+            ID104=(Token)match(input,ID,FOLLOW_ID_in_namespace_prefix1028); if (state.failed){
+				return retval;
+			}
             if ( state.backtracking==0 ) {
             ID104_tree = (CommonTree)adaptor.create(ID104);
             adaptor.addChild(root_0, ID104_tree);
@@ -4178,7 +4588,9 @@ public class DomainModelParser extends Parser {
             {
             root_0 = (CommonTree)adaptor.nil();
 
-            STRING105=(Token)match(input,STRING,FOLLOW_STRING_in_namespace_uri1037); if (state.failed) return retval;
+            STRING105=(Token)match(input,STRING,FOLLOW_STRING_in_namespace_uri1037); if (state.failed){
+				return retval;
+			}
             if ( state.backtracking==0 ) {
             STRING105_tree = (CommonTree)adaptor.create(STRING105);
             adaptor.addChild(root_0, STRING105_tree);
@@ -4215,7 +4627,9 @@ public class DomainModelParser extends Parser {
         relation_predicate();
 
         state._fsp--;
-        if (state.failed) return ;
+        if (state.failed){
+			return ;
+		}
         if ( (input.LA(1)>=44 && input.LA(1)<=45) ) {
             input.consume();
             state.errorRecovery=false;state.failed=false;
@@ -4230,7 +4644,9 @@ public class DomainModelParser extends Parser {
         rule_body();
 
         state._fsp--;
-        if (state.failed) return ;
+        if (state.failed){
+			return ;
+		}
 
         }
     }
@@ -4246,17 +4662,23 @@ public class DomainModelParser extends Parser {
         // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:142:4: ( '(' v1= column_value comparison (v2= column_value )? ')' )
         // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:142:4: '(' v1= column_value comparison (v2= column_value )? ')'
         {
-        match(input,36,FOLLOW_36_in_synpred26_DomainModel732); if (state.failed) return ;
+        match(input,36,FOLLOW_36_in_synpred26_DomainModel732); if (state.failed){
+			return ;
+		}
         pushFollow(FOLLOW_column_value_in_synpred26_DomainModel736);
         v1=column_value();
 
         state._fsp--;
-        if (state.failed) return ;
+        if (state.failed){
+			return ;
+		}
         pushFollow(FOLLOW_comparison_in_synpred26_DomainModel738);
         comparison();
 
         state._fsp--;
-        if (state.failed) return ;
+        if (state.failed){
+			return ;
+		}
         // C:\\Documents and Settings\\mariam\\My Documents\\mediator-new\\workspace\\domainparser\\DomainModel.g:142:37: (v2= column_value )?
         int alt31=2;
         int LA31_0 = input.LA(1);
@@ -4272,14 +4694,18 @@ public class DomainModelParser extends Parser {
                 v2=column_value();
 
                 state._fsp--;
-                if (state.failed) return ;
+                if (state.failed){
+					return ;
+				}
 
                 }
                 break;
 
         }
 
-        match(input,38,FOLLOW_38_in_synpred26_DomainModel745); if (state.failed) return ;
+        match(input,38,FOLLOW_38_in_synpred26_DomainModel745); if (state.failed){
+			return ;
+		}
 
         }
     }

--- a/src/main/java/edu/isi/mediator/gav/util/MediatorUtil.java
+++ b/src/main/java/edu/isi/mediator/gav/util/MediatorUtil.java
@@ -47,8 +47,9 @@ public class MediatorUtil {
 	 * 			false otherwise
 	 */
 	static public boolean isVar(String var){
-		if(var.toUpperCase().equals(MediatorConstants.NULL_VALUE))
+		if(var.toUpperCase().equals(MediatorConstants.NULL_VALUE)){
 			return false;
+		}
 		if(!var.startsWith("\"") && !var.startsWith("'")){
 			//if it's not between quotes AND is not a number
 			try{
@@ -58,8 +59,9 @@ public class MediatorUtil {
 			catch(Exception e){
 				return true;
 			}
+		}else{
+			return false;
 		}
-		else return false;
 	}
 
 	static public String removeBacktick(String s){
@@ -74,8 +76,9 @@ public class MediatorUtil {
 //		s = s.trim();
 		if(s.startsWith("`")){
 			return s;
+		}else{
+			return "`"+s+"`";
 		}
-		else return "`"+s+"`";
 	}
 
 	/**

--- a/src/main/java/edu/isi/mediator/rdf/JenaUtil.java
+++ b/src/main/java/edu/isi/mediator/rdf/JenaUtil.java
@@ -95,8 +95,9 @@ public class JenaUtil {
 				//extract the prefix
 				int ind1 = propertyValue.indexOf("http");
 				int ind2 = propertyValue.lastIndexOf("/");
-				if(ind1>=0 && ind2>0)
+				if(ind1>=0 && ind2>0){
 					propertyPrefix = propertyValue.substring(ind1,ind2+1);
+				}
 			}
 		}
 		logger.debug("Property Prefix=" +  propertyPrefix);
@@ -205,11 +206,13 @@ public class JenaUtil {
 			}
 			else {
 				//it's a URI/Resource, so I have to extract the value
-				if(valueAsURI)
+				if(valueAsURI){
 					onerow.put(var, node.toString());
-				else
+				}
+				else {
 					onerow.put(var, getValueFromUri(node.toString()));
 				//System.out.println("VAR=" + var + " Val=" + node.toString());
+				}
 			}
 
 		}

--- a/src/main/java/edu/isi/mediator/rdf/OntologyMapper.java
+++ b/src/main/java/edu/isi/mediator/rdf/OntologyMapper.java
@@ -158,9 +158,10 @@ public class OntologyMapper {
 		DomainParser sp = new DomainParser();
 		RDFDomainModel dm = (RDFDomainModel)sp.parseDomain(sourceDesc);
 
-		if(dm.getGAVRules().size()!= dm.getLAVRules().size())
+		if(dm.getGAVRules().size()!= dm.getLAVRules().size()){
 			throw new MediatorException("Number of GAV and LAV rules should be the same." +
 					"There should be a GAV rule that corresponds to every LAV Rule.");
+		}
 		
 		//create the output writer
 		PrintWriter outWriter = getOutWriter(outStr, outFile);
@@ -486,10 +487,11 @@ public class OntologyMapper {
 				}
 			}
 			objectURI.put(var, "o_" + tableName);
-			if(isJoin)
+			if(isJoin){
 				query += " ?o_" + tableName + " vocab:" + tableName + "_" + propertyName + " ?" + var + " .  \n";
-			else
+			}else{
 				query += " OPTIONAL { ?o_" + tableName + " vocab:" + tableName + "_" + propertyName + " ?" + var + " . } \n";
+			}
 		}
 		//System.out.println("PQ=" + query);
 		return query;
@@ -518,11 +520,13 @@ public class OntologyMapper {
 		String var1 = p.getVars().get(0);
 		String var2 = p.getVars().get(1);
 		String obj = keyObjects.get(var1);
-		if(obj != null)
+		if(obj != null){
 			var1 = obj;
+		}
 		obj = keyObjects.get(var2);
-		if(obj != null)
+		if(obj != null){
 			var2 = obj;
+		}
 		//I don't know which way the relationship is, so go both ways
 		query[0] = " ?" + var2 + " vocab:" + dbName + tableName + " ?" + var1 + " .  \n";
 		query[1] = " ?" + var1 + " vocab:" + dbName + tableName + " ?" + var2 + " .  \n";
@@ -542,8 +546,9 @@ public class OntologyMapper {
 	 */
 	private boolean isRelationship(Predicate p) throws MediatorException{
 		//check if properties represented by the column names exist
-		if(p.getName().startsWith("XW_"))
+		if(p.getName().startsWith("XW_")){
 			return true;
+		}
 		return false;
 		
 	}
@@ -574,8 +579,9 @@ public class OntologyMapper {
 		
 		List<Map<String, String>> allRules = JenaUtil.executeQuery(model, q);
 		
-		if(allRules.isEmpty())
+		if(allRules.isEmpty()){
 			throw new MediatorException("No transformation rule found for: " + tableName);
+		}
 		
 		for(int i=0; i<allRules.size(); i++){
 			Map<String, String> oneR = allRules.get(i);

--- a/src/main/java/edu/isi/mediator/rdf/RDFGenerator.java
+++ b/src/main/java/edu/isi/mediator/rdf/RDFGenerator.java
@@ -211,11 +211,11 @@ public class RDFGenerator {
 	 */
 	public void generateTriples(String input, String sourceType) throws MediatorException, IOException, SQLException, ClassNotFoundException{
 		
-		if(sourceType == RDFGeneratorMain.CSV)
+		if(sourceType == RDFGeneratorMain.CSV){
 			generateTriplesCSV(input);
-		else if(sourceType == RDFGeneratorMain.ACCESS)
+		}else if(sourceType == RDFGeneratorMain.ACCESS){
 			generateTriplesACCESS(input);
-		else{
+		}else{
 			//sourceType is the DBDriver
 			generateTriplesDB(input,sourceType);
 		}

--- a/src/main/java/edu/isi/mediator/rdf/RDFGeneratorMain.java
+++ b/src/main/java/edu/isi/mediator/rdf/RDFGeneratorMain.java
@@ -94,11 +94,13 @@ public class RDFGeneratorMain {
 				String line = null;
 				while ((line = buff.readLine()) != null) {
 					//System.out.println("line="+line);
-					if (line.startsWith("#") || line.trim().isEmpty())
+					if (line.startsWith("#") || line.trim().isEmpty()){
 						continue;
+					}
 					int ind = line.indexOf("=");
-					if(ind<=0)
+					if(ind<=0){
 						throw new MediatorException("Settings should be of form: PropertyName=PropertyValue " + line);
+					}
 					String name = line.substring(0,ind).trim();
 					String val = line.substring(ind+1).trim();
 
@@ -118,13 +120,14 @@ public class RDFGeneratorMain {
 						accessDb = val;
 						inputsUsed++;
 					}
-					else if (name.equals("SOURCE_DESC"))
+					else if (name.equals("SOURCE_DESC")){
 						ruleFile = val;
-					else if (name.equals("OUTPUT_FILE")){
-						if(val.toUpperCase().equals("STDOUT"))
+					}else if (name.equals("OUTPUT_FILE")){
+						if(val.toUpperCase().equals("STDOUT")){
 							outputFile=null;
-						else
+						}else{
 							outputFile=val;
+						}
 					}
 				}
 			} catch (IOException e2) {
@@ -134,10 +137,12 @@ public class RDFGeneratorMain {
 			if(ruleFile==null){
 				throw new MediatorException("Settings file is missiong SOURCE_DESC.");
 			}
-			if(inputsUsed==0)
+			if(inputsUsed==0){
 				throw new MediatorException("Settings file should contain either INPUT_FILE, CONNECT_STR or ACCESS_DB");
-			if(inputsUsed>1)
+			}
+			if(inputsUsed>1){
 				throw new MediatorException("Settings file should contain only ONE of INPUT_FILE, CONNECT_STR or ACCESS_DB.");
+			}
 			if(connectStr!=null && dbDriver==null){
 				throw new MediatorException("Settings file should contain DB_DRIVER.");
 			}

--- a/src/main/java/edu/isi/mediator/rdf/RDFUtil.java
+++ b/src/main/java/edu/isi/mediator/rdf/RDFUtil.java
@@ -88,8 +88,9 @@ public class RDFUtil {
 		
 		String tokens[] = uri.split("/");
 		
-		if(tokens.length<2)
+		if(tokens.length<2){
 			throw new MediatorException("The URI must contain a table name either as DBNAME.TableName/ or /TableName/.");
+		}
 		
 		String tableName = tokens[tokens.length-2];
 		
@@ -142,8 +143,9 @@ public class RDFUtil {
 		
 		String tokens[] = uri.split("/");
 		
-		if(tokens.length<2)
+		if(tokens.length<2){
 			throw new MediatorException("The URI must contain a table name either as DBNAME.TableName/ or /TableName/.");
+		}
 		
 		String dbName = tokens[tokens.length-2];
 		
@@ -152,8 +154,9 @@ public class RDFUtil {
 
 		if(ind>0){
 			dbName = dbName.substring(0, ind) + ".";
+		}else{
+			dbName = "";
 		}
-		else dbName = "";
 		
 		logger.debug("Database name=" + dbName);
 		

--- a/src/main/java/edu/isi/mediator/rdf/RuleRDFGenerator.java
+++ b/src/main/java/edu/isi/mediator/rdf/RuleRDFGenerator.java
@@ -302,9 +302,9 @@ public class RuleRDFGenerator {
 					//abort the process; max number of triples was reached
 					return false;
 				}
-			}
-			else
-				continue;			
+			}else{
+				continue;
+			}			
 		}
 		return true;
 	}
@@ -336,9 +336,9 @@ public class RuleRDFGenerator {
 					//abort the process; max number of triples was reached
 					return false;
 				}
-			}
-			else
+			}else{
 				continue;
+			}
 		}
 		return true;
 	}
@@ -362,13 +362,15 @@ public class RuleRDFGenerator {
 	protected boolean addClassStatement(Predicate p, Map<String,String> values) throws MediatorException, UnsupportedEncodingException{
 		String className = p.getName();
 		//remove backtick
-		if(className.startsWith("`"))
+		if(className.startsWith("`")){
 			className = className.substring(1,className.length()-1);
+		}
 		
 		//the class name is the VALUE of the column name (p=`expand@column_name(uri(`id`))) ; 
 		//look for the value of column_name in values to find the actual class name 
-		if(className.startsWith("expand@"))
+		if(className.startsWith("expand@")){
 			className = getExpandedName(className, values);
+		}
 		
 		if(className==null){
 			//the value is empty or null; don't include this triple
@@ -389,8 +391,9 @@ public class RuleRDFGenerator {
 		ArrayList<Term> terms = p.getTerms();
 		Term t = terms.get(0);
 		//should be a uri FunctionTerm uri(VAR_NAME)
-		if(!(t instanceof FunctionTerm))
+		if(!(t instanceof FunctionTerm)){
 			throw new MediatorException("A subject should have only one uri FunctionTerm: " + p);
+		}
 		
 		FunctionPredicate uri = ((FunctionTerm) t).getFunction();
 		
@@ -416,9 +419,9 @@ public class RuleRDFGenerator {
 		if(!tripleAdded){
 			//abort the process; max number of triples was reached
 			return false;
-		}
-		else
+		}else{
 			return true;
+		}
 	}
 	
 	/**
@@ -442,8 +445,9 @@ public class RuleRDFGenerator {
 		//remove back-tick
 		String predicateName = p.getName();
 		//System.out.println("Predicate Name=" + predicateName);
-		if(predicateName.startsWith("`"))
+		if(predicateName.startsWith("`")){
 			predicateName = predicateName.substring(1,predicateName.length()-1);
+		}
 		
 		// Remove the RDF literal type
 		String rdfLiteralType = "";
@@ -454,8 +458,9 @@ public class RuleRDFGenerator {
 
 		//the predicate name is the VALUE of the column name (p=`expand@predicate_name(uri(`id`))) ; 
 		//look for the value of column_name in values to find the actual class name 
-		if(predicateName.startsWith("expand@"))
+		if(predicateName.startsWith("expand@")){
 			predicateName = getExpandedName(predicateName, values);
+		}
 
 		if(predicateName==null){
 			//the value is empty or null; don't include this triple
@@ -486,14 +491,16 @@ public class RuleRDFGenerator {
 		ArrayList<Term> terms = p.getTerms();
 		//should have exactly 2 terms
 		//first is the subject, second is the value
-		if(terms.size()!=2)
+		if(terms.size()!=2){
 			throw new MediatorException("A predicate should have 2 terms: " + p);
+		}
 		
 		Term t1 = terms.get(0);
 		Term t2 = terms.get(1);
 		//t1 should be a uri FunctionTerm uri(VAR_NAME); related to the subject
-		if(!(t1 instanceof FunctionTerm))
+		if(!(t1 instanceof FunctionTerm)){
 			throw new MediatorException("First term in predicate should be uri FunctionTerm: " + p);
+		}
 		
 		FunctionPredicate uri1 = ((FunctionTerm) t1).getFunction();
 		
@@ -530,8 +537,9 @@ public class RuleRDFGenerator {
 			//it's a VarTerm
 			String varName = t2.getVar();
 			String varValue = values.get(MediatorUtil.removeBacktick(varName));
-			if(varValue==null)
+			if(varValue==null){
 				throw new MediatorException("The values map does not contain variable: " + varName + " Map is:" + values);
+			}
 			statement += prepareValue(varValue, rdfLiteralType);
 			
 			//I have a key that has no value OR has NULL value=>don't add this triple
@@ -550,9 +558,9 @@ public class RuleRDFGenerator {
 			if(!tripleAdded){
 				//abort the process; max number of triples was reached
 				return false;
-			}
-			else
+			}else{
 				return true;
+			}
 		}
 		return true;
 	}
@@ -570,9 +578,9 @@ public class RuleRDFGenerator {
 		String columnName = name.substring(7);
 
 		String varValue = values.get(columnName);
-		if(varValue==null)
+		if(varValue==null){
 			throw new MediatorException("The values map does not contain variable: " + columnName + " Map is:" + values);
-		else if(varValue.equals("") || varValue.equals("NULL")){
+		}else if(varValue.equals("") || varValue.equals("NULL")){
 			return null;
 		}
 		else if(varValue.startsWith("http://")){
@@ -597,15 +605,17 @@ public class RuleRDFGenerator {
 		
 		// If newline present in the value, quote them around with triple quotes
 		if (value.contains("\n") || value.contains("\r")) {
-			if (rdfLiteralType != null && !rdfLiteralType.equals(""))
+			if (rdfLiteralType != null && !rdfLiteralType.equals("")){
 				return "\"\"\"" + value + "\"\"\"" + "^^" + rdfLiteralType;
-			else
+			}else{
 				return "\"\"\"" + value + "\"\"\"";
+			}
 		} else {
-			if (rdfLiteralType != null && !rdfLiteralType.equals(""))
+			if (rdfLiteralType != null && !rdfLiteralType.equals("")){
 				return "\"" + value + "\""+ "^^" + rdfLiteralType;
-			else
+			}else{
 				return "\"" + value + "\"";
+			}
 		}
 	}
 	
@@ -667,8 +677,9 @@ public class RuleRDFGenerator {
 				varName = term.getVar();
 				//get its value
 				String val = values.get(MediatorUtil.removeBacktick(varName));
-				if(val==null)
+				if(val==null){
 					throw new MediatorException("The values map does not contain variable: " + varName + " Map is:" + values);
+				}
 				if(i>0 && !varValue.trim().isEmpty()) { varValue += "_"; allVarNames += "_";}
 				//System.out.println("VAL="+val);
 				if(val.equals("NULL")){
@@ -678,10 +689,11 @@ public class RuleRDFGenerator {
 					//12/7/2012 MariaM: per Karma-57
 					//if key is null set val to empty; if key is not part of a compound key return null
 					//and don't include this tuple
-					if(generateGensymForEmptyKey)
+					if(generateGensymForEmptyKey){
 						val = RDFUtil.gensym(uniqueId, rowId,"NULL_c" + i);
-					else
+					}else{
 						val="";
+					}
 				}
 				else if(val.trim().isEmpty()){
 					//for empty strings that are keys / I have to generate a URI I generate a gensym
@@ -691,10 +703,11 @@ public class RuleRDFGenerator {
 					//12/7/2012 MariaM: per Karma-57
 					//if key is null set val to empty; if key is not part of a compound key return null
 					//and don't include this tuple
-					if(generateGensymForEmptyKey)
+					if(generateGensymForEmptyKey){
 						val = RDFUtil.gensym(uniqueId, rowId,"EmptyStr_c" + i);
-					else
+					}else{
 						val="";
+					}
 
 				}
 				varValue += val;
@@ -732,10 +745,11 @@ public class RuleRDFGenerator {
 		
 		// TEMPORARY FIX TO RESOLVE PROBLEM WITH BAD URIS WHILE USING SUBCLASS LINKS
 		if (className.startsWith("http:") || className.startsWith("<http:")) {
-			if (className.contains("#"))
+			if (className.contains("#")){
 				className = className.substring(className.indexOf("#")+1).replaceAll(">", "");
-			else
+			}else{
 				className = className.substring(className.lastIndexOf("/")).replaceAll(">", "");
+			}
 		}
 		
 		//set terms for this function
@@ -773,10 +787,11 @@ public class RuleRDFGenerator {
 		}
 		else{
 			NUMBER_OF_TRIPLES++;
-			if(NUMBER_OF_TRIPLES<=MAX_NUMBER_OF_TRIPLES)
+			if(NUMBER_OF_TRIPLES<=MAX_NUMBER_OF_TRIPLES){
 				return true;
-			else
+			}else{
 				return false;
+			}
 		}
 	}
 	

--- a/src/main/java/edu/isi/mediator/rdf/RuleRDFGeneratorAccess.java
+++ b/src/main/java/edu/isi/mediator/rdf/RuleRDFGeneratorAccess.java
@@ -80,6 +80,7 @@ public class RuleRDFGeneratorAccess extends RuleRDFGenerator{
 		
 		Table table = Database.open(new File(accessDB)).getTable(tableName);
 		if(table==null)
+		 {
 			throw new MediatorException("Table " + lavRule.getHead().getName() + " not found in " + accessDB);
 		///////////////////////////
 		/*
@@ -94,6 +95,7 @@ public class RuleRDFGeneratorAccess extends RuleRDFGenerator{
 		System.out.println("]");
 		*/
 		//////////////////////
+		}
 		
 		//column names used in the rule
 		ArrayList<String> colNamesInHead = lavRule.getHead().getVars();
@@ -123,14 +125,15 @@ public class RuleRDFGeneratorAccess extends RuleRDFGenerator{
 				if(valO==null){
 					//it is possible that the value is NULL
 					val="NULL";
-				}
-				else
+				}else{
 					val = valO.toString();
+				}
 				//I need only values used in the rule
 				values.put(colName, val);
 			}
-			if(l%10000==0)
+			if(l%10000==0){
 				logger.info("Processed " + l + " rows");
+			}
 			//for one row
 			generateTriples(values);
 			//if(row==3) break;

--- a/src/main/java/edu/isi/mediator/rdf/RuleRDFGeneratorCSV.java
+++ b/src/main/java/edu/isi/mediator/rdf/RuleRDFGeneratorCSV.java
@@ -125,11 +125,13 @@ public class RuleRDFGeneratorCSV extends RuleRDFGenerator {
 				}
 
 				//I need only values used in the rule
-				if(colNamesInHead.contains(colName))
+				if(colNamesInHead.contains(colName)){
 					values.put(colName, val);
+				}
 			}
-			if(l%10000==0)
+			if(l%10000==0){
 				logger.info("Processed " + l + " rows");
+			}
 			//for one row
 			generateTriples(values);
 			//if(row==3) break;

--- a/src/main/java/edu/isi/mediator/rdf/RuleRDFGeneratorDB.java
+++ b/src/main/java/edu/isi/mediator/rdf/RuleRDFGeneratorDB.java
@@ -113,11 +113,13 @@ public class RuleRDFGeneratorDB extends RuleRDFGenerator{
 					val="NULL";
 				}
 				//I need only values used in the rule
-				if(colNamesInHead.contains(colName))
+				if(colNamesInHead.contains(colName)){
 					values.put(colName, val);
+				}
 			}
-			if(row%10000==0)
+			if(row%10000==0){
 				logger.info("Processed " + row + " rows");
+			}
 			//for one row
 			generateTriples(values);
 			//if(row==3) break;

--- a/src/main/java/edu/isi/mediator/rdf/RuleRDFMapper.java
+++ b/src/main/java/edu/isi/mediator/rdf/RuleRDFMapper.java
@@ -95,8 +95,9 @@ public class RuleRDFMapper extends RuleRDFGenerator{
 				//abort the process; max number of triples was reached
 				return false;
 			}
-			if(i%10000==0 && i>0)
+			if(i%10000==0 && i>0){
 				logger.info("Processed " + i + " rows.");
+			}
 		}
 		return true;
 	}
@@ -112,13 +113,15 @@ public class RuleRDFMapper extends RuleRDFGenerator{
 		//handle URI's separately
 		if(value.startsWith(RuleRDFMapper.URI_FLAG)){
 			int ind1 = value.indexOf("http");
-			if(ind1>0)
+			if(ind1>0){
 				value = "<" + value.substring(ind1) + ">";
-			else value="";
+			}else{
+				value="";
+			}
 			return value;
-		}
-		else
+		}else{
 			return RDFUtil.escapeQuote(value);
+		}
 	}
 
 	/**
@@ -172,8 +175,9 @@ public class RuleRDFMapper extends RuleRDFGenerator{
 				varName = term.getVar();
 				//get its value
 				String val = values.get(varName);
-				if(val==null)
+				if(val==null){
 					throw new MediatorException("The values map does not contain variable: " + varName + " Map is:" + values);
+				}
 				if(i>0){ varValue += "_"; allVarNames += "_";}
 				if(val.equals("NULL")){
 					//create a gensym for this value
@@ -239,9 +243,11 @@ public class RuleRDFMapper extends RuleRDFGenerator{
 		//if the value is already a URI just return that
 		if(varValue.startsWith(URI_FLAG)){
 			int ind = varValue.indexOf("http");
-			if(ind>0)
+			if(ind>0){
 				return "<" + varValue.substring(ind) + ">";
-			else return "";
+			}else{
+				return "";
+			}
 		}
 		else if(isGensym){
 			String newValue = className +"_" + varValue;
@@ -262,9 +268,11 @@ public class RuleRDFMapper extends RuleRDFGenerator{
 
 				if(objValue.startsWith(URI_FLAG)){
 					int ind = objValue.indexOf("http");
-					if(ind>0)
+					if(ind>0){
 						return "<" + objValue.substring(ind) + ">";
-					else return "";
+					}else{
+						return "";
+					}
 				}
 				else if(objValue.equals("NULL")){
 					//use the input URI

--- a/src/main/java/edu/isi/mediator/rdf/testing/OntologyMapperTest.java
+++ b/src/main/java/edu/isi/mediator/rdf/testing/OntologyMapperTest.java
@@ -110,11 +110,13 @@ public class OntologyMapperTest {
 				String line = null;
 				while ((line = buff.readLine()) != null) {
 					//System.out.println("line="+line);
-					if (line.startsWith("#") || line.trim().isEmpty())
+					if (line.startsWith("#") || line.trim().isEmpty()){
 						continue;
+					}
 					int ind = line.indexOf("=");
-					if(ind<=0)
+					if(ind<=0){
 						throw new MediatorException("Settings should be of form: PropertyName=PropertyValue " + line);
+					}
 					String name = line.substring(0,ind).trim();
 					String val = line.substring(ind+1).trim();
 
@@ -129,10 +131,11 @@ public class OntologyMapperTest {
 						modelName = val;
 					}
 					else if (name.equals("OUTPUT_FILE")){
-						if(val.toUpperCase().equals("STDOUT"))
+						if(val.toUpperCase().equals("STDOUT")){
 							outputFile=null;
-						else
+						}else{
 							outputFile=val;
+						}
 					}
 				}
 			} catch (IOException e2) {

--- a/src/main/java/edu/isi/mediator/rule/Binding.java
+++ b/src/main/java/edu/isi/mediator/rule/Binding.java
@@ -93,8 +93,9 @@ public class Binding{
 	public boolean unify(String key, String val){
 		//System.out.println("Unify: key=" + key + " val=" + val);
 		boolean valIsConstant=false;
-		if(!MediatorUtil.isVar(val))
+		if(!MediatorUtil.isVar(val)){
 			valIsConstant=true;
+		}
 		String existingVal = bindingList.get(key);
 		while(existingVal!=null){
 			if(!MediatorUtil.isVar(existingVal)){
@@ -163,7 +164,9 @@ public class Binding{
 				var2=var1;
 				var1=bindingList.get(var1);
 				if(var2.equals(var1))
+				 {
 					return var1; //otherwise I get in infinite cycle
+				}
 			}
 		}
 		
@@ -209,9 +212,9 @@ public class Binding{
 				String var2 = t2.getTermValue();
 				if(t1 instanceof ConstTerm){
 					return unify(var2, var1);
-				}
-				else
+				}else{
 					return unify(var1, var2);
+				}
 			}
 		}
 		return true;

--- a/src/main/java/edu/isi/mediator/rule/BuiltInPredicate.java
+++ b/src/main/java/edu/isi/mediator/rule/BuiltInPredicate.java
@@ -95,8 +95,9 @@ public class BuiltInPredicate extends Predicate{
 			Term t1 = terms.get(0);
 			Term t2 = terms.get(1);
 			if(t1 instanceof ConstTerm && t2 instanceof ConstTerm){
-				if(((ConstTerm)t1).equalsValue(((ConstTerm)t2)))
+				if(((ConstTerm)t1).equalsValue(((ConstTerm)t2))){
 					return true;
+				}
 			}
 		}
 		return false;
@@ -112,10 +113,11 @@ public class BuiltInPredicate extends Predicate{
 			s+= terms.get(i).toString();
 		}
 		s += ")";
-		if(isAssignment)
+		if(isAssignment){
 			s += " (assign) ";
-		else
+		}else{
 			s += " (select) ";
+		}
 		return s;
 	}
 

--- a/src/main/java/edu/isi/mediator/rule/ConstTerm.java
+++ b/src/main/java/edu/isi/mediator/rule/ConstTerm.java
@@ -130,20 +130,26 @@ public class ConstTerm extends Term{
 	public boolean equals(Term t){
 		//System.out.println("Equal term : " + this + " and " + t);
 		String var1, var2;
-		if(var==null)
+		if(var==null){
 			var1="null";
-		else var1=var;
+		}else{
+			var1=var;
+		}
 		
-		if(t.var==null)
+		if(t.var==null){
 			var2="null";
-		else var2=t.var;
+		}else{
+			var2=t.var;
+		}
 
-		if(!(t instanceof ConstTerm))
+		if(!(t instanceof ConstTerm)){
 			return false;
+		}
 		if(val.equals(((ConstTerm)t).val) && var1.equals(var2)){
 				return true;
+		}else{
+			return false;
 		}
-		else return false;
 	}
 	
 	/**
@@ -156,16 +162,19 @@ public class ConstTerm extends Term{
 	public boolean equalsValue(ConstTerm t){
 		
 		String newV1=val, newV2=t.val;
-		if(newV1.startsWith("\"") || newV1.startsWith("'"))
+		if(newV1.startsWith("\"") || newV1.startsWith("'")){
 			newV1 = newV1.substring(1, newV1.length()-1);
+		}
 
-		if(newV2.startsWith("\"") || newV2.startsWith("'"))
+		if(newV2.startsWith("\"") || newV2.startsWith("'")){
 			newV2 = newV2.substring(1, newV2.length()-1);
+		}
 
 		if(newV1.equals(newV2)){
 			return true;
+		}else{
+			return false;
 		}
-		else return false;
 	}
 
 	/* (non-Javadoc)
@@ -187,10 +196,11 @@ public class ConstTerm extends Term{
 	 * @see edu.isi.mediator.gav.domain.Term#getSqlVal(boolean)
 	 */
 	public String getSqlVal(boolean isNumber) throws MediatorException{
-		if(isNumber)
+		if(isNumber){
 			return getNumberVal();
-		else
+		}else{
 			return getStringVal();
+		}
 	}
 	
 	//I don't know what it is, so I return t as is
@@ -204,10 +214,11 @@ public class ConstTerm extends Term{
 		}
 		if(newV.startsWith("\"") || newV.startsWith("'")){
 			newV = val.substring(1, val.length()-1);
-			if(newV.equals(MediatorConstants.NULL_VALUE))
+			if(newV.equals(MediatorConstants.NULL_VALUE)){
 				return MediatorConstants.NULL_VALUE;
-			else
+			}else{
 				return "'" + newV + "'";
+			}
 		}
 		else{
 			return newV;
@@ -269,10 +280,11 @@ public class ConstTerm extends Term{
 		}
 		if(newV.startsWith("\"") || newV.startsWith("'")){
 			newV = val.substring(1, val.length()-1);
-			if(newV.equals(MediatorConstants.NULL_VALUE))
+			if(newV.equals(MediatorConstants.NULL_VALUE)){
 				return MediatorConstants.NULL_VALUE;
-			else
+			}else{
 				return "'" + newV + "'";
+			}
 		}
 		else{
 			throw new MediatorException(newV + " should be a String! Enclose it between \"'\"");
@@ -288,11 +300,13 @@ public class ConstTerm extends Term{
 	 * 		input value otherwise
 	 */
 	private String normalizeVal(String val){
-		if(val==null)
+		if(val==null){
 			return MediatorConstants.NULL_VALUE;
-		else if(val.toUpperCase().equals(MediatorConstants.NULL_VALUE))
+		}else if(val.toUpperCase().equals(MediatorConstants.NULL_VALUE)){
 			return MediatorConstants.NULL_VALUE;
-		else return val;
+		}else{
+			return val;
+		}
 	}
 	
 	/* (non-Javadoc)
@@ -300,10 +314,12 @@ public class ConstTerm extends Term{
 	 */
 	public String toString(){
 		String s = val;
-		if(var!=null)
+		if(var!=null){
 			s = var + ":" + s;
-		if(queryName!=null)
+		}
+		if(queryName!=null){
 			s += ":" + queryName;
+		}
 		return s;
 	}
 

--- a/src/main/java/edu/isi/mediator/rule/FunctionPredicate.java
+++ b/src/main/java/edu/isi/mediator/rule/FunctionPredicate.java
@@ -118,10 +118,12 @@ public class FunctionPredicate extends RelationPredicate{
     	ArrayList<Term> terms = getTerms();
     	for(int k=0; k<terms.size(); k++){
     		Term t = terms.get(k);
-    		if(k!=0) actualName += ",";
-    		if(t instanceof FunctionTerm)
-    			actualName += ((FunctionTerm)t).getFunctionForSQL();
-    		else if(t instanceof ConstTerm){
+    		if(k!=0){
+				actualName += ",";
+			}
+    		if(t instanceof FunctionTerm){
+				actualName += ((FunctionTerm)t).getFunctionForSQL();
+			}else if(t instanceof ConstTerm){
     			boolean isNumber = getSourceAttributeType(k);
 				actualName += t.getSqlVal(isNumber);
     		}
@@ -243,8 +245,9 @@ public class FunctionPredicate extends RelationPredicate{
 			String varName = term.getVar();
 			//get its value
 			String varVal = values.get(varName);
-			if(varVal==null)
+			if(varVal==null){
 				throw new MediatorException("The values map does not contain variable: " + varName + " Map is:" + values);
+			}
 			
 			ConstTerm ct = new ConstTerm(varName, varVal);
 			func.terms.set(i,ct);

--- a/src/main/java/edu/isi/mediator/rule/FunctionRepository.java
+++ b/src/main/java/edu/isi/mediator/rule/FunctionRepository.java
@@ -83,9 +83,11 @@ public class FunctionRepository {
 		String subject;
 		if(value.startsWith(RuleRDFMapper.URI_FLAG)){
 			int ind = value.indexOf("http");
-			if(ind>0)
+			if(ind>0){
 				subject = "<" + value.substring(ind) + ">";
-			else subject = "";
+			}else{
+				subject = "";
+			}
 		}
 		else{
 			//treat "value" as a value, not a seed
@@ -127,7 +129,9 @@ public class FunctionRepository {
 		//the first value is the separator
 		String sep = values[0];
 		for(int i=1; i<values.length; i++){
-			if(i>1) result += sep;
+			if(i>1){
+				result += sep;
+			}
 			result += values[i];
 		}
 		return result;

--- a/src/main/java/edu/isi/mediator/rule/FunctionTerm.java
+++ b/src/main/java/edu/isi/mediator/rule/FunctionTerm.java
@@ -81,9 +81,9 @@ public class FunctionTerm extends Term{
 	 * @throws MediatorException
 	 */
 	public void setFunction(FunctionPredicate p) throws MediatorException{
-		if(function==null)
+		if(function==null){
 			function=p;
-		else{
+		}else{
 			//a variable can be assigned only to one function
 			throw new MediatorException("A variable can be assigned only to one function var=" + var);
 		}
@@ -123,11 +123,14 @@ public class FunctionTerm extends Term{
 	 */
 	public boolean equals(Term t){
 		//System.out.println("Equal term : " + this + " and " + t);
-		if(!(t instanceof FunctionTerm))
+		if(!(t instanceof FunctionTerm)){
 			return false;
-		if(function.equals(((FunctionTerm)t).function))
-				return true;
-		else return false;
+		}
+		if(function.equals(((FunctionTerm)t).function)){
+			return true;
+		}else{
+			return false;
+		}
 	}
 	
 	/* (non-Javadoc)
@@ -136,8 +139,9 @@ public class FunctionTerm extends Term{
 	 * returns true if the {@link edu.isi.mediator.gav.domain.FunctionPredicate} needs binding and false otherwise. 
 	 */
 	public boolean needsBinding(boolean b){
-		if(b==true) return true;
-		else{
+		if(b==true){
+			return true;
+		}else{
 			//if this function needs bindings => return true, else false
 			return function.needsBinding();
 		}
@@ -158,10 +162,12 @@ public class FunctionTerm extends Term{
 	 */
 	public String toString(){
 		String s = "";
-		if(var!=null)
+		if(var!=null){
 			s += var + ":";
-		if(queryName!=null)
+		}
+		if(queryName!=null){
 			s += queryName + ":";
+		}
 		s+=function.toString();
 		return s;
 	}

--- a/src/main/java/edu/isi/mediator/rule/GAVRule.java
+++ b/src/main/java/edu/isi/mediator/rule/GAVRule.java
@@ -67,13 +67,15 @@ public class GAVRule extends Rule{
 	public boolean isNoneRule(){return false;}
 	public boolean isUACRule(){return false;}
 	public boolean isUACVar(String v){
-		if(v.equals(ALL_VAR) || v.equals(NONE_VAR) || v.equals(NONE_BUT_JOINABLE_VAR))
-				return true;
+		if(v.equals(ALL_VAR) || v.equals(NONE_VAR) || v.equals(NONE_BUT_JOINABLE_VAR)){
+			return true;
+		}
 		return false;
 	}
 	public boolean isNullVar(String v){
-		if(v.toUpperCase().equals(MediatorConstants.NULL_VALUE))
-				return true;
+		if(v.toUpperCase().equals(MediatorConstants.NULL_VALUE)){
+			return true;
+		}
 		return false;
 	}
 	//////////////////////////////
@@ -142,8 +144,9 @@ public class GAVRule extends Rule{
 		ArrayList<RelationPredicate> rels = new ArrayList<RelationPredicate>();
 		for(int i=0; i<antecedent.size(); i++){
 			Predicate p = antecedent.get(i);
-			if(p instanceof RelationPredicate)
+			if(p instanceof RelationPredicate){
 				rels.add((RelationPredicate)p);
+			}
 		}
 		return rels;
 	}
@@ -156,8 +159,9 @@ public class GAVRule extends Rule{
 		ArrayList<BuiltInPredicate> rels = new ArrayList<BuiltInPredicate>();
 		for(int i=0; i<antecedent.size(); i++){
 			Predicate p = antecedent.get(i);
-			if(p instanceof BuiltInPredicate)
+			if(p instanceof BuiltInPredicate){
 				rels.add((BuiltInPredicate)p);
+			}
 		}
 		return rels;
 	}
@@ -170,8 +174,9 @@ public class GAVRule extends Rule{
 		ArrayList<Predicate> rels = new ArrayList<Predicate>();
 		for(int i=0; i<antecedent.size(); i++){
 			Predicate p = antecedent.get(i);
-			if(p.getName().equals(MediatorConstants.EQUALS))
+			if(p.getName().equals(MediatorConstants.EQUALS)){
 				rels.add(p);
+			}
 		}
 		return rels;
 	}
@@ -184,8 +189,9 @@ public class GAVRule extends Rule{
 		ArrayList<Predicate> rels = new ArrayList<Predicate>();
 		for(int i=0; i<antecedent.size(); i++){
 			Predicate p = antecedent.get(i);
-			if((p instanceof BuiltInPredicate) && !p.getName().equals(MediatorConstants.EQUALS))
+			if((p instanceof BuiltInPredicate) && !p.getName().equals(MediatorConstants.EQUALS)){
 				rels.add(p);
+			}
 		}
 		return rels;
 	}
@@ -199,8 +205,9 @@ public class GAVRule extends Rule{
 		HashSet<String> predNames = new HashSet<String>();
 		for(int i=0; i<antecedent.size(); i++){
 			Predicate p = antecedent.get(i);
-			if(containsPredicate(p, i+1))
+			if(containsPredicate(p, i+1)){
 				predNames.add(p.getName());
+			}
 		}
 		return predNames;
 	}
@@ -220,8 +227,9 @@ public class GAVRule extends Rule{
 		//System.out.println("Find term " + t + " in " + terms + " starting at " + index);
 		for(int i=index; i<antecedent.size(); i++){
 			Predicate p = antecedent.get(i);
-			if(pred.getName().equals(p.getName()))
+			if(pred.getName().equals(p.getName())){
 				return true;
+			}
 		}
 		return false;
 	}
@@ -236,8 +244,9 @@ public class GAVRule extends Rule{
 		ArrayList<Predicate> preds = new ArrayList<Predicate>();
 		for(int i=0; i<antecedent.size(); i++){
 			Predicate p = antecedent.get(i);
-			if(name.equals(p.getName()))
+			if(name.equals(p.getName())){
 				preds.add(p);
+			}
 		}
 		return preds;
 	}
@@ -257,15 +266,20 @@ public class GAVRule extends Rule{
 		for(int i=0; i<antecedent.size(); i++){
 			Predicate p = antecedent.get(i);
 			bodyVars.addAll(p.getVars());
-			if(p instanceof RelationPredicate)
+			if(p instanceof RelationPredicate){
 				bodyRelationVars.addAll(p.getVars());
+			}
 		}
 		//make sure that all variables in the head are present in the body
 		for( int j=0; j<headVars.size(); j++){
 			String headVar = headVars.get(j);
 			//variable used in user access rule
-			if(isUACVar(headVar)) continue;
-			if(isNullVar(headVar)) continue;
+			if(isUACVar(headVar)){
+				continue;
+			}
+			if(isNullVar(headVar)){
+				continue;
+			}
 			if(!bodyVars.contains(headVar)){
 				throw(new MediatorException("The head variable " + headVar + " does not appear in the body of rule " + this));
 			}
@@ -280,9 +294,9 @@ public class GAVRule extends Rule{
 			for(int k=0; k<pVars.size(); k++){
 				String pVar = pVars.get(k);
 				//System.out.println("Check var : " + pVar + " in " + bodyRelationVars + " and " + headVars);
-				if(!bodyRelationVars.contains(pVar) && !headVars.contains(pVar))
+				if(!bodyRelationVars.contains(pVar) && !headVars.contains(pVar)){
 					throw(new MediatorException("The variable " + pVar + " does not appear in a body relation or head of rule " + this));
-				else{
+				}else{
 					if(!bodyRelationVars.contains(pVar)){
 						//it is in the head, but not the body => in the graph it will be represented as an AssignNode
 						((BuiltInPredicate)p).isAssignment(true);
@@ -314,7 +328,9 @@ public class GAVRule extends Rule{
 		String s = "";
 		s+= consequent.get(0) + "<-";
 		for(int i=0; i<antecedent.size(); i++){
-			if(i>0) s += " ^ \n\t";
+			if(i>0){
+				s += " ^ \n\t";
+			}
 			s += antecedent.get(i).toString();
 			//s+= conjunctiveFormula.get(i).getClass().getName();
 		}

--- a/src/main/java/edu/isi/mediator/rule/LAVRule.java
+++ b/src/main/java/edu/isi/mediator/rule/LAVRule.java
@@ -117,8 +117,9 @@ public class LAVRule extends Rule{
 		ArrayList<BuiltInPredicate> rels = new ArrayList<BuiltInPredicate>();
 		for(int i=0; i<consequent.size(); i++){
 			Predicate p = consequent.get(i);
-			if(p instanceof BuiltInPredicate)
+			if(p instanceof BuiltInPredicate){
 				rels.add((BuiltInPredicate)p);
+			}
 		}
 		return rels;
 	}
@@ -142,8 +143,9 @@ public class LAVRule extends Rule{
 		for(int i=0; i<consequent.size(); i++){
 			Predicate p = consequent.get(i);
 			bodyVars.addAll(p.getVars());
-			if(p instanceof RelationPredicate)
+			if(p instanceof RelationPredicate){
 				bodyRelationVars.addAll(p.getVars());
+			}
 		}
 		
 		//make sure that all variables in the head are present in the body
@@ -164,9 +166,9 @@ public class LAVRule extends Rule{
 			for(int k=0; k<pVars.size(); k++){
 				String pVar = pVars.get(k);
 				//System.out.println("Check var : " + pVar + " in " + bodyRelationVars + " and " + headVars);
-				if(!bodyRelationVars.contains(pVar) && !headVars.contains(pVar))
+				if(!bodyRelationVars.contains(pVar) && !headVars.contains(pVar)){
 					throw(new MediatorException("The variable " + pVar + " does not appear in a body relation or head of rule " + this));
-				else{
+				}else{
 					if(!bodyRelationVars.contains(pVar)){
 						//it is in the head, but not the body => in the graph it will be represented as an AssignNode
 						((BuiltInPredicate)p).isAssignment(true);
@@ -185,7 +187,9 @@ public class LAVRule extends Rule{
 		String s = "";
 		s+= antecedent.get(0) + "<-";
 		for(int i=0; i<consequent.size(); i++){
-			if(i>0) s += " ^ \n\t";
+			if(i>0){
+				s += " ^ \n\t";
+			}
 			s += consequent.get(i).toString();
 		}
 		return s;

--- a/src/main/java/edu/isi/mediator/rule/Predicate.java
+++ b/src/main/java/edu/isi/mediator/rule/Predicate.java
@@ -73,9 +73,11 @@ public abstract class Predicate{
 	 */
 	public void addTerm(String var){
 		Term t;
-		if(!MediatorUtil.isVar(var))
+		if(!MediatorUtil.isVar(var)){
 			t=new ConstTerm(var);
-		else t = new VarTerm(var);
+		}else{
+			t = new VarTerm(var);
+		}
 		terms.add(t);
 	}
 	
@@ -87,11 +89,14 @@ public abstract class Predicate{
 	 */
 	public void addTermIfUnique(String var){
 		Term t;
-		if(!MediatorUtil.isVar(var))
+		if(!MediatorUtil.isVar(var)){
 			t=new ConstTerm(var);
-		else t = new VarTerm(var);
-		if(!containsTerm(t))
+		}else{
+			t = new VarTerm(var);
+		}
+		if(!containsTerm(t)){
 			terms.add(t);
+		}
 	}
 
 	/**
@@ -120,8 +125,9 @@ public abstract class Predicate{
 		//System.out.println("Find term " + t + " in " + terms + " starting at " + index);
 		for(int i=index; i<terms.size(); i++){
 			Term t1 = terms.get(i);
-			if(t1.equals(t))
+			if(t1.equals(t)){
 				return i;
+			}
 		}
 		return -1;
 	}
@@ -136,8 +142,9 @@ public abstract class Predicate{
 	public boolean containsTerm(Term t1){
 		for(int i=0; i<terms.size(); i++){
 			Term t2 = terms.get(i);
-			if(t1.equals(t2))
+			if(t1.equals(t2)){
 				return true;
+			}
 		}
 		return false;
 	}
@@ -182,8 +189,9 @@ public abstract class Predicate{
 		for(int i=0; i<terms.size(); i++){
 			Term t = terms.get(i);
 			String var = t.getFreeVar();
-			if(var!=null)
+			if(var!=null){
 				vars.add(var);
+			}
 		}
 		return vars;
 	}
@@ -215,8 +223,9 @@ public abstract class Predicate{
 		for(int i=0; i<terms.size(); i++){
 			Term t = terms.get(i);
 			String var = t.getTermValue();
-			if(var!=null)
+			if(var!=null){
 				vars.add(var);
+			}
 		}
 		return vars;
 	}
@@ -262,18 +271,21 @@ public abstract class Predicate{
 	 */
 	public boolean equals(Predicate p){
 		//System.out.println("Compare " + this + " and " + p);		
-		if(!p.getName().equals(name))
+		if(!p.getName().equals(name)){
 			return false;
+		}
 		//if different number of terms, can't be a UNION
-		if(terms.size()!=p.terms.size())
+		if(terms.size()!=p.terms.size()){
 			return false;
+		}
 		//compare the terms
 		for(int i=0; i<terms.size(); i++){
 			Term t1 = terms.get(i);
 			Term t2 = p.getTerms().get(i);
 			//System.out.println("Compare " + t1 + " and " + t2);
-			if(!t1.equals(t2))
+			if(!t1.equals(t2)){
 				return false;
+			}
 		}
 		return true;
 	}

--- a/src/main/java/edu/isi/mediator/rule/RelationPredicate.java
+++ b/src/main/java/edu/isi/mediator/rule/RelationPredicate.java
@@ -134,9 +134,11 @@ public class RelationPredicate extends Predicate{
 	 * <br> false if source predicate
 	 */
 	public boolean isDomainPredicate(){
-		if(source==null)
+		if(source==null){
 			return true;
-		else return false;
+		}else{
+			return false;
+		}
 	}
 
 	/**	Returns all variables that need to be bound
@@ -152,9 +154,9 @@ public class RelationPredicate extends Predicate{
 			if(t.needsBinding(sa.needsBinding())){
 				if(t instanceof FunctionTerm){
 					vars.addAll(t.getFunction().getNeedBindingVars());
-				}
-				else
+				}else{
 					vars.add(var);
+				}
 			}
 		}
 		return vars;
@@ -168,9 +170,11 @@ public class RelationPredicate extends Predicate{
 	 */
 	public boolean needsBinding(){
 		ArrayList<String> bindVars = getNeedBindingVars();
-		if(bindVars.isEmpty())
+		if(bindVars.isEmpty()){
 			return false;
-		else return true;
+		}else{
+			return true;
+		}
 	}
 	
     /**
@@ -181,10 +185,11 @@ public class RelationPredicate extends Predicate{
      */
     public String needsBinding(String attr){
     	SourceAttribute sa = getSourceAttribute(attr);
-    	if(sa.needsBinding)
-    		return "@";
-    	else 
-    		return "";
+    	if(sa.needsBinding){
+			return "@";
+		}else{
+			return "";
+		}
     }
 	
 	/**
@@ -199,8 +204,9 @@ public class RelationPredicate extends Predicate{
 		for(int i=0; i<terms.size(); i++){
 			Term t = terms.get(i);
 			String var = t.getVar();
-			if(var!=null && p.containsTerm(t))
+			if(var!=null && p.containsTerm(t)){
 				attrs.add(var);
+			}
 		}
 		return attrs;
 	}
@@ -225,8 +231,9 @@ public class RelationPredicate extends Predicate{
 					//no source predicate is associated with this pred
 					//just return the domainAttr
 					return new SourceAttribute(domainAttr, "string", "F");
+				}else{
+					return source.getAttr(i);
 				}
-				else return source.getAttr(i);
 			}
 		}
 		return null;
@@ -368,7 +375,9 @@ public class RelationPredicate extends Predicate{
 		String s = "";
 		s += name + "(";
 		for(int i=0; i<terms.size(); i++){
-			if(i>0) s += ",";
+			if(i>0){
+				s += ",";
+			}
 			s += terms.get(i).toString();
 		}
 		s+= ")";

--- a/src/main/java/edu/isi/mediator/rule/Rule.java
+++ b/src/main/java/edu/isi/mediator/rule/Rule.java
@@ -113,7 +113,9 @@ abstract public class Rule{
 	public String antecedentToString(){
 		String s = "";
 		for(int i=0; i<antecedent.size(); i++){
-			if(i>0) s += " ^ \t";
+			if(i>0){
+				s += " ^ \t";
+			}
 			s += antecedent.get(i).toString();
 		}
 		return s;
@@ -125,12 +127,16 @@ abstract public class Rule{
 	public String toString(){
 		String s = "";
 		for(int i=0; i<antecedent.size(); i++){
-			if(i>0) s += " ^ \n\t";
+			if(i>0){
+				s += " ^ \n\t";
+			}
 			s += antecedent.get(i).toString();
 		}
 		s+= "->";
 		for(int i=0; i<consequent.size(); i++){
-			if(i>0) s += " ^ \n\t";
+			if(i>0){
+				s += " ^ \n\t";
+			}
 			s += consequent.get(i).toString();
 		}
 		return s;

--- a/src/main/java/edu/isi/mediator/rule/Term.java
+++ b/src/main/java/edu/isi/mediator/rule/Term.java
@@ -105,16 +105,19 @@ public abstract class Term{
 		Visible v;
 		if(b==true){
 			v=Visible.TRUE;
+		}else{
+			v=Visible.FALSE;
 		}
-		else v=Visible.FALSE;
 		
 		if(isAllowedAfterUAC==Visible.NOT_SET || isAllowedAfterUAC==Visible.FALSE)
+		 {
 			isAllowedAfterUAC=v;
 		//else if I already determined that it is allowed just leave it alone
 		//it will be allowed even if it is not allowed from other concepts
 		//if not allowed from a _none_ concept I will see only vals from the visible concept
 		//if from _none_but_joinable_ it will join, so I will see only the joined values, so OK
 		//same if I have partial values visible, there will be a join
+		}
 	}
 	
 	/**
@@ -123,9 +126,11 @@ public abstract class Term{
 	 * 		false otherwise
 	 */
 	public boolean isAllowed(){
-		if(isAllowedAfterUAC==Visible.NOT_SET || isAllowedAfterUAC==Visible.TRUE)
+		if(isAllowedAfterUAC==Visible.NOT_SET || isAllowedAfterUAC==Visible.TRUE){
 			return true;
-		else return false;
+		}else{
+			return false;
+		}
 	}
 	/////////////////////////////////////////////
 	
@@ -183,8 +188,9 @@ public abstract class Term{
 	 * 		an integer used to construct the name.
 	 */
 	public void changeVarName(int index){
-		if(var!=null)
+		if(var!=null){
 			var = var + "_unique" + index;
+		}
 	}
 	
 	/**

--- a/src/main/java/edu/isi/mediator/rule/VarTerm.java
+++ b/src/main/java/edu/isi/mediator/rule/VarTerm.java
@@ -66,11 +66,14 @@ public class VarTerm extends Term{
 	 * @see edu.isi.mediator.gav.domain.Term#equals(edu.isi.mediator.gav.domain.Term)
 	 */
 	public boolean equals(Term t){
-		if(!(t instanceof VarTerm))
+		if(!(t instanceof VarTerm)){
 			return false;
-		if(var.equals(t.var))
+		}
+		if(var.equals(t.var)){
 			return true;
-		else return false;
+		}else{
+			return false;
+		}
 	}
 	
 	/**
@@ -91,8 +94,9 @@ public class VarTerm extends Term{
 	 */
 	public String toString(){
 		String s = var;
-		if(queryName!=null)
+		if(queryName!=null){
 			s += ":" + queryName;
+		}
 		//s += " " + isAllowedAfterUAC;
 		return s;
 	}

--- a/src/main/java/edu/isi/mediator/simplegraph/SimpleBaseNode.java
+++ b/src/main/java/edu/isi/mediator/simplegraph/SimpleBaseNode.java
@@ -73,14 +73,17 @@ public abstract class SimpleBaseNode
     	
     	String sql="";
     	sql += "select " + distinctToken + " " +sqlSelect.toString().substring(1,sqlSelect.toString().length()-1)+" from "+ sqlFrom.toString().substring(1,sqlFrom.toString().length()-1)+" ";
-    	if (sqlWhere.size()>0)
-    		sql += " where ";
+    	if (sqlWhere.size()>0){
+			sql += " where ";
+		}
     	for (int j=0;j<sqlWhere.size();j++)
     	{
     		String nextSelect = (String)sqlWhere.get(j);
     		//System.out.println("next select ..." + nextSelect + "\n SQL so far:" + sql);
     		if(sql.indexOf(nextSelect)<0){
-    			if (j>0) sql += " and ";
+    			if (j>0){
+					sql += " and ";
+				}
     			//insert if not there
     			sql += nextSelect;
     		}
@@ -99,7 +102,9 @@ public abstract class SimpleBaseNode
     	for(int i=0; i<allDan.size(); i++){
     		SimpleDataAccessNode dan = allDan.get(i);
     		sAttr = dan.getSourceAttribute(attr);
-    		if(sAttr!=null) return sAttr;
+    		if(sAttr!=null){
+				return sAttr;
+			}
     	}
     	
     	return sAttr;
@@ -114,8 +119,9 @@ public abstract class SimpleBaseNode
     		String oneSelect = sqlSelect.get(i);
     		//I want to make sure that I match with EXACTLY that attr name (that's why I have the " " at the end
     		int ind = oneSelect.indexOf(" as " + attr + " ");
-    		if(ind>0)
-    			return oneSelect.substring(0, ind);
+    		if(ind>0){
+				return oneSelect.substring(0, ind);
+			}
     	}
     	//attr not found
 		throw new MediatorException("Attribute " + attr + " not found in " + sqlSelect);
@@ -129,10 +135,12 @@ public abstract class SimpleBaseNode
     	ArrayList<Term> terms = p.getTerms();
     	for(int k=0; k<terms.size(); k++){
     		Term t = terms.get(k);
-    		if(k!=0) actualName += ",";
-    		if(t instanceof FunctionTerm)
-    			actualName += getActualName(t.getFunction());
-    		else if(t instanceof ConstTerm){
+    		if(k!=0){
+				actualName += ",";
+			}
+    		if(t instanceof FunctionTerm){
+				actualName += getActualName(t.getFunction());
+			}else if(t instanceof ConstTerm){
     			SourceAttribute sa = p.getSourceAttribute(k);
 				actualName += t.getSqlVal(sa.isNumber());
     		}
@@ -159,8 +167,9 @@ public abstract class SimpleBaseNode
     		if(ind>0){
     			String varWithTable = oneSelect.substring(0, ind);
     	    	ind = varWithTable.indexOf(".");
-    	    	if(ind>0 && ind+1<varWithTable.length()-1) 
-    	    		allAttr.add(varWithTable.substring(ind+1));
+    	    	if(ind>0 && ind+1<varWithTable.length()-1){
+					allAttr.add(varWithTable.substring(ind+1));
+				}
     		}
     	}
     	return allAttr;
@@ -175,21 +184,29 @@ public abstract class SimpleBaseNode
     		for(int i=0; i<joinAttributes.size(); i++){
     			String joinAttr = joinAttributes.get(i);
     			int ind = oneSelect.indexOf(" as " + joinAttr +" ");
-    			if(ind>0) addSelect = false; 
+    			if(ind>0){
+					addSelect = false;
+				} 
     		}
-    		if(addSelect) newSelect.add(oneSelect);
+    		if(addSelect){
+				newSelect.add(oneSelect);
+			}
     	}
     	return newSelect;
     }
     
     public void getDataAccessNodes(ArrayList<SimpleDataAccessNode> dan){
     	ArrayList<SimpleBaseNode> nodes = getSubNodes();
-    	if(nodes==null) return;
+    	if(nodes==null){
+			return;
+		}
     	for(int i=0; i<nodes.size(); i++){
     		SimpleBaseNode pn = (SimpleBaseNode)nodes.get(i);
-    		if(pn instanceof SimpleDataAccessNode)
-    			dan.add((SimpleDataAccessNode)pn);
-    		else pn.getDataAccessNodes(dan);
+    		if(pn instanceof SimpleDataAccessNode){
+				dan.add((SimpleDataAccessNode)pn);
+			}else{
+				pn.getDataAccessNodes(dan);
+			}
     	}
     }
     

--- a/src/main/java/edu/isi/mediator/simplegraph/SimpleDataAccessNode.java
+++ b/src/main/java/edu/isi/mediator/simplegraph/SimpleDataAccessNode.java
@@ -53,8 +53,9 @@ public class SimpleDataAccessNode extends SimpleBaseNode
 	
 	public ArrayList<SimpleBaseNode> getSubNodes() {
 		ArrayList<SimpleBaseNode> subnodes = new ArrayList<SimpleBaseNode>();
-		if (child != null)
+		if (child != null){
 			subnodes.add(child);
+		}
 		return subnodes;
 	}
 
@@ -76,8 +77,9 @@ public class SimpleDataAccessNode extends SimpleBaseNode
 			ArrayList<String> joinAttrs = source.findCommonAttrs(((SimpleDataAccessNode)dn).source);
 			for(int i=0; i<joinAttrs.size(); i++){
 				String attr = joinAttrs.get(i);
-				if(!commonAttrs.contains(attr))
+				if(!commonAttrs.contains(attr)){
 					commonAttrs.add(attr);
+				}
 			}
 			//System.out.println(" commonAttrs " + commonAttrs);
 		}
@@ -96,8 +98,9 @@ public class SimpleDataAccessNode extends SimpleBaseNode
 		
 		//I already did setSQL() in this node
     	//because of binding patterns there may be 2 ways to this node
-		if(!sqlSelect.isEmpty())
+		if(!sqlSelect.isEmpty()){
 			return;
+		}
 		
 		if(child!=null){
 			child.setSQL();
@@ -110,11 +113,13 @@ public class SimpleDataAccessNode extends SimpleBaseNode
 		String newName = sourceName + "_" + sourceId;
 		//we use endsWith instead of startsWith because for sources that include the OGSA-DAI resource
 		// it looks like: TestR2_`table name`
-		if(sourceName.endsWith("`"))
+		if(sourceName.endsWith("`")){
 			newName = sourceName.substring(0, sourceName.length()-1) + "_" + sourceId + "`";
+		}
 		
-		if(newName.length()>29)
+		if(newName.length()>29){
 			newName = "T"+MediatorConstants.getTableId();
+		}
 		sqlFrom.add(source.getSQLName()+" "+ newName);
 		String tableName = newName;
 		
@@ -141,7 +146,9 @@ public class SimpleDataAccessNode extends SimpleBaseNode
 		ArrayList<String> select = new ArrayList<String>();
 		for(int i=0; i<source.getTerms().size(); i++){
 			Term t = source.getTerms().get(i);
-			if(t.getVar()==null) continue;
+			if(t.getVar()==null){
+				continue;
+			}
 			SourceAttribute sourceAttr = source.getSourceAttribute(i);
 			//I'm adding a space at then end, so it's easier when I have to search for the var name
 			//otherwise if I search for "S" it will return true for any variable that starts with "S"
@@ -177,10 +184,11 @@ public class SimpleDataAccessNode extends SimpleBaseNode
 			}
 			if(t instanceof ConstTerm){
 				String val = ((ConstTerm)t).getSqlVal(sourceAttr.isNumber());
-				if(val.equals(MediatorConstants.NULL_VALUE))
+				if(val.equals(MediatorConstants.NULL_VALUE)){
 					where.add(bindMarker + tableName+"."+sourceAttr.getSQLName()+" IS "+val);
-				else
+				}else{
 					where.add(bindMarker + tableName+"."+sourceAttr.getSQLName()+" = "+val);
+				}
 			}
 			if(t instanceof FunctionTerm){
 				if(child!=null){
@@ -218,13 +226,14 @@ public class SimpleDataAccessNode extends SimpleBaseNode
 		String s = "";
 		s += getPrintName();
 		s += source + "\n";
-		if(child == null)
+		if(child == null){
 			s += "child=NULL\n";
-		else{
-    		if(child.alreadyPrinted)
-    			s += "child=" + child.getPrintName();
-    		else
-    			s += "child="+ child.getString();
+		}else{
+    		if(child.alreadyPrinted){
+				s += "child=" + child.getPrintName();
+			}else{
+				s += "child="+ child.getString();
+			}
 		}
 		s += "-------------------------------------\n";
 		return s;

--- a/src/main/java/edu/isi/mediator/simplegraph/SimpleJoinNode.java
+++ b/src/main/java/edu/isi/mediator/simplegraph/SimpleJoinNode.java
@@ -40,10 +40,12 @@ public class SimpleJoinNode extends SimpleBaseNode
     
     public ArrayList<SimpleBaseNode> getSubNodes() {
         ArrayList<SimpleBaseNode> subnodes = new ArrayList<SimpleBaseNode>();
-	if (child1 != null)
-	    subnodes.add(child1);
-	if (child2 != null)
-	    subnodes.add(child2);
+	if (child1 != null){
+		subnodes.add(child1);
+	}
+	if (child2 != null){
+		subnodes.add(child2);
+	}
 	return subnodes;
     }
     
@@ -51,8 +53,9 @@ public class SimpleJoinNode extends SimpleBaseNode
     	
 		//I already did setSQL() in this node
     	//because of binding patterns there may be 2 ways to this node
-		if(!sqlSelect.isEmpty())
+		if(!sqlSelect.isEmpty()){
 			return;
+		}
 
     	child1.setSQL();
     	child2.setSQL();
@@ -80,8 +83,9 @@ public class SimpleJoinNode extends SimpleBaseNode
     	sqlSelect.addAll(selectWithoutJoinAttrs);
     	for(int i=0; i<selectWithoutJoinAttrs.size(); i++){
     		String oneSelect = selectWithoutJoinAttrs.get(i);
-    		if(!sqlSelect.contains(oneSelect))
-    			sqlSelect.add(oneSelect);
+    		if(!sqlSelect.contains(oneSelect)){
+				sqlSelect.add(oneSelect);
+			}
     	}
 		//System.out.println("Join select=" + sqlSelect);
     }
@@ -91,21 +95,23 @@ public class SimpleJoinNode extends SimpleBaseNode
     	String s = "";
     	s += getPrintName();
     	s += "joinAttributes=" + joinAttributes + "\n";
-    	if(child1 == null)
-    		s += "child1=NULL\n";
-    	else{
-    		if(child1.alreadyPrinted)
-    			s += "child1=" + child1.getPrintName();
-    		else
-    			s += "child1=" + child1.getString();
+    	if(child1 == null){
+			s += "child1=NULL\n";
+		}else{
+    		if(child1.alreadyPrinted){
+				s += "child1=" + child1.getPrintName();
+			}else{
+				s += "child1=" + child1.getString();
+			}
     	}
-    	if(child2 == null)
-    		s += "child2=NULL\n";
-    	else{
-    		if(child2.alreadyPrinted)
-    			s += "child2=" + child2.getPrintName();
-    		else
-    			s += "child2=" + child2.getString();
+    	if(child2 == null){
+			s += "child2=NULL\n";
+		}else{
+    		if(child2.alreadyPrinted){
+				s += "child2=" + child2.getPrintName();
+			}else{
+				s += "child2=" + child2.getString();
+			}
     	}
     	s += "-------------------------------------\n";
     	return s;


### PR DESCRIPTION
Currently single line control statements are not enclosed in blocks.  This is dangerous because people tend to follow the indentation, not the actual control structure, so the following:

```
if (a==true)
  statement 1
```

can be modified by someone who's not careful to be

```
if (a==true)
  statement 1
  statement 2
```

which won't do what they think it's doing.  It's much safer to just always wrap things as blocks even though it costs an extra line of vertical space.

The automatic refactoring was done using Eclipse cleanup followed by manual verification.
