### PR TITLE
Convert uses of Vector to List/ArrayList

### DIFF
--- a/src/main/java/edu/isi/karma/cleaning/ANode.java
+++ b/src/main/java/edu/isi/karma/cleaning/ANode.java
@@ -21,17 +21,16 @@
 
 package edu.isi.karma.cleaning;
 
-import java.util.Vector;
-
-import org.python.antlr.PythonParser.return_stmt_return;
+import java.util.ArrayList;
+import java.util.List;
 //used in alignment
 public class ANode {
-	public Vector<Integer> orgPos = new Vector<Integer>();
-	public Vector<Integer> tarPos = new Vector<Integer>();
-	public Vector<Integer> length = new Vector<Integer>();
-	public Vector<String[]> exps = new Vector<String[]>();
-	public Vector<ANode> children = new Vector<ANode>();
-	public ANode(Vector<Integer> orgPos, Vector<Integer> tarPos, Vector<Integer>length, Vector<String[]> exps)
+	public List<Integer> orgPos = new ArrayList<Integer>();
+	public List<Integer> tarPos = new ArrayList<Integer>();
+	public List<Integer> length = new ArrayList<Integer>();
+	public List<String[]> exps = new ArrayList<String[]>();
+	public List<ANode> children = new ArrayList<ANode>();
+	public ANode(List<Integer> orgPos, List<Integer> tarPos, List<Integer>length, List<String[]> exps)
 	{
 		this.orgPos = orgPos;
 		this.tarPos = tarPos;

--- a/src/main/java/edu/isi/karma/cleaning/ConstrainedAlignment.java
+++ b/src/main/java/edu/isi/karma/cleaning/ConstrainedAlignment.java
@@ -1,16 +1,17 @@
 package edu.isi.karma.cleaning;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ConstrainedAlignment {
-	public Vector<Vector<TNode>> olist;
-	public Vector<Vector<TNode>> tlist;
+	public List<List<TNode>> olist;
+	public List<List<TNode>> tlist;
 	public int expnum;
 	public ConstrainedAlignment()
 	{
 		
 	}
-	public Vector<Integer> findAll(TNode t,Vector<TNode> x)
+	public List<Integer> findAll(TNode t,List<TNode> x)
 	{
 		return null;
 	}
@@ -18,7 +19,7 @@ public class ConstrainedAlignment {
 	public void traverse()
 	{
 		//inite
-		Vector<Integer> spos = new Vector<Integer>();
+		List<Integer> spos = new ArrayList<Integer>();
 		for(int i = 0; i<expnum;i++)
 		{
 			spos.add(0);
@@ -42,11 +43,11 @@ class LatentState{
 	static final int ANC = 3;//a anchor state
 	public int StateType;
 	public LatentState nextState;
-	public Vector<int[]> segments;
-	public LatentState(Vector<Integer> spos)
+	public List<int[]> segments;
+	public LatentState(List<Integer> spos)
 	{
 		this.StateType = LatentState.UND;
-		segments = new Vector<int[]>();
+		segments = new ArrayList<int[]>();
 		if(segments.size() !=spos.size())
 		{
 			System.out.println("Length different");
@@ -67,7 +68,7 @@ class LatentState{
 	{
 		segments.get(lindex)[1] = e;
 	}
-	public void createNewState(Vector<Integer> spos)
+	public void createNewState(List<Integer> spos)
 	{
 		LatentState nState =new LatentState(spos);
 		this.nextState = nState;

--- a/src/main/java/edu/isi/karma/cleaning/DataCollection.java
+++ b/src/main/java/edu/isi/karma/cleaning/DataCollection.java
@@ -23,13 +23,14 @@ package edu.isi.karma.cleaning;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Vector;
+import java.util.List;
 
 public class DataCollection {
 	public static String config = "";
-	Vector<FileStat> fstates = new Vector<FileStat>();
+	List<FileStat> fstates = new ArrayList<FileStat>();
 	public DataCollection()
 	{
 		MyLogger myLogger = new MyLogger();
@@ -105,7 +106,7 @@ class FileStat
 	public String program = "" ;// the correct program
 	public long ruleNo = 0; // order of the first consistent rule
 	public long checkedrow = 0;
-	public FileStat(String fname, long l,long g,long e,int exp,Vector<String[]> exps,long ruleNo,long checkedrow, String program)
+	public FileStat(String fname, long l,long g,long e,int exp,List<String[]> exps,long ruleNo,long checkedrow, String program)
 	{
 		this.fileNameString = fname;
 		this.learnTime = l;

--- a/src/main/java/edu/isi/karma/cleaning/ExampleSelection.java
+++ b/src/main/java/edu/isi/karma/cleaning/ExampleSelection.java
@@ -21,18 +21,13 @@
 
 package edu.isi.karma.cleaning;
 
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Vector;
-
-import org.apache.xpath.axes.AxesWalker;
-import org.geotools.filter.expression.ThisPropertyAccessorFactory;
-import org.python.antlr.PythonParser.return_stmt_return;
-
-import uk.ac.shef.wit.simmetrics.TestArbitrators;
+import java.util.List;
 
 public class ExampleSelection {
-	public HashMap<String, Vector<TNode>> org = new HashMap<String, Vector<TNode>>();
-	public HashMap<String, Vector<TNode>> tran = new HashMap<String, Vector<TNode>>();
+	public HashMap<String, List<TNode>> org = new HashMap<String, List<TNode>>();
+	public HashMap<String, List<TNode>> tran = new HashMap<String, List<TNode>>();
 	public HashMap<String, String[]> raw = new HashMap<String, String[]>();
 	public OutlierDetector out;
 	// testdata rowid:{tar, tarcolor}
@@ -78,12 +73,12 @@ public class ExampleSelection {
 	// exps: rowId: {org, tar, tarcode,classlabel}
 	// example: partition id: [{tar,tarcode}]
 	public void inite(HashMap<String, String[]> exps,
-			HashMap<String, Vector<String[]>> examples) {
+			HashMap<String, List<String[]>> examples) {
 		// inite the class center vector
 	
 		if (way >= 6) {
 			out = new OutlierDetector();
-			out.buildMeanVector(examples);
+			out.buildMeanList(examples);
 		}
 		Ruler ruler = new Ruler();
 		for (String keyString : exps.keySet()) {
@@ -152,7 +147,7 @@ public class ExampleSelection {
 		return ID;
 	}
 
-	public int ambiguityScore(Vector<TNode> vec) {
+	public int ambiguityScore(List<TNode> vec) {
 		HashMap<String, Integer> d = new HashMap<String, Integer>();
 		int score = 0;
 		for (int i = 0; i < vec.size(); i++) {
@@ -191,13 +186,13 @@ public class ExampleSelection {
 
 	public String way6() {
 		String row = "";
-		if (out.rVectors.size() == 0) {
+		if (out.rLists.size() == 0) {
 			return this.way2();
 		}
 		double max = -1;
 		for (String key : this.testdata.keySet()) {
 			String trowid = out.getOutliers(testdata.get(key),
-					out.rVectors.get(key), max);
+					out.rLists.get(key), max);
 			max = out.currentMax;
 			if (trowid.length() > 0) {
 				row = trowid;
@@ -211,7 +206,7 @@ public class ExampleSelection {
 			firsttime = false;
 			return this.way2();
 		}
-		Vector<String> examples = new Vector<String>();
+		List<String> examples = new ArrayList<String>();
 		for (String key : raw.keySet()) {
 			int cnt = 0;
 			int spos = 0;
@@ -242,7 +237,7 @@ public class ExampleSelection {
 			double tmax = -1;
 			for (String key : this.testdata.keySet()) {
 				String trowid = out.getOutliers(testdata.get(key),
-						out.rVectors.get(key), tmax);
+						out.rLists.get(key), tmax);
 				tmax = out.currentMax;
 				if (trowid.length() > 0) {
 					row = trowid;

--- a/src/main/java/edu/isi/karma/cleaning/Feature1.java
+++ b/src/main/java/edu/isi/karma/cleaning/Feature1.java
@@ -21,13 +21,14 @@
 
 package edu.isi.karma.cleaning;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 //counting  text feature
 public class Feature1 implements RecFeature{
 	public String target;
-	public Vector<TNode> xNodes =new Vector<TNode>();
-	public Feature1(String tar,Vector<TNode> xNodes)
+	public List<TNode> xNodes =new ArrayList<TNode>();
+	public Feature1(String tar,List<TNode> xNodes)
 	{
 		target = tar;
 		this.xNodes = xNodes;

--- a/src/main/java/edu/isi/karma/cleaning/Feature2.java
+++ b/src/main/java/edu/isi/karma/cleaning/Feature2.java
@@ -21,14 +21,15 @@
 
 package edu.isi.karma.cleaning;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 //type count feature
 public class Feature2 implements RecFeature {
 
 	public int type;
-	public Vector<TNode> xNodes =new Vector<TNode>();
-	public Feature2(int type,Vector<TNode> xNodes)
+	public List<TNode> xNodes =new ArrayList<TNode>();
+	public Feature2(int type,List<TNode> xNodes)
 	{
 		this.type = type;
 		this.xNodes = xNodes;

--- a/src/main/java/edu/isi/karma/cleaning/FeatureVector.java
+++ b/src/main/java/edu/isi/karma/cleaning/FeatureVector.java
@@ -21,14 +21,13 @@
 
 package edu.isi.karma.cleaning;
 
-import java.util.Vector;
-
-import edu.isi.mediator.domain.parser.grammar.DomainModelParser.in_comparison_return;
+import java.util.ArrayList;
+import java.util.List;
 
 public class FeatureVector {
 	String[] symbol = {"#",";",",","!","~","@","$","%","^","&","*","(",")","_","-","{","}","[","]","\"","'",":","?","<",">","."};
 	int[] types = {TNode.NUMTYP,TNode.SYBSTYP,TNode.LWRDTYP,TNode.UWRDTYP};
-	Vector<RecFeature> x = new Vector<RecFeature>();
+	List<RecFeature> x = new ArrayList<RecFeature>();
 	public int size;
 	
 	public FeatureVector()
@@ -40,17 +39,17 @@ public class FeatureVector {
 	{
 		return symbol.length+types.length+1;
 	}
-	public Vector<RecFeature> createVector(String raw,String color)
+	public List<RecFeature> createList(String raw,String color)
 	{
-		Vector<RecFeature> v = new Vector<RecFeature>();
+		List<RecFeature> v = new ArrayList<RecFeature>();
 		Ruler r = new Ruler();
 		r.setNewInput(raw);
-		Vector<TNode> vt = new Vector<TNode>();
+		List<TNode> vt = new ArrayList<TNode>();
 		vt = r.vec;
-		constructVector(vt,color,v);
+		constructList(vt,color,v);
 		return v;
 	}
-	public void constructVector(Vector<TNode> t,String color,Vector<RecFeature> v)
+	public void constructList(List<TNode> t,String color,List<RecFeature> v)
 	{
 		
 		for(String s:symbol)

--- a/src/main/java/edu/isi/karma/cleaning/GrammarTreeNode.java
+++ b/src/main/java/edu/isi/karma/cleaning/GrammarTreeNode.java
@@ -7,7 +7,7 @@ public interface GrammarTreeNode {
 	public String getNodeType();
 	public double getScore();
 	public String getrepString(); // return a string represent the type info of the grammar tree node
-	public void createTotalOrderVector(); // use the predefined partial order to creat a total order vector
+	public void createTotalOrderList(); // use the predefined partial order to creat a total order vector
 	public void emptyState();
 	public long size();
 }

--- a/src/main/java/edu/isi/karma/cleaning/GrammarTreeNode.java
+++ b/src/main/java/edu/isi/karma/cleaning/GrammarTreeNode.java
@@ -7,7 +7,7 @@ public interface GrammarTreeNode {
 	public String getNodeType();
 	public double getScore();
 	public String getrepString(); // return a string represent the type info of the grammar tree node
-	public void createTotalOrderList(); // use the predefined partial order to creat a total order vector
+	public void createTotalOrderVector(); // use the predefined partial order to create a total order vector
 	public void emptyState();
 	public long size();
 }

--- a/src/main/java/edu/isi/karma/cleaning/Loop.java
+++ b/src/main/java/edu/isi/karma/cleaning/Loop.java
@@ -87,7 +87,7 @@ public class Loop implements GrammarTreeNode {
 		return this.loopbody.getrepString();
 	}
 	@Override
-	public void createTotalOrderVector() {
+	public void createTotalOrderList() {
 		// TODO Auto-generated method stub
 		
 	}

--- a/src/main/java/edu/isi/karma/cleaning/Loop.java
+++ b/src/main/java/edu/isi/karma/cleaning/Loop.java
@@ -87,7 +87,7 @@ public class Loop implements GrammarTreeNode {
 		return this.loopbody.getrepString();
 	}
 	@Override
-	public void createTotalOrderList() {
+	public void createTotalOrderVector() {
 		// TODO Auto-generated method stub
 		
 	}

--- a/src/main/java/edu/isi/karma/cleaning/MultipleStringAlign.java
+++ b/src/main/java/edu/isi/karma/cleaning/MultipleStringAlign.java
@@ -20,25 +20,26 @@
  ******************************************************************************/
 
 package edu.isi.karma.cleaning;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public class MultipleStringAlign {
-	public MultipleStringAlign(Vector<String[]> strs)
+	public MultipleStringAlign(List<String[]> strs)
 	{
 		
 	}
 	// generate all the possible next state in DFA
 	public void generateChildren(ANode a)
 	{
-		Vector<Vector<int[]>> multiSeqMapping = new Vector<Vector<int[]>>();
-		Vector<Long> indexes = new Vector<Long>();
+		List<List<int[]>> multiSeqMapping = new ArrayList<List<int[]>>();
+		List<Long> indexes = new ArrayList<Long>();
 		for(int i = 0; i < a.exps.size(); i++)
 		{
 			String[] example = a.exps.get(i);
 			int pos = a.orgPos.get(i);
-			Vector<int[]> mappings = findNext(example[0], example[1], pos);
+			List<int[]> mappings = findNext(example[0], example[1], pos);
 			// tarpos, orgstartpos, orgendpos
-			Vector<int[]> nmapping = new Vector<int[]>();
+			List<int[]> nmapping = new ArrayList<int[]>();
 			for(int[] elem: mappings)
 			{
 				int[] el = {pos, elem[0],elem[1]};
@@ -48,15 +49,15 @@ public class MultipleStringAlign {
 			multiSeqMapping.add(nmapping);
 		}
 		// generate combinations
-		Vector<Vector<Integer>> configs = new Vector<Vector<Integer>>();
+		List<List<Integer>> configs = new ArrayList<List<Integer>>();
 		getCrossIndex(indexes, configs);
 		// using a combination to generate the ANode
 		for(int i=0; i<configs.size(); i++)
 		{
-			Vector<Integer> poses = configs.get(i);
-			Vector<Integer> orgPos = new Vector<Integer>();
-			Vector<Integer> tarPos = new Vector<Integer>();
-			Vector<Integer> length = new Vector<Integer>();
+			List<Integer> poses = configs.get(i);
+			List<Integer> orgPos = new ArrayList<Integer>();
+			List<Integer> tarPos = new ArrayList<Integer>();
+			List<Integer> length = new ArrayList<Integer>();
 			for(int j = 0; j< poses.size(); j++)
 			{
 				int[] e = multiSeqMapping.get(j).get(poses.get(j));
@@ -70,13 +71,13 @@ public class MultipleStringAlign {
 		}
 	}
 	// iteratively generate the combinations
-	public void getCrossIndex(Vector<Long> indexs,Vector<Vector<Integer>> configs) {
+	public void getCrossIndex(List<Long> indexs,List<List<Integer>> configs) {
 	    int k = indexs.size();
 		int[] com = new int[k];
 	    for (int i = 0; i < k; i++) 
 	    		com[i] = 0;
 	    while (com[k - 1] < indexs.get(k-1)) {
-	    		Vector<Integer> res = new Vector<Integer>();
+	    		List<Integer> res = new ArrayList<Integer>();
 	        for (int i = 0; i < k; i++)
 	        {
 	        		//System.out.print(""+com[i]);
@@ -96,9 +97,9 @@ public class MultipleStringAlign {
 	    }
 	}
 	//{[orgstartPos, orgendPos ], ...}
-	public Vector<int[]> findNext(String org, String tar, int pos)
+	public List<int[]> findNext(String org, String tar, int pos)
 	{
-		Vector<int[]> segs = new Vector<int[]>();
+		List<int[]> segs = new ArrayList<int[]>();
 		if(tar.length() == 0)
 		{
 			int[] elem = {-1,0};
@@ -132,14 +133,14 @@ public class MultipleStringAlign {
 			for (int j = pos; j <= i; j++) {
 				tvec += tar.charAt(j);
 			}
-			Vector<Integer> mappings = new Vector<Integer>();
+			List<Integer> mappings = new ArrayList<Integer>();
 			int r = org.indexOf(tvec);
 			while (r != -1) {
 				mappings.add(r);
 				r = org.indexOf(tvec,r+1);
 			}
 			if (mappings.size() > 1) {
-				Vector<int[]> corrm = new Vector<int[]>();
+				List<int[]> corrm = new ArrayList<int[]>();
 				for (int t : mappings) {
 					int[] m = { t, t + tvec.length() };
 					corrm.add(m);
@@ -148,7 +149,7 @@ public class MultipleStringAlign {
 				segs.addAll(corrm);
 				continue;
 			} else if (mappings.size() == 1) {
-				Vector<int[]> corrm = new Vector<int[]>();
+				List<int[]> corrm = new ArrayList<int[]>();
 				// creating based on whether can find segment with one more
 				// token
 				if (i >= (tar.length() - 1)) {
@@ -184,7 +185,7 @@ public class MultipleStringAlign {
 	}
 	public static void main(String[] args)
 	{
-		Vector<String[]> strs = new Vector<String[]>();
+		List<String[]> strs = new ArrayList<String[]>();
 		MultipleStringAlign msa = new MultipleStringAlign(strs);
 		String org = "hello world";
 		String tar = "world";
@@ -192,7 +193,7 @@ public class MultipleStringAlign {
 		for(int i = 0; i<tar.length(); i++)
 		{
 			System.out.println("starting pos: "+i);
-			Vector<int[]> result = msa.findNext(org, tar, i);
+			List<int[]> result = msa.findNext(org, tar, i);
 			for(int[] seg:result)
 			{
 				System.out.println(""+org.substring(seg[0],seg[1]));

--- a/src/main/java/edu/isi/karma/cleaning/OutlierDetector.java
+++ b/src/main/java/edu/isi/karma/cleaning/OutlierDetector.java
@@ -22,16 +22,10 @@
 package edu.isi.karma.cleaning;
 
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Vector;
-
-import org.geotools.filter.expression.ThisPropertyAccessorFactory;
-import org.python.antlr.PythonParser.return_stmt_return;
-
-import com.hp.hpl.jena.sparql.function.library.max;
+import java.util.List;
 
 public class OutlierDetector {
-	public HashMap<String,double[]> rVectors = new HashMap<String,double[]>();
+	public HashMap<String,double[]> rLists = new HashMap<String,double[]>();
 	public double currentMax = -1;
 	public OutlierDetector()
 	{
@@ -51,22 +45,22 @@ public class OutlierDetector {
 	// find outliers for one partition
 	//simple 2d distance
 	//testdata rowid:{tar, tarcolor}
-	public String getOutliers(HashMap<String,String[]> testdata,double[] meanVector,double Max)
+	public String getOutliers(HashMap<String,String[]> testdata,double[] meanList,double Max)
 	{
 		String Id = "";
 		for(String key: testdata.keySet())
 		{
 			String[] vpair = testdata.get(key);
 			FeatureVector fvFeatureVector = new FeatureVector();
-			Vector<RecFeature> vRecFeatures = fvFeatureVector.createVector(vpair[0], vpair[1]);
+			List<RecFeature> vRecFeatures = fvFeatureVector.createList(vpair[0], vpair[1]);
 			double[] x = new double[fvFeatureVector.size()];
 			for(int i = 0; i< vRecFeatures.size(); i++)
 			{
 				x[i] = vRecFeatures.get(i).computerScore();
 			}
-			double value = this.getDistance(x, meanVector);
+			double value = this.getDistance(x, meanList);
 			/*System.out.println("current: "+ vpair[0]+ " "+Max);
-			System.out.println("=======\n"+this.test(x)+"\n"+this.test(meanVector));
+			System.out.println("=======\n"+this.test(x)+"\n"+this.test(meanList));
 			System.out.println("distance: "+value);*/
 			if(value > Max)
 			{
@@ -78,21 +72,21 @@ public class OutlierDetector {
 		return Id;
 	}
 	// pid: [{rawstring, code}]
-	public void buildMeanVector(HashMap<String,Vector<String[]>> data)
+	public void buildMeanList(HashMap<String,List<String[]>> data)
 	{
 		if(data == null)
 			return;
 		for(String key:data.keySet())
 		{
-			Vector<String[]> vs = data.get(key);
-			FeatureVector fVector = new FeatureVector();
-			double[] dvec = new double[fVector.size()];
+			List<String[]> vs = data.get(key);
+			FeatureVector fList = new FeatureVector();
+			double[] dvec = new double[fList.size()];
 			for (int i = 0; i < dvec.length; i++) {
 				dvec[i] = 0;
 			}
 			for(String[] elem:vs)
 			{
-				Vector<RecFeature> sFeatures = fVector.createVector(elem[0], elem[1]);
+				List<RecFeature> sFeatures = fList.createList(elem[0], elem[1]);
 				for(int j = 0; j<sFeatures.size();j++)
 				{
 					dvec[j] += sFeatures.get(j).computerScore();
@@ -103,7 +97,7 @@ public class OutlierDetector {
 			{
 				dvec[i] = dvec[i]*1.0/ vs.size();
 			}
-			rVectors.put(key, dvec);
+			rLists.put(key, dvec);
 		}
 	}
 	public String test(double[] row)

--- a/src/main/java/edu/isi/karma/cleaning/Partition.java
+++ b/src/main/java/edu/isi/karma/cleaning/Partition.java
@@ -1,13 +1,14 @@
 package edu.isi.karma.cleaning;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class Partition implements GrammarTreeNode {
 	public Traces trace;
-	public Vector<Vector<TNode>> orgNodes;
-	public Vector<Vector<TNode>> tarNodes;
-	public Vector<String> mapping = new Vector<String>();
+	public List<List<TNode>> orgNodes;
+	public List<List<TNode>> tarNodes;
+	public List<String> mapping = new ArrayList<String>();
 	public String label; // the class label of current partition
 	public String cls;
 	public Partition()
@@ -18,11 +19,11 @@ public class Partition implements GrammarTreeNode {
 	{
 		return trace.size();
 	}
-	public Partition(Vector<Vector<TNode>> org,Vector<Vector<TNode>> tar)
+	public Partition(List<List<TNode>> org,List<List<TNode>> tar)
 	{
 		this.orgNodes = org;
 		this.tarNodes = tar;
-		Vector<Traces> ts = new Vector<Traces>();
+		List<Traces> ts = new ArrayList<Traces>();
 		for(int i = 0; i<orgNodes.size();i++)
 		{
 			Traces t = new Traces(orgNodes.get(i),tarNodes.get(i));
@@ -39,7 +40,7 @@ public class Partition implements GrammarTreeNode {
 	{
 		this.trace = t;
 	}
-	public void setExamples(Vector<Vector<TNode>> orgNodes,Vector<Vector<TNode>> tarNodes)
+	public void setExamples(List<List<TNode>> orgNodes,List<List<TNode>> tarNodes)
 	{
 		this.orgNodes = orgNodes;
 		this.tarNodes = tarNodes;
@@ -52,8 +53,8 @@ public class Partition implements GrammarTreeNode {
 	{
 		Traces mt = this.trace.mergewith(b.trace);
 		//add the examples
-		Vector<Vector<TNode>> norg = new Vector<Vector<TNode>>();
-		Vector<Vector<TNode>> ntar = new Vector<Vector<TNode>>();
+		List<List<TNode>> norg = new ArrayList<List<TNode>>();
+		List<List<TNode>> ntar = new ArrayList<List<TNode>>();
 		norg.addAll(this.orgNodes);
 		norg.addAll(b.orgNodes);
 		ntar.addAll(this.tarNodes);
@@ -130,7 +131,7 @@ public class Partition implements GrammarTreeNode {
 		return "Partition";
 	}
 	@Override
-	public void createTotalOrderVector() {
+	public void createTotalOrderList() {
 		// TODO Auto-generated method stub
 		
 	}

--- a/src/main/java/edu/isi/karma/cleaning/Partition.java
+++ b/src/main/java/edu/isi/karma/cleaning/Partition.java
@@ -131,7 +131,7 @@ public class Partition implements GrammarTreeNode {
 		return "Partition";
 	}
 	@Override
-	public void createTotalOrderList() {
+	public void createTotalOrderVector() {
 		// TODO Auto-generated method stub
 		
 	}

--- a/src/main/java/edu/isi/karma/cleaning/PartitionClassifier.java
+++ b/src/main/java/edu/isi/karma/cleaning/PartitionClassifier.java
@@ -1,6 +1,6 @@
 package edu.isi.karma.cleaning;
 
-import java.util.Vector;
+import java.util.List;
 
 import org.python.core.PyObject;
 import org.python.util.PythonInterpreter;
@@ -36,7 +36,7 @@ public class PartitionClassifier {
         interpreter.exec("from IDCTClassifier import *");  
         interpreterClass = interpreter.get("IDCTClassifier");
 	}
-	public PartitionClassifierType create(Vector<Partition> pars)
+	public PartitionClassifierType create(List<Partition> pars)
 	{
 		PyObject buildingObject = interpreterClass.__call__();
 		PartitionClassifierType ele =  (PartitionClassifierType)buildingObject.__tojava__(PartitionClassifierType.class);
@@ -54,7 +54,7 @@ public class PartitionClassifier {
 		this.clssettingString = ele.learnClassifer();
 		return ele;
 	}
-	public PartitionClassifierType create2(Vector<Partition> pars)
+	public PartitionClassifierType create2(List<Partition> pars)
 	{
 		RecordClassifier2 ele = new RecordClassifier2();
 		for(int i = 0; i<pars.size(); i++)

--- a/src/main/java/edu/isi/karma/cleaning/Position.java
+++ b/src/main/java/edu/isi/karma/cleaning/Position.java
@@ -1,29 +1,30 @@
 package edu.isi.karma.cleaning;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.Vector;
 
 public class Position implements GrammarTreeNode {
-	public Vector<TNode> leftContextNodes = new Vector<TNode>();
-	public Vector<TNode> rightContextNodes = new Vector<TNode>();
-	public Vector<Integer> absPosition = new Vector<Integer>();
-	public Vector<Integer> counters = new Vector<Integer>();
-	public Vector<String> orgStrings = new Vector<String>();
-	public Vector<String> tarStrings = new Vector<String>();
+	public List<TNode> leftContextNodes = new ArrayList<TNode>();
+	public List<TNode> rightContextNodes = new ArrayList<TNode>();
+	public List<Integer> absPosition = new ArrayList<Integer>();
+	public List<Integer> counters = new ArrayList<Integer>();
+	public List<String> orgStrings = new ArrayList<String>();
+	public List<String> tarStrings = new ArrayList<String>();
 	public boolean isinloop = false;
 	public int curState = 0;
 	public static Interpretor itInterpretor = null;
 	public static int fixedlength = 1;
 
-	public Position(Vector<Integer> absPos, Vector<TNode> lcxt,
-			Vector<TNode> rcxt, Vector<String> orgStrings,
-			Vector<String> tarStrings, boolean loop) {
+	public Position(List<Integer> absPos, List<TNode> lcxt,
+			List<TNode> rcxt, List<String> orgStrings,
+			List<String> tarStrings, boolean loop) {
 		this.absPosition = absPos;
 		this.orgStrings.addAll(orgStrings);
 		this.tarStrings.addAll(tarStrings);
@@ -35,7 +36,7 @@ public class Position implements GrammarTreeNode {
 		this.leftContextNodes = lcxt;
 		this.rightContextNodes = rcxt;
 		this.isinloop = loop;
-		createTotalOrderVector();
+		createTotalOrderList();
 	}
 
 	public Position(Position p, boolean loop) {
@@ -46,10 +47,10 @@ public class Position implements GrammarTreeNode {
 		this.leftContextNodes = p.leftContextNodes;
 		this.rightContextNodes = p.rightContextNodes;
 		this.isinloop = loop;
-		createTotalOrderVector();
+		createTotalOrderList();
 	}
 
-	public void getString(Vector<TNode> x, int cur, String path, Double value,
+	public void getString(List<TNode> x, int cur, String path, Double value,
 			HashMap<String, Double> smap, boolean isleft) {
 		if(fixedlength == 0)
 		{
@@ -110,9 +111,9 @@ public class Position implements GrammarTreeNode {
 	}
 
 	// option: left or right context
-	public Vector<TNode> mergeCNXT(Vector<TNode> a, Vector<TNode> b,
+	public List<TNode> mergeCNXT(List<TNode> a, List<TNode> b,
 			String option) {
-		Vector<TNode> xNodes = new Vector<TNode>();
+		List<TNode> xNodes = new ArrayList<TNode>();
 		if (a == null || b == null)
 			return null;
 		else {
@@ -169,17 +170,17 @@ public class Position implements GrammarTreeNode {
 	public Position mergewith(Position b) {
 		if (this == null || b == null)
 			return null;
-		Vector<Integer> tmpIntegers = new Vector<Integer>();
+		List<Integer> tmpIntegers = new ArrayList<Integer>();
 		tmpIntegers.addAll(this.absPosition);
 		tmpIntegers.retainAll(b.absPosition);
-		Vector<Integer> tmpIntegers2 = new Vector<Integer>();
+		List<Integer> tmpIntegers2 = new ArrayList<Integer>();
 		tmpIntegers2.addAll(this.counters);
 		tmpIntegers2.retainAll(b.counters);
-		Vector<TNode> tl = b.leftContextNodes;
-		Vector<TNode> tr = b.rightContextNodes;
-		Vector<TNode> g_lcxtNodes = mergeCNXT(this.leftContextNodes, tl,
+		List<TNode> tl = b.leftContextNodes;
+		List<TNode> tr = b.rightContextNodes;
+		List<TNode> g_lcxtNodes = mergeCNXT(this.leftContextNodes, tl,
 				Segment.LEFTPOS);
-		Vector<TNode> g_rcxtNodes = mergeCNXT(this.rightContextNodes, tr,
+		List<TNode> g_rcxtNodes = mergeCNXT(this.rightContextNodes, tr,
 				Segment.RIGHTPOS);
 		// this.leftContextNodes = g_lcxtNodes;
 		// this.rightContextNodes = g_rcxtNodes;
@@ -188,8 +189,8 @@ public class Position implements GrammarTreeNode {
 			return null;
 		boolean loop = this.isinloop || b.isinloop;
 
-		Vector<String> aStrings = new Vector<String>();
-		Vector<String> bStrings = new Vector<String>();
+		List<String> aStrings = new ArrayList<String>();
+		List<String> bStrings = new ArrayList<String>();
 
 		if (this.orgStrings.size() == 1
 				&& this.orgStrings.size() == b.tarStrings.size()
@@ -274,7 +275,7 @@ public class Position implements GrammarTreeNode {
 		this.curState = 0;
 	}
 
-	public Vector<String> rules = new Vector<String>();
+	public List<String> rules = new ArrayList<String>();
 
 	public String toProgram() {
 		if (curState >= rules.size())
@@ -362,7 +363,7 @@ public class Position implements GrammarTreeNode {
 		}
 		return "null";
 	}
-	public void createTotalOrderVector() {
+	public void createTotalOrderList() {
 		HashMap<String, Double> lMap = new HashMap<String, Double>();
 		HashMap<String, Double> rMap = new HashMap<String, Double>();
 		if (this.leftContextNodes != null) {
@@ -380,7 +381,7 @@ public class Position implements GrammarTreeNode {
 			rMap.put("ANY", 1.0);
 		}
 		String reString = "";
-		SortedMap<Double, Vector<String>> sortedMap = new TreeMap<Double, Vector<String>>();
+		SortedMap<Double, List<String>> sortedMap = new TreeMap<Double, List<String>>();
 		String negString = "";
 		for (String a : lMap.keySet()) {
 			for (String b : rMap.keySet()) {
@@ -395,7 +396,7 @@ public class Position implements GrammarTreeNode {
 					sortedMap.get(key).add(reString);
 					sortedMap.get(key).add(negString);
 				} else {
-					Vector<String> svec = new Vector<String>();
+					List<String> svec = new ArrayList<String>();
 					svec.add(reString);
 					svec.add(negString);
 					sortedMap.put(key, svec);

--- a/src/main/java/edu/isi/karma/cleaning/Position.java
+++ b/src/main/java/edu/isi/karma/cleaning/Position.java
@@ -36,7 +36,7 @@ public class Position implements GrammarTreeNode {
 		this.leftContextNodes = lcxt;
 		this.rightContextNodes = rcxt;
 		this.isinloop = loop;
-		createTotalOrderList();
+		createTotalOrderVector();
 	}
 
 	public Position(Position p, boolean loop) {
@@ -47,7 +47,7 @@ public class Position implements GrammarTreeNode {
 		this.leftContextNodes = p.leftContextNodes;
 		this.rightContextNodes = p.rightContextNodes;
 		this.isinloop = loop;
-		createTotalOrderList();
+		createTotalOrderVector();
 	}
 
 	public void getString(List<TNode> x, int cur, String path, Double value,
@@ -363,7 +363,7 @@ public class Position implements GrammarTreeNode {
 		}
 		return "null";
 	}
-	public void createTotalOrderList() {
+	public void createTotalOrderVector() {
 		HashMap<String, Double> lMap = new HashMap<String, Double>();
 		HashMap<String, Double> rMap = new HashMap<String, Double>();
 		if (this.leftContextNodes != null) {

--- a/src/main/java/edu/isi/karma/cleaning/ProgSynthesis.java
+++ b/src/main/java/edu/isi/karma/cleaning/ProgSynthesis.java
@@ -1,13 +1,14 @@
 package edu.isi.karma.cleaning;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Vector;
+import java.util.List;
 
 public class ProgSynthesis {
 	public static int time_limit = 20;
-	Vector<Vector<TNode>> orgVector = new Vector<Vector<TNode>>();
-	Vector<Vector<TNode>> tarVector = new Vector<Vector<TNode>>();
+	List<List<TNode>> orgList = new ArrayList<List<TNode>>();
+	List<List<TNode>> tarList = new ArrayList<List<TNode>>();
 	String bestRuleString = "";
 	// for tracking the stats
 	public long learnspan = 0;
@@ -15,44 +16,44 @@ public class ProgSynthesis {
 	public long ruleNo = 0;
 	public PartitionClassifierType classifier;
 
-	public void inite(Vector<String[]> examples) {
+	public void inite(List<String[]> examples) {
 		for (int i = 0; i < examples.size(); i++) {
 			Ruler r = new Ruler();
 			r.setNewInput(examples.get(i)[0]);
-			orgVector.add(r.vec);
+			orgList.add(r.vec);
 			Ruler r1 = new Ruler();
 			r1.setNewInput(examples.get(i)[1]);
-			tarVector.add(r1.vec);
+			tarList.add(r1.vec);
 		}
 	}
 
-	public Vector<Vector<Integer>> generateCrossIndex(Vector<Integer> poss,
-			Vector<Vector<Integer>> p, int index) {
-		Vector<Vector<Integer>> qVector = new Vector<Vector<Integer>>();
+	public List<List<Integer>> generateCrossIndex(List<Integer> poss,
+			List<List<Integer>> p, int index) {
+		List<List<Integer>> qList = new ArrayList<List<Integer>>();
 		if (index >= poss.size()) {
 			return p;
 		}
 		int curleng = poss.get(index);
 		if (p.size() == 0) {
 			for (int i = 0; i < curleng; i++) {
-				Vector<Integer> x = new Vector<Integer>();
+				List<Integer> x = new ArrayList<Integer>();
 				x.add(i);
-				qVector.add(x);
+				qList.add(x);
 			}
 		} else {
 			for (int j = 0; j < p.size(); j++) {
 				for (int i = 0; i < curleng; i++) {
-					Vector<Integer> x = (Vector<Integer>) p.get(j).clone();
+					List<Integer> x = new ArrayList<Integer>(p.get(j));
 					x.add(i);
-					qVector.add(x);
+					qList.add(x);
 				}
 			}
 		}
-		qVector = generateCrossIndex(poss, qVector, index + 1);
-		return qVector;
+		qList = generateCrossIndex(poss, qList, index + 1);
+		return qList;
 	}
 
-	public double getCompScore(int i, int j, Vector<Partition> pars) {
+	public double getCompScore(int i, int j, List<Partition> pars) {
 		Partition p = pars.get(i).mergewith(pars.get(j));
 		if (p == null) {
 			return -Double.MAX_VALUE;
@@ -70,21 +71,21 @@ public class ProgSynthesis {
 		return validCnt;
 	}
 
-	public Vector<Partition> initePartitions() {
-		Vector<Partition> pars = new Vector<Partition>();
+	public List<Partition> initePartitions() {
+		List<Partition> pars = new ArrayList<Partition>();
 		// inite partition for each example
-		for (int i = 0; i < orgVector.size(); i++) {
-			Vector<Vector<TNode>> ovt = new Vector<Vector<TNode>>();
-			Vector<Vector<TNode>> tvt = new Vector<Vector<TNode>>();
-			ovt.add(this.orgVector.get(i));
-			tvt.add(this.tarVector.get(i));
+		for (int i = 0; i < orgList.size(); i++) {
+			List<List<TNode>> ovt = new ArrayList<List<TNode>>();
+			List<List<TNode>> tvt = new ArrayList<List<TNode>>();
+			ovt.add(this.orgList.get(i));
+			tvt.add(this.tarList.get(i));
 			Partition pt = new Partition(ovt, tvt);
 			pars.add(pt);
 		}
 		return pars;
 	}
 
-	public void mergePartitions(Vector<Partition> pars) {
+	public void mergePartitions(List<Partition> pars) {
 		double maxScore = 0;
 		int[] pos = { -1, -1 };
 		for (int i = 0; i < pars.size(); i++) {
@@ -104,7 +105,7 @@ public class ProgSynthesis {
 			UpdatePartitions(pos[0], pos[1], pars);
 	}
 
-	public void UpdatePartitions(int i, int j, Vector<Partition> pars) {
+	public void UpdatePartitions(int i, int j, List<Partition> pars) {
 		Partition p = pars.get(i).mergewith(pars.get(j));
 		pars.set(i, p);
 		pars.remove(j);
@@ -114,8 +115,8 @@ public class ProgSynthesis {
 		return this.bestRuleString;
 	}
 
-	public Vector<Partition> ProducePartitions(boolean condense) {
-		Vector<Partition> pars = this.initePartitions();
+	public List<Partition> ProducePartitions(boolean condense) {
+		List<Partition> pars = this.initePartitions();
 		int size = pars.size();
 		while (condense) {
 			this.mergePartitions(pars);
@@ -128,7 +129,7 @@ public class ProgSynthesis {
 		return pars;
 	}
 
-	public Collection<ProgramRule> producePrograms(Vector<Partition> pars) {
+	public Collection<ProgramRule> producePrograms(List<Partition> pars) {
 		Program prog = new Program(pars);
 		HashSet<ProgramRule> rules = new HashSet<ProgramRule>();
 		int prog_cnt = 1;
@@ -179,7 +180,7 @@ public class ProgSynthesis {
 
 	public Collection<ProgramRule> run_main() {
 		long t1 = System.currentTimeMillis();
-		Vector<Partition> vp = this.ProducePartitions(true);
+		List<Partition> vp = this.ProducePartitions(true);
 		long t2 = System.currentTimeMillis();
 		Collection<ProgramRule> cpr = this.producePrograms(vp);
 		long t3 = System.currentTimeMillis();
@@ -198,7 +199,7 @@ public class ProgSynthesis {
 		return cpr;
 	}
 
-	public String validRule(ProgramRule p,Vector<Partition> vp) {
+	public String validRule(ProgramRule p,List<Partition> vp) {
 		for(Partition px:vp)
 		{
 			for (int i = 0; i < px.orgNodes.size(); i++) {

--- a/src/main/java/edu/isi/karma/cleaning/Program.java
+++ b/src/main/java/edu/isi/karma/cleaning/Program.java
@@ -129,7 +129,7 @@ public class Program implements GrammarTreeNode {
 		return "Program";
 	}
 	@Override
-	public void createTotalOrderList() {
+	public void createTotalOrderVector() {
 		// TODO Auto-generated method stub
 		
 	}

--- a/src/main/java/edu/isi/karma/cleaning/Program.java
+++ b/src/main/java/edu/isi/karma/cleaning/Program.java
@@ -1,13 +1,14 @@
 package edu.isi.karma.cleaning;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Program implements GrammarTreeNode {
-	public Vector<Partition> partitions = new Vector<Partition>();
+	public List<Partition> partitions = new ArrayList<Partition>();
 	public String cls = "";
 	public double score = 0.0;
 	public PartitionClassifierType classifier;
-	public Program(Vector<Partition> pars)
+	public Program(List<Partition> pars)
 	{
 		this.partitions = pars;
 		for(int i=0;i<this.partitions.size();i++)
@@ -128,7 +129,7 @@ public class Program implements GrammarTreeNode {
 		return "Program";
 	}
 	@Override
-	public void createTotalOrderVector() {
+	public void createTotalOrderList() {
 		// TODO Auto-generated method stub
 		
 	}

--- a/src/main/java/edu/isi/karma/cleaning/RecordDistiller.java
+++ b/src/main/java/edu/isi/karma/cleaning/RecordDistiller.java
@@ -23,15 +23,12 @@ package edu.isi.karma.cleaning;
 
 import java.io.File;
 import java.io.FileReader;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.Vector;
+import java.util.List;
 
 import au.com.bytecode.opencsv.CSVReader;
-
-import com.hp.hpl.jena.tdb.store.Hash;
 
 //select the most reprentative records from a huge list of rows
 //to ensure that the program learned from the subset could work correctly on the whole dataset
@@ -41,7 +38,7 @@ public class RecordDistiller {
 	public static int cxt_limit = 3;
 	public int totalnumber = 0;
 	public HashMap<String,Anchor> anchors = new  HashMap<String,Anchor>(); 
-	public void readRecord(String ID, Vector<TNode> record)
+	public void readRecord(String ID, List<TNode> record)
 	{
 		HashMap<String, Integer> curIndices = new HashMap<String, Integer>();
 		for(int i = 1; i< record.size()-1; i++) // skip the start and end token
@@ -82,7 +79,7 @@ public class RecordDistiller {
 			}
 			else
 			{
-				Vector<String> Ids = new Vector<String>();
+				List<String> Ids = new ArrayList<String>();
 				Ids.add(ID);
 				HashMap<String,String> vlcxt = new HashMap<String,String>();
 				vlcxt.put(ID,lcxt);
@@ -96,7 +93,7 @@ public class RecordDistiller {
 	//identify the anchor tokens 
 	public void idenAnchor(int total)
 	{
-		Vector<String> dels = new Vector<String>();
+		List<String> dels = new ArrayList<String>();
 		for(String a:anchors.keySet())
 		{
 			int count = anchors.get(a).count;
@@ -115,8 +112,8 @@ public class RecordDistiller {
 	//minimal set 
 	public HashSet<String> idenAnchorRecords(String anchor)
 	{
-		HashMap<String,Vector<String>> lcxt2ids = new HashMap<String, Vector<String>>();
-		HashMap<String,Vector<String>> rcxt2ids = new HashMap<String, Vector<String>>();
+		HashMap<String,List<String>> lcxt2ids = new HashMap<String, List<String>>();
+		HashMap<String,List<String>> rcxt2ids = new HashMap<String, List<String>>();
 		for(String Id: this.anchors.get(anchor).lefCxt.keySet())
 		{
 			String s  =this.anchors.get(anchor).lefCxt.get(Id);
@@ -131,7 +128,7 @@ public class RecordDistiller {
 			}
 			if(isnew)
 			{
-				Vector<String> vs = new Vector<String>();
+				List<String> vs = new ArrayList<String>();
 				vs.add(Id);
 				lcxt2ids.put(s, vs);
 			}
@@ -154,7 +151,7 @@ public class RecordDistiller {
 			}
 			if(isnew)
 			{
-				Vector<String> vs = new Vector<String>();
+				List<String> vs = new ArrayList<String>();
 				vs.add(Id);
 				rcxt2ids.put(s, vs);
 			}
@@ -252,13 +249,13 @@ public class RecordDistiller {
 
 class Anchor{
 	public String name;
-	public Vector<String> IDs;
+	public List<String> IDs;
 	public int count;
 	// id 2 the left context
 	public HashMap<String, String> lefCxt = new HashMap<String, String>();
 	// id 2 the right context
 	public HashMap<String, String> rigCxt =new HashMap<String, String>();
-	public Anchor(String anchor,Vector<String> Ids,int count, HashMap<String, String> lcxt, HashMap<String, String> rcxt)
+	public Anchor(String anchor,List<String> Ids,int count, HashMap<String, String> lcxt, HashMap<String, String> rcxt)
 	{
 		this.name = anchor;
 		this.IDs = Ids;

--- a/src/main/java/edu/isi/karma/cleaning/Ruler.java
+++ b/src/main/java/edu/isi/karma/cleaning/Ruler.java
@@ -19,11 +19,12 @@
  * and related projects, please see: http://www.isi.edu/integration
  ******************************************************************************/
 package edu.isi.karma.cleaning;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.ListIterator;
 import java.util.StringTokenizer;
-import java.util.Vector;
 
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.CharStream;
@@ -33,25 +34,25 @@ public class Ruler {
 	String Trgt = "";
 	StringTokenizer st = null;
 	String[] seperator = {" ",","};
-	public Vector<TNode> vec;
+	public List<TNode> vec;
 	int curPos = 0;
-	Vector<Object[]> operators = new Vector<Object[]>();
-	Vector<Integer> positions;
-	Vector<TNode> whats;
-	Vector<Integer> consPos;
+	List<Object[]> operators = new ArrayList<Object[]>();
+	List<Integer> positions;
+	List<TNode> whats;
+	List<Integer> consPos;
 	public Ruler()
 	{
-		positions = new Vector<Integer>();
-		consPos = new Vector<Integer>();
-		whats = new Vector<TNode>();
+		positions = new ArrayList<Integer>();
+		consPos = new ArrayList<Integer>();
+		whats = new ArrayList<TNode>();
 	}
 	public Ruler(String x)
 	{
-		positions = new Vector<Integer>();
-		consPos = new Vector<Integer>();
-		whats = new Vector<TNode>();
+		positions = new ArrayList<Integer>();
+		consPos = new ArrayList<Integer>();
+		whats = new ArrayList<TNode>();
 		this.initConstantPosition();
-		vec = new Vector<TNode>();
+		vec = new ArrayList<TNode>();
 		Org = x;
 		tokenize();
 	}
@@ -71,22 +72,22 @@ public class Ruler {
 	{
 		this.Org = x;
 		this.Trgt = "";
-		this.vec = new Vector<TNode>();
+		this.vec = new ArrayList<TNode>();
 		this.curPos = 0;
 		this.tokenize();
 		this.initConstantPosition();
 	}
-	public void setNewInput(Vector<TNode> x)
+	public void setNewInput(List<TNode> x)
 	{
 		this.Org = x.toString();
 		this.Trgt = "";
-		this.vec = new Vector<TNode>();
+		this.vec = new ArrayList<TNode>();
 		this.curPos = 0;
 		this.vec = x;
 		this.initConstantPosition();
 	}
 	//in current data,search the position of the tvec
-	public static int Search(Vector<TNode> xvec,Vector<TNode> tvec,int bpos)
+	public static int Search(List<TNode> xvec,List<TNode> tvec,int bpos)
 	{
 		boolean isFind = false;
 		int p1 = -1;
@@ -115,7 +116,7 @@ public class Ruler {
 		return -1;
 	}
 	//evalPos()
-	public int evalPos(String input,Vector<TNode> t, String option)
+	public int evalPos(String input,List<TNode> t, String option)
 	{
 		boolean incld = false;
 		if(input.contains("first"))
@@ -156,7 +157,7 @@ public class Ruler {
 			}
 			else
 			{
-				Vector<TNode> tmpvec = (Vector<TNode>)this.vec.clone();
+				List<TNode> tmpvec = new ArrayList<TNode>(this.vec);
 				Collections.reverse(tmpvec);
 				int pos = Ruler.Search(tmpvec,t, 0);
 				if(pos == -1)
@@ -305,7 +306,7 @@ public class Ruler {
 		}
 		return res;
 	}
-	public void doOperation(String oper,String num,Vector<TNode> x,int spos,int epos)
+	public void doOperation(String oper,String num,List<TNode> x,int spos,int epos)
 	{
 		int quan = 0 ;
 		if(num==null||num.compareTo("anynumber")==0)
@@ -356,7 +357,7 @@ public class Ruler {
 	}
 	//toks is the token sequence that needed to be inserted into original token sequence
 	//dpos is the position start of the insertion
-	public void ins(Vector<TNode> toks,int dpos)
+	public void ins(List<TNode> toks,int dpos)
 	{
 		if(dpos<vec.size())
 		{
@@ -371,7 +372,7 @@ public class Ruler {
 	//toks specify the tokens need to be moved
 	//spos is the start position of the segment
 	//epos is the end position of the segment
-	public void mov(Vector<TNode> toks, int dpos, int spos,int epos)
+	public void mov(List<TNode> toks, int dpos, int spos,int epos)
 	{
 		int pos = 0;
 		int size = 0;
@@ -399,7 +400,7 @@ public class Ruler {
 		ListIterator<TNode> l = this.vec.listIterator(pos);
 		//ListIterator<TNode> dl = this.vec.listIterator(dpos);
 		int c = 0;
-		Vector<TNode> x = new Vector<TNode>();
+		List<TNode> x = new ArrayList<TNode>();
 		for(c = 0;c<size;c++)
 		{
 			//this.collectPoss(pos);
@@ -430,7 +431,7 @@ public class Ruler {
 			this.vec.addAll(dpos, x);
 		}
 	}
-	public void det(int n,Vector<TNode> toks, int start, int end)
+	public void det(int n,List<TNode> toks, int start, int end)
 	{
 		int cnt = 0;
 		int pos = 0;

--- a/src/main/java/edu/isi/karma/cleaning/Section.java
+++ b/src/main/java/edu/isi/karma/cleaning/Section.java
@@ -1,19 +1,20 @@
 package edu.isi.karma.cleaning;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Section implements GrammarTreeNode {
 	public Position[] pair;
 	public static int time_limit = 10;
-	public Vector<int[]> rules = new Vector<int[]>();
+	public List<int[]> rules = new ArrayList<int[]>();
 	public int rule_cxt_size = Segment.cxtsize_limit;
 	public int curState = 0;
 	public boolean isinloop = false;
-	public Vector<String> orgStrings = new Vector<String>();
-	public Vector<String> tarStrings = new Vector<String>();
+	public List<String> orgStrings = new ArrayList<String>();
+	public List<String> tarStrings = new ArrayList<String>();
 	public static Interpretor itInterpretor = null;
 	public static int supermode = 0;
-	public Section(Position[] p,Vector<String> orgStrings,Vector<String> tarStrings,boolean isinloop)
+	public Section(Position[] p,List<String> orgStrings,List<String> tarStrings,boolean isinloop)
 	{
 		pair = p;
 		this.orgStrings = orgStrings;
@@ -21,7 +22,7 @@ public class Section implements GrammarTreeNode {
 		if(itInterpretor==null)
 			itInterpretor =  new Interpretor();
 		if(supermode == 0)
-			this.createTotalOrderVector();
+			this.createTotalOrderList();
 		else
 		{
 			this.reiniteRules();
@@ -71,8 +72,8 @@ public class Section implements GrammarTreeNode {
 		{
 			Position[] pa = {x,y};
 			boolean loop = this.isinloop || sec.isinloop;
-			Vector<String> strs = new Vector<String>();
-			Vector<String> tars = new Vector<String>();
+			List<String> strs = new ArrayList<String>();
+			List<String> tars = new ArrayList<String>();
 			if(this.orgStrings.size() == sec.orgStrings.size() && this.orgStrings.size() == 1 && this.orgStrings.get(0).compareTo(sec.orgStrings.get(0))==0)
 			{
 				// merge within one example. test the loop expression
@@ -114,7 +115,7 @@ public class Section implements GrammarTreeNode {
 	}
 
 	@Override
-	public void createTotalOrderVector() {
+	public void createTotalOrderList() {
 		for(int i = 0; i< pair[0].rules.size(); i++)
 		{
 			for(int j = 0; j< pair[1].rules.size(); j++)
@@ -126,10 +127,10 @@ public class Section implements GrammarTreeNode {
 	}
 	public void reiniteRules()
 	{
-		Vector<Long> indexs = new Vector<Long>();
+		List<Long> indexs = new ArrayList<Long>();
 		indexs.add((long)16);
 		indexs.add((long)16);
-		Vector<Vector<Integer>> configs = new Vector<Vector<Integer>>();
+		List<List<Integer>> configs = new ArrayList<List<Integer>>();
 		rules.clear();
 		getCrossIndex(indexs, 0, "", configs);
 		for(int i = 0; i<configs.size(); i++)
@@ -138,12 +139,12 @@ public class Section implements GrammarTreeNode {
 			rules.add(elem);
 		}
 	}
-	public void getCrossIndex(Vector<Long> indexs, int cur, String path,
-			Vector<Vector<Integer>> configs) {
+	public void getCrossIndex(List<Long> indexs, int cur, String path,
+			List<List<Integer>> configs) {
 		String tpath = path;
 		if (cur >= indexs.size()) {
 			String[] elems = tpath.split(",");
-			Vector<Integer> line = new Vector<Integer>();
+			List<Integer> line = new ArrayList<Integer>();
 			for (String s : elems) {
 				String x = s.trim();
 				if (x.length() > 0) {

--- a/src/main/java/edu/isi/karma/cleaning/Section.java
+++ b/src/main/java/edu/isi/karma/cleaning/Section.java
@@ -22,7 +22,7 @@ public class Section implements GrammarTreeNode {
 		if(itInterpretor==null)
 			itInterpretor =  new Interpretor();
 		if(supermode == 0)
-			this.createTotalOrderList();
+			this.createTotalOrderVector();
 		else
 		{
 			this.reiniteRules();
@@ -115,7 +115,7 @@ public class Section implements GrammarTreeNode {
 	}
 
 	@Override
-	public void createTotalOrderList() {
+	public void createTotalOrderVector() {
 		for(int i = 0; i< pair[0].rules.size(); i++)
 		{
 			for(int j = 0; j< pair[1].rules.size(); j++)

--- a/src/main/java/edu/isi/karma/cleaning/Segment.java
+++ b/src/main/java/edu/isi/karma/cleaning/Segment.java
@@ -1,12 +1,13 @@
 package edu.isi.karma.cleaning;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.Vector;
 
 public class Segment implements GrammarTreeNode {
-	public Vector<Section> section = new Vector<Section>();
+	public List<Section> section = new ArrayList<Section>();
 	public static int cxtsize_limit = 2;
 	public static int time_limit = 5;
 	public String tarString = "";
@@ -16,32 +17,32 @@ public class Segment implements GrammarTreeNode {
 	public static final int UNDFN = -2;
 	public int start = 0; // start position in tarNodes
 	public int end = 0; // end position in tarNodes
-	public Vector<int[]> mappings; // corresponding areas in org
+	public List<int[]> mappings; // corresponding areas in org
 	public boolean isinloop = false;
-	public Vector<TNode> constNodes = new Vector<TNode>();
+	public List<TNode> constNodes = new ArrayList<TNode>();
 	public String repString = "";
 	private int curState = -1;
-	public Vector<String> segStrings = new Vector<String>();
+	public List<String> segStrings = new ArrayList<String>();
 	public int VersionSP_size = 0;
-	public Segment(Vector<TNode> cont)
+	public Segment(List<TNode> cont)
 	{
 		constNodes = cont;
-		createTotalOrderVector();
+		createTotalOrderList();
 	}
-	public Segment(int start, int end, Vector<TNode> cont)
+	public Segment(int start, int end, List<TNode> cont)
 	{
 		this.start = start;
 		this.end = end;
 		this.constNodes = cont;
-		this.createTotalOrderVector();
+		this.createTotalOrderList();
 	}
-	public Segment(Vector<Section> sections,boolean loop)
+	public Segment(List<Section> sections,boolean loop)
 	{
 		this.section = sections;
 		this.isinloop = loop;
-		this.createTotalOrderVector();
+		this.createTotalOrderList();
 	}
-	public Segment(int start, int end, Vector<int[]> mapping,Vector<TNode> orgNodes,Vector<TNode> tarNodes)
+	public Segment(int start, int end, List<int[]> mapping,List<TNode> orgNodes,List<TNode> tarNodes)
 	{
 		this.start = start;
 		this.end = end;
@@ -62,23 +63,23 @@ public class Segment implements GrammarTreeNode {
 			if(end >start+1)
 				repString += tarNodes.get(this.end-1).getType();
 		}
-		this.createTotalOrderVector();
+		this.createTotalOrderList();
 	}
-/*	public void setSections(Vector<Position[]> sections)
+/*	public void setSections(List<Position[]> sections)
 	{
-		Vector<Section> s = new Vector<Section>();
+		List<Section> s = new ArrayList<Section>();
 		for(Position[] p:sections)
 		{
 			Section sx = new Section(p,this.isinloop);
 			s.add(sx);
 		}
 		this.section = s;
-		this.createTotalOrderVector();
+		this.createTotalOrderList();
 	}*/
-	public Vector<TNode> getLeftCxt(int c, Vector<TNode> x)
+	public List<TNode> getLeftCxt(int c, List<TNode> x)
 	{
 		int i = Segment.cxtsize_limit;
-		Vector<TNode> res = new Vector<TNode>();
+		List<TNode> res = new ArrayList<TNode>();
 		while(i>0)
 		{
 			if((c-i)<0)
@@ -91,10 +92,10 @@ public class Segment implements GrammarTreeNode {
 		}
 		return res;
 	}
-	public Vector<TNode> getRightCxt(int c, Vector<TNode> x)
+	public List<TNode> getRightCxt(int c, List<TNode> x)
 	{
 		int i = 0;
-		Vector<TNode> res = new Vector<TNode>();
+		List<TNode> res = new ArrayList<TNode>();
 		while(i<Segment.cxtsize_limit)
 		{
 			if((c+i)>=x.size())
@@ -136,15 +137,15 @@ public class Segment implements GrammarTreeNode {
 		return ruleString;
 	}
 	//
-	public void initSections(Vector<TNode> orgNodes)
+	public void initSections(List<TNode> orgNodes)
 	{
 		for (int[] elem: mappings)
 		{
 			int s = elem[0];
 			int e = elem[1];
 			//record the data
-			Vector<String> orgStrings = new Vector<String>();
-			Vector<String> tarStrings = new Vector<String>();
+			List<String> orgStrings = new ArrayList<String>();
+			List<String> tarStrings = new ArrayList<String>();
 			String org = "";
 			for(int i = 0; i<orgNodes.size(); i++)
 			{
@@ -153,16 +154,16 @@ public class Segment implements GrammarTreeNode {
 			orgStrings.add(org);
 			tarStrings.add(tarString);
 			//create the startPosition
-			Vector<Integer> sset = new Vector<Integer>();
+			List<Integer> sset = new ArrayList<Integer>();
 			sset = UtilTools.getStringPos(s, orgNodes);
-			Vector<String> tars = new Vector<String>();
+			List<String> tars = new ArrayList<String>();
 			tars.add(sset.get(0).toString());
 			Position sPosition = new Position(sset, getLeftCxt(s, orgNodes), getRightCxt(s, orgNodes),orgStrings,tars,this.isinloop);
 			sPosition.isinloop = this.isinloop;
 			//create the endPosition
-			Vector<Integer> eset = new Vector<Integer>();
+			List<Integer> eset = new ArrayList<Integer>();
 			eset = UtilTools.getStringPos(e, orgNodes);
-			Vector<String> tars1 = new Vector<String>();
+			List<String> tars1 = new ArrayList<String>();
 			tars1.add(eset.get(0).toString());
 			Position ePosition = new Position(eset, getLeftCxt(e, orgNodes), getRightCxt(e, orgNodes),orgStrings,tars1,this.isinloop);
 			ePosition.isinloop = this.isinloop;
@@ -184,7 +185,7 @@ public class Segment implements GrammarTreeNode {
 			pair.isinloop = res;
 		}
 	}
-	public void setCnt(Vector<TNode> cnst)
+	public void setCnt(List<TNode> cnst)
 	{
 		for(TNode t:cnst)
 		{
@@ -231,7 +232,7 @@ public class Segment implements GrammarTreeNode {
 		}
 		//merge the position
 		HashSet<String> uniqueKeys = new HashSet<String>();
-		Vector<Section> newSections = new Vector<Section>();
+		List<Section> newSections = new ArrayList<Section>();
 		for(Section x:this.section)
 		{
 			for(Section y:s.section)
@@ -295,10 +296,10 @@ public class Segment implements GrammarTreeNode {
 		this.score = 0.0;
 		return r;
 	}
-	public Vector<Integer> rules = new Vector<Integer>();
-	public void createTotalOrderVector()
+	public List<Integer> rules = new ArrayList<Integer>();
+	public void createTotalOrderList()
 	{
-		SortedMap<Double,Vector<Integer>> xmap = new TreeMap<Double, Vector<Integer>>();
+		SortedMap<Double,List<Integer>> xmap = new TreeMap<Double, List<Integer>>();
 		for(int i=0; i< section.size(); i++)
 		{
 			Double double1 = 0.0;
@@ -311,7 +312,7 @@ public class Segment implements GrammarTreeNode {
 			}
 			else
 			{
-				Vector<Integer> vi = new Vector<Integer>();
+				List<Integer> vi = new ArrayList<Integer>();
 				vi.add(i);
 				xmap.put(key, vi);
 			}
@@ -319,7 +320,7 @@ public class Segment implements GrammarTreeNode {
 		while(!xmap.isEmpty())
 		{
 			Double x = xmap.firstKey();
-			Vector<Integer> v = xmap.get(x);
+			List<Integer> v = xmap.get(x);
 			//add the vth pair's rules
 			for(Integer e:v)
 			{

--- a/src/main/java/edu/isi/karma/cleaning/Segment.java
+++ b/src/main/java/edu/isi/karma/cleaning/Segment.java
@@ -27,20 +27,20 @@ public class Segment implements GrammarTreeNode {
 	public Segment(List<TNode> cont)
 	{
 		constNodes = cont;
-		createTotalOrderList();
+		createTotalOrderVector();
 	}
 	public Segment(int start, int end, List<TNode> cont)
 	{
 		this.start = start;
 		this.end = end;
 		this.constNodes = cont;
-		this.createTotalOrderList();
+		this.createTotalOrderVector();
 	}
 	public Segment(List<Section> sections,boolean loop)
 	{
 		this.section = sections;
 		this.isinloop = loop;
-		this.createTotalOrderList();
+		this.createTotalOrderVector();
 	}
 	public Segment(int start, int end, List<int[]> mapping,List<TNode> orgNodes,List<TNode> tarNodes)
 	{
@@ -63,7 +63,7 @@ public class Segment implements GrammarTreeNode {
 			if(end >start+1)
 				repString += tarNodes.get(this.end-1).getType();
 		}
-		this.createTotalOrderList();
+		this.createTotalOrderVector();
 	}
 /*	public void setSections(List<Position[]> sections)
 	{
@@ -297,7 +297,7 @@ public class Segment implements GrammarTreeNode {
 		return r;
 	}
 	public List<Integer> rules = new ArrayList<Integer>();
-	public void createTotalOrderList()
+	public void createTotalOrderVector()
 	{
 		SortedMap<Double,List<Integer>> xmap = new TreeMap<Double, List<Integer>>();
 		for(int i=0; i< section.size(); i++)

--- a/src/main/java/edu/isi/karma/cleaning/Template.java
+++ b/src/main/java/edu/isi/karma/cleaning/Template.java
@@ -1,20 +1,19 @@
 package edu.isi.karma.cleaning;
 
-import java.util.Vector;
-
-import org.python.antlr.PythonParser.return_stmt_return;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Template implements GrammarTreeNode {
 	public static int temp_limit = 2048;
 	public static int supermode = 0;
-	public Vector<GrammarTreeNode> body = new Vector<GrammarTreeNode>();
-	public Vector<Vector<Integer>> indexes = new Vector<Vector<Integer>>();
+	public List<GrammarTreeNode> body = new ArrayList<GrammarTreeNode>();
+	public List<List<Integer>> indexes = new ArrayList<List<Integer>>();
 	public int curState = 0;
 	public long size = 1;
 
-	public Template(Vector<GrammarTreeNode> body) {
+	public Template(List<GrammarTreeNode> body) {
 		this.body = body;
-		Vector<Long> x = new Vector<Long>();
+		List<Long> x = new ArrayList<Long>();
 		for (GrammarTreeNode g : body) {
 			x.add(g.size());
 		}
@@ -32,15 +31,15 @@ public class Template implements GrammarTreeNode {
 		return str;
 	}
 
-/*	public void getCrossIndex(Vector<Long> indexs, int cur, String path,
-			Vector<Vector<Integer>> configs) {
+/*	public void getCrossIndex(List<Long> indexs, int cur, String path,
+			List<List<Integer>> configs) {
 		String tpath = path;
 		if (configs.size() > temp_limit) {
 			return;
 		}
 		if (cur >= indexs.size()) {
 			String[] elems = tpath.split(",");
-			Vector<Integer> line = new Vector<Integer>();
+			List<Integer> line = new ArrayList<Integer>();
 			for (String s : elems) {
 				String x = s.trim();
 				if (x.length() > 0) {
@@ -58,13 +57,13 @@ public class Template implements GrammarTreeNode {
 		}
 	} */
 	//iteratively generate combinations
-	public void getCrossIndex(Vector<Long> indexs,Vector<Vector<Integer>> configs) {
+	public void getCrossIndex(List<Long> indexs,List<List<Integer>> configs) {
 	    int k = indexs.size();
 		int[] com = new int[k];
 	    for (int i = 0; i < k; i++) 
 	    		com[i] = 0;
 	    while (com[k - 1] < indexs.get(k-1)) {
-	    		Vector<Integer> res = new Vector<Integer>();
+	    		List<Integer> res = new ArrayList<Integer>();
 	        for (int i = 0; i < k; i++)
 	        {
 	        		//System.out.print(""+com[i]);
@@ -140,7 +139,7 @@ public class Template implements GrammarTreeNode {
 		while (true) {
 			if (curState >= indexes.size())
 				return "null";
-			Vector<Integer> xIntegers = indexes.get(curState);
+			List<Integer> xIntegers = indexes.get(curState);
 			String res = "";
 			for (int i = 0; i < xIntegers.size(); i++) {
 				GrammarTreeNode gt = body.get(i);
@@ -177,9 +176,9 @@ public class Template implements GrammarTreeNode {
 
 	@Override
 	public GrammarTreeNode mergewith(GrammarTreeNode a) {
-		Vector<GrammarTreeNode> line2 = ((Template) a).body;
-		Vector<GrammarTreeNode> line1 = this.body;
-		Vector<GrammarTreeNode> nLine = new Vector<GrammarTreeNode>();
+		List<GrammarTreeNode> line2 = ((Template) a).body;
+		List<GrammarTreeNode> line1 = this.body;
+		List<GrammarTreeNode> nLine = new ArrayList<GrammarTreeNode>();
 		if (line1.size() != line2.size()) {
 			return null;
 		}
@@ -213,7 +212,7 @@ public class Template implements GrammarTreeNode {
 	}
 
 	@Override
-	public void createTotalOrderVector() {
+	public void createTotalOrderList() {
 		// TODO Auto-generated method stub
 
 	}

--- a/src/main/java/edu/isi/karma/cleaning/Template.java
+++ b/src/main/java/edu/isi/karma/cleaning/Template.java
@@ -212,7 +212,7 @@ public class Template implements GrammarTreeNode {
 	}
 
 	@Override
-	public void createTotalOrderList() {
+	public void createTotalOrderVector() {
 		// TODO Auto-generated method stub
 
 	}

--- a/src/main/java/edu/isi/karma/cleaning/Test.java
+++ b/src/main/java/edu/isi/karma/cleaning/Test.java
@@ -2,17 +2,17 @@ package edu.isi.karma.cleaning;
 
 import java.io.File;
 import java.io.FileReader;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Vector;
+import java.util.List;
 
 import au.com.bytecode.opencsv.CSVReader;
 
 public class Test {
 	public static void test1()
 	{
-		Vector<String[]> examples = new Vector<String[]>();
+		List<String[]> examples = new ArrayList<String[]>();
 		String[] xStrings = {"<_START>Jan<_END>", ""};
 		String[] yStrings = {"<_START>Feb<_END>", "02"};
 		String[] zStrings = {"<_START>Mar<_END>", "03"};
@@ -21,7 +21,7 @@ public class Test {
 		examples.add(zStrings);
 		ProgSynthesis psProgSynthesis = new ProgSynthesis();
 		psProgSynthesis.inite(examples);
-		Vector<ProgramRule> pls = new Vector<ProgramRule>();
+		List<ProgramRule> pls = new ArrayList<ProgramRule>();
 		Collection<ProgramRule> ps = psProgSynthesis.run_main();
 		ProgramRule pr = ps.iterator().next();
 		String val = "Jan";
@@ -33,16 +33,16 @@ public class Test {
 		
 	}
 	public static void test4(String dirpath) {
-		HashMap<String, Vector<String>> records = new HashMap<String, Vector<String>>();
+		HashMap<String, List<String>> records = new HashMap<String, List<String>>();
 		File nf = new File(dirpath);
 		File[] allfiles = nf.listFiles();
 		// statistics
 		DataCollection dCollection = new DataCollection();
 		// list all the csv file under the dir
 		for (File f : allfiles) {
-			Vector<String[]> examples = new Vector<String[]>();
-			Vector<String[]> addExamples = new Vector<String[]>();
-			Vector<String[]> entries = new Vector<String[]>();
+			List<String[]> examples = new ArrayList<String[]>();
+			List<String[]> addExamples = new ArrayList<String[]>();
+			List<String[]> entries = new ArrayList<String[]>();
 			try {
 				
 				if (f.getName().indexOf(".csv") == (f.getName().length() - 4)) {
@@ -71,12 +71,12 @@ public class Test {
 					while (true) // repeat as no correct answer appears.
 					{
 						long checknumber = 1;
-						HashMap<String, Vector<String[]>> expFeData = new HashMap<String, Vector<String[]>>();
-						Vector<String> resultString = new Vector<String>();
+						HashMap<String, List<String[]>> expFeData = new HashMap<String, List<String[]>>();
+						List<String> resultString = new ArrayList<String>();
 						xHashMap = new HashMap<String, String[]>();
 						ProgSynthesis psProgSynthesis = new ProgSynthesis();
 						psProgSynthesis.inite(examples);
-						Vector<ProgramRule> pls = new Vector<ProgramRule>();
+						List<ProgramRule> pls = new ArrayList<ProgramRule>();
 						Collection<ProgramRule> ps = psProgSynthesis.run_main();
 						if (ps != null)
 							pls.addAll(ps);
@@ -117,7 +117,7 @@ public class Test {
 										String[] exp = {s,tmps};
 										if(!expFeData.containsKey(classlabel))
 										{
-											Vector<String[]> vstr = new Vector<String[]>();
+											List<String[]> vstr = new ArrayList<String[]>();
 											vstr.add(exp);
 											expFeData.put(classlabel, vstr);
 										}
@@ -135,7 +135,7 @@ public class Test {
 										String[] exp = {s,tmps};
 										if(!expFeData.containsKey(classlabel))
 										{
-											Vector<String[]> vstr = new Vector<String[]>();
+											List<String[]> vstr = new ArrayList<String[]>();
 											vstr.add(exp);
 											expFeData.put(classlabel, vstr);
 										}
@@ -212,7 +212,7 @@ public class Test {
 		dCollection.print1();
 		//hashResultPrint(records);
 	}
-	public static void hashResultPrint(HashMap<String, Vector<String>> res)
+	public static void hashResultPrint(HashMap<String, List<String>> res)
 	{
 		String s = "";
 		for(String key:res.keySet())
@@ -225,8 +225,8 @@ public class Test {
 		}
 		System.out.println(""+s);
 	}
-	public static void test0_sub(Vector<String[]> all, Vector<String[]> cand,
-			Vector<String[]> examples, int cnt) {
+	public static void test0_sub(List<String[]> all, List<String[]> cand,
+			List<String[]> examples, int cnt) {
 		if (cand.size() <= 0) {
 			if (cnt > Test.MaximalNumber) {
 				MaximalNumber = cnt;
@@ -240,16 +240,16 @@ public class Test {
 			return;
 		}
 		for (int p = 0; p < cand.size(); p++) {
-			Vector<String[]> tmp = new Vector<String[]>();
+			List<String[]> tmp = new ArrayList<String[]>();
 			tmp.addAll(examples);
 			String[] x = { "<_START>" + cand.get(p)[0] + "<_END>",
 					cand.get(p)[1] };
 			tmp.add(x);
-			Vector<String[]> tmpxStrings = new Vector<String[]>();
+			List<String[]> tmpxStrings = new ArrayList<String[]>();
 
 			ProgSynthesis psProgSynthesis = new ProgSynthesis();
 			psProgSynthesis.inite(tmp);
-			Vector<ProgramRule> pls = new Vector<ProgramRule>();
+			List<ProgramRule> pls = new ArrayList<ProgramRule>();
 			Collection<ProgramRule> ps = psProgSynthesis.run_main();
 			if (ps != null)
 				pls.addAll(ps);
@@ -286,8 +286,8 @@ public class Test {
 
 	public static int MaximalNumber = -1;
 	public static int MinimalNumber = 100;
-	public static Vector<String[]> larexamples = new Vector<String[]>();
-	public static Vector<String[]> smalexamples = new Vector<String[]>();
+	public static List<String[]> larexamples = new ArrayList<String[]>();
+	public static List<String[]> smalexamples = new ArrayList<String[]>();
 
 	public static void test0(String dirpath) {
 		File nf = new File(dirpath);
@@ -296,8 +296,8 @@ public class Test {
 		DataCollection dCollection = new DataCollection();
 		// list all the csv file under the dir
 		for (File f : allfiles) {
-			Vector<String[]> examples = new Vector<String[]>();
-			Vector<String[]> entries = new Vector<String[]>();
+			List<String[]> examples = new ArrayList<String[]>();
+			List<String[]> entries = new ArrayList<String[]>();
 			try {
 				if (f.getName().indexOf(".csv") == (f.getName().length() - 4)) {
 					CSVReader cr = new CSVReader(new FileReader(f), ',', '"',
@@ -311,7 +311,7 @@ public class Test {
 					if (entries.size() <= 1)
 						continue;
 					int cnt = 0;
-					Vector<String[]> candStrings = new Vector<String[]>();
+					List<String[]> candStrings = new ArrayList<String[]>();
 					candStrings.addAll(entries);
 					test0_sub(entries, candStrings, examples, cnt);
 					System.out.println("File " + f.getName() + "\n");
@@ -331,9 +331,9 @@ public class Test {
 					System.out.println("Smallest: " + str1);
 					//clear
 					Test.MaximalNumber = -1;
-					Test.larexamples = new Vector<String[]>();
+					Test.larexamples = new ArrayList<String[]>();
 					Test.MinimalNumber = 200;
-					Test.smalexamples = new Vector<String[]>();
+					Test.smalexamples = new ArrayList<String[]>();
 				}
 				//
 			} catch (Exception e) {

--- a/src/main/java/edu/isi/karma/cleaning/TestJAVA.java
+++ b/src/main/java/edu/isi/karma/cleaning/TestJAVA.java
@@ -21,18 +21,19 @@
 
 package edu.isi.karma.cleaning;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 
 
 public class TestJAVA {
-	void generate_combos(Vector<Long> indexs,Vector<Vector<Integer>> configs) {
+	void generate_combos(List<Long> indexs,List<List<Integer>> configs) {
 	    int k = indexs.size();
 		int[] com = new int[k];
 	    for (int i = 0; i < k; i++) 
 	    		com[i] = 0;
 	    while (com[k - 1] < indexs.get(k-1)) {
-	    		Vector<Integer> res = new Vector<Integer>();
+	    		List<Integer> res = new ArrayList<Integer>();
 	        for (int i = 0; i < k; i++)
 	        {
 	        		//System.out.print(""+com[i]);
@@ -54,11 +55,11 @@ public class TestJAVA {
 	}
 	public static void main(String[] args)
 	{
-		Vector<Long> x = new Vector<Long>();
+		List<Long> x = new ArrayList<Long>();
 		x.add((long)9);
 		x.add((long)6);
 		x.add((long)4);
-		Vector<Vector<Integer>> cfig = new Vector<Vector<Integer>>();
+		List<List<Integer>> cfig = new ArrayList<List<Integer>>();
 		TestJAVA jx = new TestJAVA();
 		jx.generate_combos(x, cfig);
 		for(int i = 0; i< cfig.size(); i++)

--- a/src/main/java/edu/isi/karma/cleaning/TextVector.java
+++ b/src/main/java/edu/isi/karma/cleaning/TextVector.java
@@ -21,10 +21,10 @@
 
 package edu.isi.karma.cleaning;
 
-import java.util.Vector;
+import java.util.List;
 
 public class TextVector {
-	public TextVector(Vector<String> lines)
+	public TextVector(List<String> lines)
 	{
 		
 	}

--- a/src/main/java/edu/isi/karma/cleaning/Traces.java
+++ b/src/main/java/edu/isi/karma/cleaning/Traces.java
@@ -24,10 +24,10 @@ public class Traces implements GrammarTreeNode {
 		this.orgNodes = org;
 		this.tarNodes = tar;
 		this.createTraces();
-		createTotalOrderList();
+		createTotalOrderVector();
 	}
 
-	public void createTotalOrderList() {
+	public void createTotalOrderVector() {
 		ArrayList<Integer> xArrayList = new ArrayList<Integer>();
 		xArrayList.addAll(traceline.keySet());
 		xArrayList.addAll(loopline.keySet());
@@ -47,7 +47,7 @@ public class Traces implements GrammarTreeNode {
 			HashMap<Integer,HashMap<String, Template>> l) {
 		this.traceline = t;
 		this.loopline = l;
-		createTotalOrderList();
+		createTotalOrderVector();
 	}
 
 	// initialize the tree to represent the grammar tree

--- a/src/main/java/edu/isi/karma/cleaning/Traces.java
+++ b/src/main/java/edu/isi/karma/cleaning/Traces.java
@@ -6,28 +6,28 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.Vector;
+import java.util.List;
 
 
 public class Traces implements GrammarTreeNode {
 	public static int time_limit = 20;
-	public Vector<TNode> orgNodes;
-	public Vector<TNode> tarNodes;
+	public List<TNode> orgNodes;
+	public List<TNode> tarNodes;
 	public HashMap<Integer, Template> traceline = new HashMap<Integer, Template>();
 	public HashMap<Integer, HashMap<String,Template>> loopline = new HashMap<Integer, HashMap<String,Template>>();
 	private int curState = 0;
-	private Vector<Template> totalOrderVector = new Vector<Template>();
+	private List<Template> totalOrderList = new ArrayList<Template>();
 	//keep all the segment expression to prevent repeated construction
 	public static HashMap<String, Segment> AllSegs = new HashMap<String, Segment>();
 
-	public Traces(Vector<TNode> org, Vector<TNode> tar) {
+	public Traces(List<TNode> org, List<TNode> tar) {
 		this.orgNodes = org;
 		this.tarNodes = tar;
 		this.createTraces();
-		createTotalOrderVector();
+		createTotalOrderList();
 	}
 
-	public void createTotalOrderVector() {
+	public void createTotalOrderList() {
 		ArrayList<Integer> xArrayList = new ArrayList<Integer>();
 		xArrayList.addAll(traceline.keySet());
 		xArrayList.addAll(loopline.keySet());
@@ -35,10 +35,10 @@ public class Traces implements GrammarTreeNode {
 		Arrays.sort(xArrayList.toArray(a));
 		for (Integer elem : a) {
 			if (loopline.get(elem) != null) {
-				totalOrderVector.addAll(loopline.get(elem).values());
+				totalOrderList.addAll(loopline.get(elem).values());
 			}
 			if (traceline.get(elem) != null) {
-				totalOrderVector.add(traceline.get(elem));
+				totalOrderList.add(traceline.get(elem));
 			}
 		}
 	}
@@ -47,17 +47,17 @@ public class Traces implements GrammarTreeNode {
 			HashMap<Integer,HashMap<String, Template>> l) {
 		this.traceline = t;
 		this.loopline = l;
-		createTotalOrderVector();
+		createTotalOrderList();
 	}
 
 	// initialize the tree to represent the grammar tree
 	public void createTraces() {
-		Vector<Vector<Segment>> lines = new Vector<Vector<Segment>>();
-		HashMap<Integer, Vector<Segment>> pos2Segs = new HashMap<Integer, Vector<Segment>>();
-		Vector<Segment> children = findSegs(0);
-		Vector<Vector<Segment>> tlines = new Vector<Vector<Segment>>();
+		List<List<Segment>> lines = new ArrayList<List<Segment>>();
+		HashMap<Integer, List<Segment>> pos2Segs = new HashMap<Integer, List<Segment>>();
+		List<Segment> children = findSegs(0);
+		List<List<Segment>> tlines = new ArrayList<List<Segment>>();
 		for (Segment c : children) {
-			Vector<Segment> vs = new Vector<Segment>();
+			List<Segment> vs = new ArrayList<Segment>();
 			vs.add(c);
 			tlines.add(vs);
 		}
@@ -70,8 +70,8 @@ public class Traces implements GrammarTreeNode {
 				lines.clear();
 				break; // otherwise takes too much time
 			}
-			Vector<Vector<Segment>> nlines = new Vector<Vector<Segment>>();
-			Vector<Segment> segs = tlines.remove(0);
+			List<List<Segment>> nlines = new ArrayList<List<Segment>>();
+			List<Segment> segs = tlines.remove(0);
 			int curPos = segs.get(segs.size() - 1).end;
 			if(curPos == 0) // target string is empty
 			{
@@ -87,29 +87,29 @@ public class Traces implements GrammarTreeNode {
 				lines.add(segs);
 			}
 			for (Segment s : children) {
-				Vector<Segment> tmp = new Vector<Segment>();
+				List<Segment> tmp = new ArrayList<Segment>();
 				tmp.addAll(segs);
 				tmp.add(s);
 				nlines.add(tmp);
 			}
 			tlines.addAll(nlines);
 		}
-		Vector<Vector<GrammarTreeNode>> vSeg = new Vector<Vector<GrammarTreeNode>>();
-		Vector<Vector<GrammarTreeNode>> lSeg = new Vector<Vector<GrammarTreeNode>>();
-		for (Vector<Segment> vs : lines) {
-			Vector<GrammarTreeNode> vsGrammarTreeNodes = UtilTools
-					.convertSegVector(vs);
+		List<List<GrammarTreeNode>> vSeg = new ArrayList<List<GrammarTreeNode>>();
+		List<List<GrammarTreeNode>> lSeg = new ArrayList<List<GrammarTreeNode>>();
+		for (List<Segment> vs : lines) {
+			List<GrammarTreeNode> vsGrammarTreeNodes = UtilTools
+					.convertSegList(vs);
 			vSeg.add(vsGrammarTreeNodes);
 		}
 		// detect loops
 		// verify loops
 		long vgt_time_limit = System.currentTimeMillis();
-		for (Vector<Segment> vgt : lines) {
+		for (List<Segment> vgt : lines) {
 			if((System.currentTimeMillis()-vgt_time_limit)/1000>time_limit) 
 			{
 				break; // otherwise takes too much time
 			}
-			Vector<Vector<GrammarTreeNode>> lLine = this.genLoop(vgt);
+			List<List<GrammarTreeNode>> lLine = this.genLoop(vgt);
 			if (lLine != null)
 				lSeg.addAll(lLine);
 		}
@@ -119,12 +119,12 @@ public class Traces implements GrammarTreeNode {
 	}
 
 	// find all segments starting from pos
-	Vector<Segment> findSegs(int pos) {
-		Vector<Segment> segs = new Vector<Segment>();
+	List<Segment> findSegs(int pos) {
+		List<Segment> segs = new ArrayList<Segment>();
 		if(tarNodes.size() == 0)
 		{
 			int[] mapping = {0,0};
-			Vector<int[]> corrm = new Vector<int[]>();
+			List<int[]> corrm = new ArrayList<int[]>();
 			corrm.add(mapping);
 			Segment s = new Segment(0, 0, corrm, orgNodes, tarNodes);
 			segs.add(s);
@@ -132,13 +132,13 @@ public class Traces implements GrammarTreeNode {
 		}
 		if (pos >= tarNodes.size())
 			return segs;
-		Vector<TNode> tmp = new Vector<TNode>();
+		List<TNode> tmp = new ArrayList<TNode>();
 		tmp.add(tarNodes.get(pos));
 		// identify the const string	
 		int q = Ruler.Search(orgNodes, tmp, 0);
 		if (q == -1) {
 			int cnt = pos;
-			Vector<TNode> tvec = new Vector<TNode>();
+			List<TNode> tvec = new ArrayList<TNode>();
 			while (q == -1) {
 				tvec.add(tarNodes.get(cnt));
 				cnt++;
@@ -163,18 +163,18 @@ public class Traces implements GrammarTreeNode {
 			return segs;
 		}
 		for (int i = pos; i < tarNodes.size(); i++) {
-			Vector<TNode> tvec = new Vector<TNode>();
+			List<TNode> tvec = new ArrayList<TNode>();
 			for (int j = pos; j <= i; j++) {
 				tvec.add(tarNodes.get(j));
 			}
-			Vector<Integer> mappings = new Vector<Integer>();
+			List<Integer> mappings = new ArrayList<Integer>();
 			int r = Ruler.Search(orgNodes, tvec, 0);
 			while (r != -1) {
 				mappings.add(r);
 				r = Ruler.Search(orgNodes, tvec, r + 1);
 			}
 			if (mappings.size() > 1) {
-				Vector<int[]> corrm = new Vector<int[]>();
+				List<int[]> corrm = new ArrayList<int[]>();
 				for (int t : mappings) {
 					int[] m = { t, t + tvec.size() };
 					corrm.add(m);
@@ -195,7 +195,7 @@ public class Traces implements GrammarTreeNode {
 					segs.add(s);
 				continue;
 			} else if (mappings.size() == 1) {
-				Vector<int[]> corrm = new Vector<int[]>();
+				List<int[]> corrm = new ArrayList<int[]>();
 				// creating based on whether can find segment with one more
 				// token
 				if (i >= (tarNodes.size() - 1)) {
@@ -217,7 +217,7 @@ public class Traces implements GrammarTreeNode {
 				} else {
 					tvec.add(tarNodes.get(i + 1));
 					int p = Ruler.Search(orgNodes, tvec, 0);
-					Vector<TNode> repToken = new Vector<TNode>();
+					List<TNode> repToken = new ArrayList<TNode>();
 					repToken.add(tarNodes.get(i+1));
 					int rind = 0;
 					int tokenCnt = 0;
@@ -272,7 +272,7 @@ public class Traces implements GrammarTreeNode {
 			nLines.put(index, nLine);
 		}
 		// merge loop and segment lines
-		HashMap<Integer, HashMap<String,Vector<Template>>> allLoops = new HashMap<Integer, HashMap<String,Vector<Template>>>();
+		HashMap<Integer, HashMap<String,List<Template>>> allLoops = new HashMap<Integer, HashMap<String,List<Template>>>();
 		Set<Integer> keyset1 = new HashSet<Integer>(this.traceline.keySet());
 		keyset1.retainAll(t.loopline.keySet());
 		for (Integer index : keyset1) {
@@ -292,14 +292,14 @@ public class Traces implements GrammarTreeNode {
 					}
 					else
 					{
-						Vector<Template> vTemplates = new Vector<Template>();
+						List<Template> vTemplates = new ArrayList<Template>();
 						vTemplates.add(nLine);
 						allLoops.get(index).put(line2, vTemplates);
 					}
 				} else {
-					Vector<Template> tgt = new Vector<Template>();
+					List<Template> tgt = new ArrayList<Template>();
 					tgt.add(nLine);
-					HashMap<String, Vector<Template>> tHashMap = new HashMap<String, Vector<Template>>();
+					HashMap<String, List<Template>> tHashMap = new HashMap<String, List<Template>>();
 					tHashMap.put(line2, tgt);
 					allLoops.put(index,tHashMap);
 				}
@@ -325,14 +325,14 @@ public class Traces implements GrammarTreeNode {
 					}
 					else
 					{
-						Vector<Template> vTemplates = new Vector<Template>();
+						List<Template> vTemplates = new ArrayList<Template>();
 						vTemplates.add(nLine);
 						allLoops.get(index).put(line2, vTemplates);
 					}
 				} else {
-					Vector<Template> tgt = new Vector<Template>();
+					List<Template> tgt = new ArrayList<Template>();
 					tgt.add(nLine);
-					HashMap<String, Vector<Template>> tHashMap = new HashMap<String, Vector<Template>>();
+					HashMap<String, List<Template>> tHashMap = new HashMap<String, List<Template>>();
 					tHashMap.put(line2, tgt);
 					allLoops.put(index,tHashMap);
 				}
@@ -364,14 +364,14 @@ public class Traces implements GrammarTreeNode {
 						}
 						else
 						{
-							Vector<Template> vTemplates = new Vector<Template>();
+							List<Template> vTemplates = new ArrayList<Template>();
 							vTemplates.add(nLine);
 							allLoops.get(index).put(line2, vTemplates);
 						}
 					} else {
-						Vector<Template> tgt = new Vector<Template>();
+						List<Template> tgt = new ArrayList<Template>();
 						tgt.add(nLine);
-						HashMap<String, Vector<Template>> tHashMap = new HashMap<String, Vector<Template>>();
+						HashMap<String, List<Template>> tHashMap = new HashMap<String, List<Template>>();
 						tHashMap.put(line2, tgt);
 						allLoops.put(index,tHashMap);
 					}
@@ -406,7 +406,7 @@ public class Traces implements GrammarTreeNode {
 				&& y.getNodeType().compareTo("segment") == 0) {
 			Segment s = (Segment) x;
 			Segment t = (Segment) y;
-			Vector<Section> sec = new Vector<Section>();
+			List<Section> sec = new ArrayList<Section>();
 			HashSet<String> hset = new HashSet<String>();
 			for(Section nSection:s.section)
 			{
@@ -446,7 +446,7 @@ public class Traces implements GrammarTreeNode {
 				&& y.getNodeType().compareTo("loop") == 0) {
 			Loop s = (Loop) x;
 			Loop t = (Loop) y;
-			Vector<Section> sec = new Vector<Section>();
+			List<Section> sec = new ArrayList<Section>();
 			HashSet<String> hset = new HashSet<String>();
 			for(Section nSection:s.loopbody.section)
 			{
@@ -493,10 +493,10 @@ public class Traces implements GrammarTreeNode {
 		return null;
 	}
 	public HashMap<Integer, HashMap<String,Template>> consolidateDiffLoop(
-			Vector<Vector<GrammarTreeNode>> paths) {
+			List<List<GrammarTreeNode>> paths) {
 		HashMap<Integer, HashMap<String,Template>> resHashMap = new HashMap<Integer, HashMap<String,Template>>();
-		HashMap<Integer, HashMap<String, Vector<Template>>> tmpStore = new HashMap<Integer,HashMap<String, Vector<Template>>>();
-		for (Vector<GrammarTreeNode> vg : paths) {
+		HashMap<Integer, HashMap<String, List<Template>>> tmpStore = new HashMap<Integer,HashMap<String, List<Template>>>();
+		for (List<GrammarTreeNode> vg : paths) {
 			int key = vg.size();
 			String subkey = "";
 			for(GrammarTreeNode nodetype: vg)
@@ -510,17 +510,17 @@ public class Traces implements GrammarTreeNode {
 				}
 				else
 				{
-					Vector<Template> vte = new Vector<Template>();
+					List<Template> vte = new ArrayList<Template>();
 					vte.add(new Template(vg));
 					tmpStore.get(key).put(subkey, vte);
 				}
 			} else {
-				Vector<Template> xVector = new Vector<Template>();
+				List<Template> xList = new ArrayList<Template>();
 				if(!isLegalVS(vg))
 					continue;
-				xVector.add(new Template(vg));
-				HashMap<String, Vector<Template>> xHashMap = new HashMap<String, Vector<Template>>();
-				xHashMap.put(subkey, xVector);
+				xList.add(new Template(vg));
+				HashMap<String, List<Template>> xHashMap = new HashMap<String, List<Template>>();
+				xHashMap.put(subkey, xList);
 				tmpStore.put(key, xHashMap);
 			}
 		}
@@ -543,11 +543,11 @@ public class Traces implements GrammarTreeNode {
 		return resHashMap;
 	}
 	public HashMap<Integer, Template> consolidateDiffSize(
-			Vector<Vector<GrammarTreeNode>> paths) {
+			List<List<GrammarTreeNode>> paths) {
 		HashMap<Integer, Template> resHashMap = new HashMap<Integer, Template>();
-		HashMap<Integer, Vector<Template>> tmpStore = new HashMap<Integer, Vector<Template>>();
+		HashMap<Integer, List<Template>> tmpStore = new HashMap<Integer, List<Template>>();
 		long stime = System.currentTimeMillis();
-		for (Vector<GrammarTreeNode> vg : paths) {
+		for (List<GrammarTreeNode> vg : paths) {
 			if((System.currentTimeMillis()-stime)/1000>time_limit) 
 			{
 				//System.out.println("Exceed the time limit");
@@ -557,11 +557,11 @@ public class Traces implements GrammarTreeNode {
 			if (tmpStore.containsKey(key)) {
 				tmpStore.get(key).add(new Template(vg));
 			} else {
-				Vector<Template> xVector = new Vector<Template>();
+				List<Template> xList = new ArrayList<Template>();
 				if(!isLegalVS(vg))
 					continue;
-				xVector.add(new Template(vg));
-				tmpStore.put(key, xVector);
+				xList.add(new Template(vg));
+				tmpStore.put(key, xList);
 			}
 		}
 		for (Integer key : tmpStore.keySet()) {
@@ -572,7 +572,7 @@ public class Traces implements GrammarTreeNode {
 		//System.out.println("end consolidating");
 		return resHashMap;
 	}
-	public boolean isLegalVS(Vector<GrammarTreeNode> x)
+	public boolean isLegalVS(List<GrammarTreeNode> x)
 	{
 		for(GrammarTreeNode t:x)
 		{
@@ -582,12 +582,12 @@ public class Traces implements GrammarTreeNode {
 		return true;
 	}
 	public Template consolidate(
-			Vector<Template> paths) {
-		Vector<GrammarTreeNode> res = paths.get(0).body;
-		Vector<GrammarTreeNode> result = new Vector<GrammarTreeNode>();
+			List<Template> paths) {
+		List<GrammarTreeNode> res = paths.get(0).body;
+		List<GrammarTreeNode> result = new ArrayList<GrammarTreeNode>();
 		for (int i = 1; i < paths.size(); i++) {
 			
-			result = new Vector<GrammarTreeNode>();
+			result = new ArrayList<GrammarTreeNode>();
 			for (int j = 0; j < res.size(); j++) {
 				GrammarTreeNode t = this.union(res.get(j), paths.get(i).body.get(j));
 				result.add(t);
@@ -597,27 +597,27 @@ public class Traces implements GrammarTreeNode {
 		return new Template(res);
 	}
 
-	public Vector<Vector<GrammarTreeNode>> loopPathes = new Vector<Vector<GrammarTreeNode>>();
+	public List<List<GrammarTreeNode>> loopPathes = new ArrayList<List<GrammarTreeNode>>();
 
-	public Vector<Vector<GrammarTreeNode>> genLoop(Vector<Segment> curPath) {
+	public List<List<GrammarTreeNode>> genLoop(List<Segment> curPath) {
 		// cluster chunk with the same head and tail token
-		Vector<Vector<GrammarTreeNode>> res = new Vector<Vector<GrammarTreeNode>>();
-		HashMap<String, Vector<Integer>> map = new HashMap<String, Vector<Integer>>();
+		List<List<GrammarTreeNode>> res = new ArrayList<List<GrammarTreeNode>>();
+		HashMap<String, List<Integer>> map = new HashMap<String, List<Integer>>();
 		for (int i = 0; i < curPath.size(); i++) {
 			String rep = curPath.get(i).repString;
 			if (map.containsKey(rep)) {
 				map.get(rep).add(i);
 			} else {
-				Vector<Integer> vIntegers = new Vector<Integer>();
+				List<Integer> vIntegers = new ArrayList<Integer>();
 				vIntegers.add(i);
 				map.put(rep, vIntegers);
 			}
 		}
 		for (String key : map.keySet()) {
-			Vector<Integer> v = map.get(key);
+			List<Integer> v = map.get(key);
 			if (v.size() <= 1 || !this.verfiyLoop(v, curPath))
 				continue;
-			Vector<Vector<GrammarTreeNode>> vtn = this.detectLoop(v, curPath);
+			List<List<GrammarTreeNode>> vtn = this.detectLoop(v, curPath);
 			if (vtn != null && vtn.size() > 0) {
 				res.addAll(vtn);
 			}
@@ -628,7 +628,7 @@ public class Traces implements GrammarTreeNode {
 			return res;
 	}
 	//if there is a cross of the mapping. the loop doesn't exist
-	public boolean verfiyLoop(Vector<Integer> vx,Vector<Segment> segs)
+	public boolean verfiyLoop(List<Integer> vx,List<Segment> segs)
 	{
 		boolean res = true;
 		int pre = -1;
@@ -664,11 +664,11 @@ public class Traces implements GrammarTreeNode {
 		return res;
 	}
 	
-	public Vector<GrammarTreeNode> subVector(Vector<Segment> nodes, int start, int end)
+	public List<GrammarTreeNode> subList(List<Segment> nodes, int start, int end)
 	{
 		if(start>=end || start <0 || end>nodes.size())
 			return null;
-		Vector<GrammarTreeNode> vgt = new Vector<GrammarTreeNode>();
+		List<GrammarTreeNode> vgt = new ArrayList<GrammarTreeNode>();
 		for(int i = start; i< end; i++)
 		{
 			vgt.add(nodes.get(i));
@@ -677,14 +677,14 @@ public class Traces implements GrammarTreeNode {
 	}
 	// merge the longest mergable chunk. 
 	// if None chunk could be merged together return null
-	public Vector<GrammarTreeNode> createLoop(Vector<GrammarTreeNode> nodes,int span)
+	public List<GrammarTreeNode> createLoop(List<GrammarTreeNode> nodes,int span)
 	{
-		Vector<GrammarTreeNode> res = new Vector<GrammarTreeNode>();
-		Vector<Vector<GrammarTreeNode>> gt = new Vector<Vector<GrammarTreeNode>>();
+		List<GrammarTreeNode> res = new ArrayList<GrammarTreeNode>();
+		List<List<GrammarTreeNode>> gt = new ArrayList<List<GrammarTreeNode>>();
 		int pos = 0;
 		while(pos < nodes.size())
 		{
-			Vector<GrammarTreeNode> x = new Vector<GrammarTreeNode>();
+			List<GrammarTreeNode> x = new ArrayList<GrammarTreeNode>();
 			for(int k = pos; k<pos+span && k< nodes.size(); k++)
 			{
 				x.add(nodes.get(k));
@@ -702,14 +702,14 @@ public class Traces implements GrammarTreeNode {
 		int presize = gt.size();
 		while(gt.size() > 1)
 		{
-			Vector<Vector<GrammarTreeNode>> tmp_gt = new Vector<Vector<GrammarTreeNode>>();
+			List<List<GrammarTreeNode>> tmp_gt = new ArrayList<List<GrammarTreeNode>>();
 			boolean isLegal = true;
 			for(int j = 0; j<gt.size()-1; j++)
 			{
 				isLegal = true;
-				Vector<GrammarTreeNode> elem = new Vector<GrammarTreeNode>();
-				Vector<GrammarTreeNode> mx = gt.get(j);
-				Vector<GrammarTreeNode> nx = gt.get(j+1);
+				List<GrammarTreeNode> elem = new ArrayList<GrammarTreeNode>();
+				List<GrammarTreeNode> mx = gt.get(j);
+				List<GrammarTreeNode> nx = gt.get(j+1);
 				if(mx.size() != nx.size())
 					return null;
 				
@@ -757,7 +757,7 @@ public class Traces implements GrammarTreeNode {
 			}
 			else if(i ==curStartPos+itercnt*span-1)
 			{
-				Vector<GrammarTreeNode> body = gt.get(0);
+				List<GrammarTreeNode> body = gt.get(0);
 				if(span == 1)
 				{
 					Loop loop = new Loop((Segment)body.get(0), Loop.LOOP_BOTH);
@@ -790,11 +790,11 @@ public class Traces implements GrammarTreeNode {
 		}
 		return res;
 	}
-	public Vector<Vector<GrammarTreeNode>> detectLoop(Vector<Integer> rep,
-			Vector<Segment> curPath) {
+	public List<List<GrammarTreeNode>> detectLoop(List<Integer> rep,
+			List<Segment> curPath) {
 		int span = rep.get(1) - rep.get(0);
-		Vector<Vector<GrammarTreeNode>> resVector = new Vector<Vector<GrammarTreeNode>>();
-		Vector<GrammarTreeNode> nodelist = new Vector<GrammarTreeNode>();
+		List<List<GrammarTreeNode>> resList = new ArrayList<List<GrammarTreeNode>>();
+		List<GrammarTreeNode> nodelist = new ArrayList<GrammarTreeNode>();
 		if (span == 1) {
 			int startpos = rep.get(0);
 			int endpos = rep.get(rep.size() - 1);
@@ -804,7 +804,7 @@ public class Traces implements GrammarTreeNode {
 				if (i < startpos) {
 					nodelist.add(curPath.get(i));
 				} else if ( i == endpos) {
-					Vector<GrammarTreeNode> sublist = this.createLoop(subVector(curPath, startpos, endpos+1), 1);
+					List<GrammarTreeNode> sublist = this.createLoop(subList(curPath, startpos, endpos+1), 1);
 					if(sublist == null)
 						return null;
 					nodelist.addAll(sublist);
@@ -823,7 +823,7 @@ public class Traces implements GrammarTreeNode {
 						nodelist.add(curPath.get(i));
 					}
 					if (i == endpos + span - 1) {
-						Vector<GrammarTreeNode> sublist = this.createLoop(subVector(curPath, startpos, endpos+span), span);
+						List<GrammarTreeNode> sublist = this.createLoop(subList(curPath, startpos, endpos+span), span);
 						if(sublist == null)
 							return null;
 						nodelist.addAll(sublist);
@@ -841,7 +841,7 @@ public class Traces implements GrammarTreeNode {
 						nodelist.add(curPath.get(i));
 					}
 					if (i == endpos) {						
-						Vector<GrammarTreeNode> sublist = this.createLoop(subVector(curPath, startpos-span+1, endpos+1), span);
+						List<GrammarTreeNode> sublist = this.createLoop(subList(curPath, startpos-span+1, endpos+1), span);
 						if(sublist == null)
 							return null;
 						nodelist.addAll(sublist);
@@ -861,7 +861,7 @@ public class Traces implements GrammarTreeNode {
 						nodelist.add(curPath.get(i));
 					}
 					if (i == endpos) {
-						Vector<GrammarTreeNode> sublist = this.createLoop(subVector(curPath, startpos+1, endpos+1), span);
+						List<GrammarTreeNode> sublist = this.createLoop(subList(curPath, startpos+1, endpos+1), span);
 						if(sublist == null)
 						{
 							nodelist.clear();
@@ -872,15 +872,15 @@ public class Traces implements GrammarTreeNode {
 						nodelist.add(curPath.get(i));
 					}
 				}
-				Vector<GrammarTreeNode> nodelist1 = new Vector<GrammarTreeNode>();
+				List<GrammarTreeNode> nodelist1 = new ArrayList<GrammarTreeNode>();
 				// skip the endpos
 				for (int i = 0; i < curPath.size(); i++) {
 					if (i < startpos) {
 						nodelist1.add(curPath.get(i));
 					}
 					if (i == endpos - 1) {
-						Vector<GrammarTreeNode> sublist = this.createLoop(
-								subVector(curPath, startpos, endpos), span);
+						List<GrammarTreeNode> sublist = this.createLoop(
+								subList(curPath, startpos, endpos), span);
 						if (sublist == null) {
 							nodelist1.clear();
 							break;
@@ -892,7 +892,7 @@ public class Traces implements GrammarTreeNode {
 				}
 				if(nodelist1.size()>0)
 				{
-					resVector.add(nodelist1);
+					resList.add(nodelist1);
 				}
 			}
 			else {
@@ -902,7 +902,7 @@ public class Traces implements GrammarTreeNode {
 						nodelist.add(curPath.get(i));
 					}
 					if (i == endpos) {
-						Vector<GrammarTreeNode> sublist = this.createLoop(subVector(curPath, startpos-span+1, endpos+1), span);
+						List<GrammarTreeNode> sublist = this.createLoop(subList(curPath, startpos-span+1, endpos+1), span);
 						if(sublist == null)
 						{
 							nodelist.clear();
@@ -913,14 +913,14 @@ public class Traces implements GrammarTreeNode {
 						nodelist.add(curPath.get(i));
 					}
 				}
-				Vector<GrammarTreeNode> nodelist1 = new Vector<GrammarTreeNode>();
+				List<GrammarTreeNode> nodelist1 = new ArrayList<GrammarTreeNode>();
 				for (int i = 0; i < curPath.size(); i++) {
 					//shift right
 					if (i < startpos) {
 						nodelist1.add(curPath.get(i));
 					}
 					if (i == endpos + span - 1) {
-						Vector<GrammarTreeNode> sublist = this.createLoop(subVector(curPath, startpos, endpos+span), span);
+						List<GrammarTreeNode> sublist = this.createLoop(subList(curPath, startpos, endpos+span), span);
 						if(sublist == null)
 						{
 							nodelist1.clear();
@@ -932,14 +932,14 @@ public class Traces implements GrammarTreeNode {
 					}
 				}
 				if(nodelist1.size()>0)
-					resVector.add(nodelist1);
+					resList.add(nodelist1);
 			}
 		}
 		if(nodelist.size()!=0)
 		{
-			resVector.add(nodelist);
+			resList.add(nodelist);
 		}
-		return resVector;
+		return resList;
 	}
 
 	public void tracePrint() {
@@ -955,11 +955,11 @@ public class Traces implements GrammarTreeNode {
 	public static boolean test() {
 		String[] xStrings = { "<_START>A_BB_C_DD_E<_END>", "ABBCDDE" };
 		String[] yStrings = { "<_START>F_GG_H_II_J<_END>", "FGGHIIJ" };
-		Vector<String[]> examples = new Vector<String[]>();
+		List<String[]> examples = new ArrayList<String[]>();
 		examples.add(xStrings);
 		examples.add(yStrings);
-		Vector<Vector<TNode>> org = new Vector<Vector<TNode>>();
-		Vector<Vector<TNode>> tar = new Vector<Vector<TNode>>();
+		List<List<TNode>> org = new ArrayList<List<TNode>>();
+		List<List<TNode>> tar = new ArrayList<List<TNode>>();
 		for (int i = 0; i < examples.size(); i++) {
 			Ruler r = new Ruler();
 			r.setNewInput(examples.get(i)[0]);
@@ -977,7 +977,7 @@ public class Traces implements GrammarTreeNode {
 	}
 
 	public void emptyState() {
-		for(GrammarTreeNode t:this.totalOrderVector)
+		for(GrammarTreeNode t:this.totalOrderList)
 		{
 			t.emptyState();
 		}
@@ -985,15 +985,15 @@ public class Traces implements GrammarTreeNode {
 	
 	public String toProgram() {
 		String resString = "";
-		while (curState < totalOrderVector.size() ) {
-			resString = this.totalOrderVector.get(curState).toProgram();
+		while (curState < totalOrderList.size() ) {
+			resString = this.totalOrderList.get(curState).toProgram();
 			if(!resString.contains("null"))
 			{
 				return resString;
 			}
 			else
 			{
-				this.totalOrderVector.get(curState).emptyState();
+				this.totalOrderList.get(curState).emptyState();
 				curState ++;
 			}
 		}
@@ -1002,7 +1002,7 @@ public class Traces implements GrammarTreeNode {
 	public long size()
 	{
 		long size = 0;
-		for(Template t:this.totalOrderVector)
+		for(Template t:this.totalOrderList)
 		{
 			size += t.size();
 		}

--- a/src/main/java/edu/isi/karma/cleaning/UtilTools.java
+++ b/src/main/java/edu/isi/karma/cleaning/UtilTools.java
@@ -1,16 +1,17 @@
 package edu.isi.karma.cleaning;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Random;
-import java.util.Vector;
 
 public class UtilTools {
 	public static int index = 0;
-	public static Vector<String> results = new Vector<String>();
-	public static Vector<Integer> getStringPos(int tokenpos,Vector<TNode> example)
+	public static List<String> results = new ArrayList<String>();
+	public static List<Integer> getStringPos(int tokenpos,List<TNode> example)
 	{
-		Vector<Integer> poss = new Vector<Integer>();
+		List<Integer> poss = new ArrayList<Integer>();
 		if(tokenpos < 0)
 			return poss;
 		int pos = 0;
@@ -27,9 +28,9 @@ public class UtilTools {
 		poss.add(pos-strleng); // backward position
 		return poss;
 	}
-	public static Vector<GrammarTreeNode> convertSegVector(Vector<Segment> x)
+	public static List<GrammarTreeNode> convertSegList(List<Segment> x)
 	{
-		Vector<GrammarTreeNode> res = new Vector<GrammarTreeNode>();
+		List<GrammarTreeNode> res = new ArrayList<GrammarTreeNode>();
 		for(Segment e:x)
 		{
 			res.add(e);
@@ -57,7 +58,7 @@ public class UtilTools {
 		return r.nextInt(n);
 	}
 
-	public static String print(Vector<TNode> x) {
+	public static String print(List<TNode> x) {
 		String str = "";
 		if(x == null)
 			return "null";
@@ -69,7 +70,7 @@ public class UtilTools {
 		return str;
 	}
 
-	public static boolean samesteplength(Vector<Integer> s) {
+	public static boolean samesteplength(List<Integer> s) {
 		if (s.size() <= 1)
 			return false;
 		if (s.size() == 2) {
@@ -184,8 +185,8 @@ public class UtilTools {
 		}
 		return s;
 	}
-	public static Vector<TNode> subtokenseqs(int a, int b, Vector<TNode> org) {
-		Vector<TNode> xNodes = new Vector<TNode>();
+	public static List<TNode> subtokenseqs(int a, int b, List<TNode> org) {
+		List<TNode> xNodes = new ArrayList<TNode>();
 		if (a < 0 || b >= org.size() || a > b) {
 			return null;
 		} else {
@@ -212,8 +213,8 @@ public class UtilTools {
 			CSVWriter cw = new CSVWriter(new FileWriter(new File(dirpathString
 					+ "grammar/tmp/tmp.csv")), ',');
 			// write header into the csv file
-			Vector<String> tmp = new Vector<String>();
-			Vector<String> tmp1 = new Vector<String>();
+			List<String> tmp = new ArrayList<String>();
+			List<String> tmp1 = new ArrayList<String>();
 			RegularityFeatureSet rfs = new RegularityFeatureSet();
 			Collection<Feature> cols = rfs.computeFeatures(tmp, tmp1);
 			String[] xyz = new String[rfs.fnames.size() + 1];
@@ -223,7 +224,7 @@ public class UtilTools {
 			xyz[xyz.length - 1] = "label";
 			cw.writeNext(xyz);
 			// write the data
-			Vector<String> examples = new Vector<String>();
+			List<String> examples = new ArrayList<String>();
 			if (s != null && s.length() > 0) {
 				String[] z = s.split("\n");
 				for (String elem : z) {
@@ -234,10 +235,10 @@ public class UtilTools {
 			}
 			for (String o : dic) {
 				UtilTools.results.add(o);
-				Vector<String> row = new Vector<String>();
+				List<String> row = new ArrayList<String>();
 				if (s != null && o.compareTo(s) == 0) {
 					RegularityFeatureSet rf = new RegularityFeatureSet();
-					Vector<String> oexamples = new Vector<String>();
+					List<String> oexamples = new ArrayList<String>();
 					String[] y = o.split("\n");
 					for (String elem : y) {
 						if (elem.trim().length() > 0) {
@@ -254,7 +255,7 @@ public class UtilTools {
 					row.add("3"); // change this according to the dataset.
 				} else {
 					RegularityFeatureSet rf = new RegularityFeatureSet();
-					Vector<String> oexamples = new Vector<String>();
+					List<String> oexamples = new ArrayList<String>();
 					String[] y = o.split("\n");
 					for (String elem : y) {
 						if (elem.trim().length() > 0) {
@@ -285,9 +286,9 @@ public class UtilTools {
 
 	}
 
-	public static Vector<Integer> topKindexs(Vector<Double> scores, int k) {
+	public static List<Integer> topKindexs(List<Double> scores, int k) {
 		int cnt = 0;
-		Vector<Integer> res = new Vector<Integer>();
+		List<Integer> res = new ArrayList<Integer>();
 		ScoreObj[] sas = new ScoreObj[scores.size()];
 		for (int i = 0; i < scores.size(); i++) {
 			sas[i] = new ScoreObj(i, scores.get(i));
@@ -301,8 +302,8 @@ public class UtilTools {
 	}
 
 	// unsupervised learning
-	public static Vector<Double> getScores2(String[] res, String cpres) {
-		Vector<Double> vds = new Vector<Double>();
+	public static List<Double> getScores2(String[] res, String cpres) {
+		List<Double> vds = new ArrayList<Double>();
 		// convert the json format to \n seperated format
 		try {
 			String[] csvres = new String[res.length];
@@ -315,7 +316,7 @@ public class UtilTools {
 				}
 				csvres[i] = lines;
 			}
-			Vector<String> examples = new Vector<String>();
+			List<String> examples = new ArrayList<String>();
 			String s = cpres;
 			String[] sy = cpres.split("\n");
 			for(String tp:sy)
@@ -327,7 +328,7 @@ public class UtilTools {
 			for (String o : csvres) {
 				double soc = 0.0;
 				RegularityFeatureSet rf = new RegularityFeatureSet();
-				Vector<String> oexamples = new Vector<String>();
+				List<String> oexamples = new ArrayList<String>();
 				String[] y = o.split("\n");
 				for (String elem : y) {
 					if (elem.trim().length() > 0) {
@@ -368,8 +369,8 @@ public class UtilTools {
 		}
 	}
 
-	public static Vector<Double> getScores(String[] res, String trainPath) {
-		Vector<Double> vds = new Vector<Double>();
+	public static List<Double> getScores(String[] res, String trainPath) {
+		List<Double> vds = new ArrayList<Double>();
 		// convert the json format to \n seperated format
 		try {
 			String[] csvres = new String[res.length];

--- a/src/main/java/edu/isi/karma/cleaning/features/CntFeature.java
+++ b/src/main/java/edu/isi/karma/cleaning/features/CntFeature.java
@@ -1,8 +1,7 @@
 package edu.isi.karma.cleaning.features;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Vector;
+import java.util.List;
 
 import edu.isi.karma.cleaning.Ruler;
 import edu.isi.karma.cleaning.TNode;
@@ -10,25 +9,25 @@ import edu.isi.karma.cleaning.TNode;
 public class CntFeature implements Feature{
 		String name = "";
 		double score = 0.0;
-		Vector<TNode> pa;
+		List<TNode> pa;
 		public void setName(String name)
 		{
 			this.name = name;
 		}
-		public CntFeature(ArrayList<Vector<TNode>> v,ArrayList<Vector<TNode>> n,Vector<TNode> t)
+		public CntFeature(List<List<TNode>> v,List<List<TNode>> n,List<TNode> t)
 		{
 			pa = t;
 			score= calFeatures(v,n);
 		}
 		// x is the old y is the new example
-		public double calFeatures(ArrayList<Vector<TNode>> x,ArrayList<Vector<TNode>> y)
+		public double calFeatures(List<List<TNode>> v,List<List<TNode>> n)
 		{
 			HashMap<Integer,Integer> tmp = new HashMap<Integer,Integer>();
-			for(int i = 0; i<y.size();i++)
+			for(int i = 0; i<n.size();i++)
 			{
 				int cnt = 0;
-				Vector<TNode> z = x.get(i);
-				Vector<TNode> z1 = y.get(i);
+				List<TNode> z = v.get(i);
+				List<TNode> z1 = n.get(i);
 				int bpos = 0;
 				int p = 0;
 				int bpos1 = 0;
@@ -69,7 +68,7 @@ public class CntFeature implements Feature{
 			{
 				b[i] = a[i].intValue();
 			}
-			double res = RegularityFeatureSet.calShannonEntropy(b)*1.0/Math.log(x.size());
+			double res = RegularityFeatureSet.calShannonEntropy(b)*1.0/Math.log(v.size());
 			return res;
 		}
 		public String getName() {

--- a/src/main/java/edu/isi/karma/cleaning/features/Data2Features.java
+++ b/src/main/java/edu/isi/karma/cleaning/features/Data2Features.java
@@ -2,9 +2,10 @@ package edu.isi.karma.cleaning.features;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Vector;
+import java.util.List;
 
 import au.com.bytecode.opencsv.CSVWriter;
 
@@ -27,7 +28,7 @@ public class Data2Features {
 		}
 	}*/
 
-	public static void Testdata2CSV(Vector<String> tests, String fpath,RecordFeatureSet rf) {
+	public static void Testdata2CSV(List<String> tests, String fpath,RecordFeatureSet rf) {
 		try {
 			CSVWriter writer = new CSVWriter(new FileWriter(new File(fpath)));
 			// get attribute names
@@ -37,7 +38,7 @@ public class Data2Features {
 			attr_names[attr_names.length - 1] = "label";
 			writer.writeNext(attr_names);
 			for (String Record : tests) {
-				Vector<String> row = new Vector<String>();
+				List<String> row = new ArrayList<String>();
 				Collection<Feature> cf = rf.computeFeatures(Record,"");
 				Feature[] x = cf.toArray(new Feature[cf.size()]);
 				// row.add(f.getName());
@@ -57,11 +58,11 @@ public class Data2Features {
 
 	// class: records convert them into csv file
 	public static void Traindata2CSV(
-			HashMap<String, Vector<String>> class2Records, String fpath,RecordFeatureSet rf) {
+			HashMap<String, List<String>> class2Records, String fpath,RecordFeatureSet rf) {
 		try {
 			CSVWriter writer = new CSVWriter(new FileWriter(new File(fpath)));
-			Vector<String> vsStrings = new Vector<String>();
-			for(Vector<String> vecs:class2Records.values())
+			List<String> vsStrings = new ArrayList<String>();
+			for(List<String> vecs:class2Records.values())
 			{
 				vsStrings.addAll(vecs);
 			}
@@ -74,7 +75,7 @@ public class Data2Features {
 			for (String label : class2Records.keySet()) {
 				
 				for (String Record : class2Records.get(label)) {
-					Vector<String> row = new Vector<String>();
+					List<String> row = new ArrayList<String>();
 					Collection<Feature> cf = rf.computeFeatures(Record, label);
 					Feature[] x = cf.toArray(new Feature[cf.size()]);
 					// row.add(f.getName());

--- a/src/main/java/edu/isi/karma/cleaning/features/DataRanking.java
+++ b/src/main/java/edu/isi/karma/cleaning/features/DataRanking.java
@@ -1,7 +1,8 @@
 package edu.isi.karma.cleaning.features;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public class DataRanking {
-	public Vector<Double> coreVector = new Vector<Double>();
+	public List<Double> coreList = new ArrayList<Double>();
 }

--- a/src/main/java/edu/isi/karma/cleaning/features/Main.java
+++ b/src/main/java/edu/isi/karma/cleaning/features/Main.java
@@ -21,12 +21,13 @@
 package edu.isi.karma.cleaning.features;
 import java.io.File;
 import java.io.FileReader;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Vector;
-
-import com.sun.istack.logging.Logger;
+import java.util.List;
 
 import au.com.bytecode.opencsv.CSVReader;
+
+import com.sun.istack.logging.Logger;
 
 public class Main {
 	public static void main(String[] args)
@@ -39,9 +40,9 @@ public class Main {
 			boolean isfirstRun = true;
 			for(int i = 0 ; i<flist.length;i++)
 			{
-				Vector<String> row = new Vector<String>();
-				Vector<String> examples = new Vector<String>();
-				Vector<String> oexamples = new Vector<String>();
+				List<String> row = new ArrayList<String>();
+				List<String> examples = new ArrayList<String>();
+				List<String> oexamples = new ArrayList<String>();
 				if(!flist[i].getName().contains(".csv"))
 					continue;
 				CSVReader re = new CSVReader(new FileReader(flist[i]), '\t');
@@ -65,7 +66,7 @@ public class Main {
 						row.add(x[l].getName());
 					}
 					isfirstRun = false;
-					row = new Vector<String>();
+					row = new ArrayList<String>();
 				}
 				if(!isfirstRun)
 				{

--- a/src/main/java/edu/isi/karma/cleaning/features/MovFeature.java
+++ b/src/main/java/edu/isi/karma/cleaning/features/MovFeature.java
@@ -2,7 +2,7 @@ package edu.isi.karma.cleaning.features;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Vector;
+import java.util.List;
 
 import edu.isi.karma.cleaning.Ruler;
 import edu.isi.karma.cleaning.TNode;
@@ -10,21 +10,21 @@ import edu.isi.karma.cleaning.TNode;
 public class MovFeature implements Feature {
 	String name = "";
 	double score = 0.0;
-	Vector<TNode> pa;
-	public MovFeature(ArrayList<Vector<TNode>> v,ArrayList<Vector<TNode>> n,Vector<TNode> t)
+	List<TNode> pa;
+	public MovFeature(ArrayList<List<TNode>> v,ArrayList<List<TNode>> n,List<TNode> t)
 	{
 		pa = t;
 		score= calFeatures(v,n);
 	}
 	// x is the old y is the new example
-	public double calFeatures(ArrayList<Vector<TNode>> x,ArrayList<Vector<TNode>> y)
+	public double calFeatures(ArrayList<List<TNode>> x,ArrayList<List<TNode>> y)
 	{
 		HashMap<Integer,Integer> tmp = new HashMap<Integer,Integer>();
 		for(int i = 0; i<x.size();i++)
 		{
 			int cnt = 0;
-			Vector<TNode> z = x.get(i);
-			Vector<TNode> z1 = y.get(i);
+			List<TNode> z = x.get(i);
+			List<TNode> z1 = y.get(i);
 			int bpos = 0;
 			int p = 0;
 			int bpos1 = 0;

--- a/src/main/java/edu/isi/karma/cleaning/features/RecordClassifier2.java
+++ b/src/main/java/edu/isi/karma/cleaning/features/RecordClassifier2.java
@@ -23,15 +23,11 @@ package edu.isi.karma.cleaning.features;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileReader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
-import java.util.Vector;
 
 import org.apache.mahout.classifier.sgd.CsvRecordFactory;
 import org.apache.mahout.classifier.sgd.OnlineLogisticRegression;
@@ -45,7 +41,7 @@ import com.google.common.io.Closeables;
 import edu.isi.karma.cleaning.PartitionClassifierType;
 
 public class RecordClassifier2 implements PartitionClassifierType {
-	HashMap<String, Vector<String>> trainData = new HashMap<String, Vector<String>>();
+	HashMap<String, List<String>> trainData = new HashMap<String, List<String>>();
 	RecordFeatureSet rf = new RecordFeatureSet();
 	OnlineLogisticRegression cf;
 	List<String> labels = new ArrayList<String>();
@@ -55,7 +51,7 @@ public class RecordClassifier2 implements PartitionClassifierType {
 	}
 
 	public OnlineLogisticRegression train(
-			HashMap<String, Vector<String>> traindata) throws Exception {
+			HashMap<String, List<String>> traindata) throws Exception {
 		String csvTrainFile = "./target/tmp/csvtrain.csv";
 		Data2Features.Traindata2CSV(traindata, csvTrainFile, rf);
 		lmp = new LogisticModelParameters();
@@ -136,7 +132,7 @@ public class RecordClassifier2 implements PartitionClassifierType {
 		if (trainData.containsKey(label)) {
 			trainData.get(label).add(value);
 		} else {
-			Vector<String> vsStrings = new Vector<String>();
+			List<String> vsStrings = new ArrayList<String>();
 			vsStrings.add(value);
 			trainData.put(label, vsStrings);
 		}
@@ -169,16 +165,16 @@ public class RecordClassifier2 implements PartitionClassifierType {
 
 	public static void main(String[] args) {
 		try {
-			HashMap<String, Vector<String>> trainData = new HashMap<String, Vector<String>>();
-			Vector<String> test = new Vector<String>();
-			Vector<String> par1 = new Vector<String>();
+			HashMap<String, List<String>> trainData = new HashMap<String, List<String>>();
+			List<String> test = new ArrayList<String>();
+			List<String> par1 = new ArrayList<String>();
 			par1.add("1286 adams blvd");
 			par1.add("3711 catalina st");
 			// par1.add("11 w 37th pl, los angeles");
-			Vector<String> par2 = new Vector<String>();
+			List<String> par2 = new ArrayList<String>();
 			par2.add("1142 37st");
 			// par2.add("1 jefferson st");
-			Vector<String> par3 = new Vector<String>();
+			List<String> par3 = new ArrayList<String>();
 			par3.add("710 27");
 			trainData.put("c1", par1);
 			trainData.put("c2", par2);

--- a/src/main/java/edu/isi/karma/cleaning/features/RecordFeatureSet.java
+++ b/src/main/java/edu/isi/karma/cleaning/features/RecordFeatureSet.java
@@ -21,12 +21,10 @@
 
 package edu.isi.karma.cleaning.features;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Vector;
-
-import com.sun.tools.xjc.reader.xmlschema.bindinfo.BIConversion.Static;
+import java.util.List;
 
 import edu.isi.karma.cleaning.Ruler;
 import edu.isi.karma.cleaning.TNode;
@@ -49,7 +47,7 @@ public class RecordFeatureSet {
 	}
 
 	// convert the records to tokensequences and then construct the vocabulary
-	public void initialize(Vector<String> Records) {
+	public void initialize(List<String> Records) {
 		HashSet<String> hSet = new HashSet<String>();
 		for (String s : Records) {
 			Ruler r = new Ruler();
@@ -64,7 +62,7 @@ public class RecordFeatureSet {
 	}
 
 	public Collection<Feature> computeFeatures(String record, String label) {
-		Vector<Feature> xCollection = new Vector<Feature>();
+		List<Feature> xCollection = new ArrayList<Feature>();
 		for (String c : xStrings) {
 			Feature f = new RecordCntFeatures(c, record, c);
 			xCollection.add(f);
@@ -82,7 +80,7 @@ public class RecordFeatureSet {
 	}
 
 	public Collection<String> getFeatureNames() {
-		Vector<String> x = new Vector<String>();
+		List<String> x = new ArrayList<String>();
 		int cnt = 0;
 		for (String s : xStrings) {
 			x.add("attr_" + cnt);

--- a/src/main/java/edu/isi/karma/cleaning/features/RecordTextFeature.java
+++ b/src/main/java/edu/isi/karma/cleaning/features/RecordTextFeature.java
@@ -21,7 +21,8 @@
 
 package edu.isi.karma.cleaning.features;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 import edu.isi.karma.cleaning.Ruler;
 import edu.isi.karma.cleaning.TNode;
@@ -30,7 +31,7 @@ import edu.isi.karma.cleaning.TNode;
 public class RecordTextFeature implements Feature {
 	public double score = 1.0;
 	public String text = "";
-	public Vector<TNode> nodes = new Vector<TNode>();
+	public List<TNode> nodes = new ArrayList<TNode>();
 	public String value = "";
 	public RecordTextFeature(String text,String value)
 	{

--- a/src/main/java/edu/isi/karma/cleaning/features/RegularityFeatureSet.java
+++ b/src/main/java/edu/isi/karma/cleaning/features/RegularityFeatureSet.java
@@ -22,7 +22,7 @@ package edu.isi.karma.cleaning.features;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Vector;
+import java.util.List;
 
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.CharStream;
@@ -34,23 +34,23 @@ import edu.isi.karma.cleaning.Tokenizer;
 
 public class RegularityFeatureSet implements FeatureSet {
 
-	public ArrayList<Vector<TNode>> tokenseqs;
-	public ArrayList<Vector<TNode>> otokenseqs;
-	public Vector<String> fnames;
+	public ArrayList<List<TNode>> tokenseqs;
+	public ArrayList<List<TNode>> otokenseqs;
+	public List<String> fnames;
 	public static String[] targets = {"#",";",",","!","~","@","$","%","^","&","*","(",")","_","-","{","}","[","]","\"","\'",":","?","<",">",".","bnk","syb","wrd","num"};
 	public RegularityFeatureSet()
 	{
-		tokenseqs = new ArrayList<Vector<TNode>>();
-		otokenseqs= new ArrayList<Vector<TNode>>();
-		fnames = new Vector<String>();
+		tokenseqs = new ArrayList<List<TNode>>();
+		otokenseqs= new ArrayList<List<TNode>>();
+		fnames = new ArrayList<String>();
 	}
-	public Vector<TNode> tokenizer(String Org)
+	public List<TNode> tokenizer(String Org)
 	{
 		CharStream cs =  new ANTLRStringStream(Org);
 		Tokenizer tk = new Tokenizer(cs);
 		Token t;
 		t = tk.nextToken();
-		Vector<TNode> x = new Vector<TNode>();
+		List<TNode> x = new ArrayList<TNode>();
 		while(t.getType()!=-1)
 		{
 			int mytype = -1;
@@ -81,27 +81,27 @@ public class RegularityFeatureSet implements FeatureSet {
 		return x;
 	}
 	public Collection<Feature> computeFeatures(Collection<String> examples,Collection<String> oexamples) {
-		Vector<Feature> r = new Vector<Feature>();
+		List<Feature> r = new ArrayList<Feature>();
 		
 		for(String s:examples)
 		{
-			Vector<TNode> x = this.tokenizer(s);
+			List<TNode> x = this.tokenizer(s);
 			this.tokenseqs.add(x);
 		}
 		for(String s:oexamples)
 		{
-			Vector<TNode> x = this.tokenizer(s);
+			List<TNode> x = this.tokenizer(s);
 			this.otokenseqs.add(x);
 		}
 		//counting feature
 		String[] symbol = {"#",";",",","!","~","@","$","%","^","&","*","(",")","_","-","{","}","[","]","\"","'",":","?","<",">","."};
-		Vector<CntFeature> cntfs = new Vector<CntFeature>(symbol.length);
+		List<CntFeature> cntfs = new ArrayList<CntFeature>(symbol.length);
 		//moving feature
-		Vector<MovFeature> movfs = new Vector<MovFeature>(symbol.length);
+		List<MovFeature> movfs = new ArrayList<MovFeature>(symbol.length);
 		for(int i=0; i<symbol.length;i++)
 		{
 			TNode t = new TNode(TNode.SYBSTYP,symbol[i]);
-			Vector<TNode> li = new Vector<TNode>();
+			List<TNode> li = new ArrayList<TNode>();
 			li.add(t);
 			cntfs.add(i,new CntFeature(this.otokenseqs,this.tokenseqs,li));
 			cntfs.get(i).setName("entr_cnt_"+symbol[i]);
@@ -110,27 +110,27 @@ public class RegularityFeatureSet implements FeatureSet {
 		}
 		//count the blank, symbol  wrd and number token
 		TNode t = new TNode(TNode.BNKTYP,TNode.ANYTOK);
-		Vector<TNode> li = new Vector<TNode>();
+		List<TNode> li = new ArrayList<TNode>();
 		li.add(t);
 		CntFeature cf = new CntFeature(this.otokenseqs,this.tokenseqs,li);
 		cf.setName("entr_cnt_bnk");
 		TNode t1 = new TNode(TNode.SYBSTYP,TNode.ANYTOK);
-		Vector<TNode> li1 = new Vector<TNode>();
+		List<TNode> li1 = new ArrayList<TNode>();
 		li1.add(t1);
 		CntFeature cf1 = new CntFeature(this.otokenseqs,this.tokenseqs,li1);
 		cf1.setName("entr_cnt_syb");
 		TNode t2 = new TNode(TNode.LWRDTYP,TNode.ANYTOK);
-		Vector<TNode> li2 = new Vector<TNode>();
+		List<TNode> li2 = new ArrayList<TNode>();
 		li2.add(t2);
 		CntFeature cf2 = new CntFeature(this.otokenseqs,this.tokenseqs,li2);
 		cf2.setName("entr_cnt_lwrd");
 		TNode t3 = new TNode(TNode.NUMTYP,TNode.ANYTOK);
-		Vector<TNode> li3 = new Vector<TNode>();
+		List<TNode> li3 = new ArrayList<TNode>();
 		li3.add(t3);
 		CntFeature cf3 = new CntFeature(this.otokenseqs,this.tokenseqs,li3);
 		cf3.setName("entr_cnt_num");
 		/*TNode t4 = new TNode(TNode.UWRDTYP,TNode.ANYTOK);
-		Vector<TNode> li4 = new Vector<TNode>();
+		List<TNode> li4 = new ArrayList<TNode>();
 		li3.add(t4);
 		CntFeature cf4 = new CntFeature(this.otokenseqs,this.tokenseqs,li4);
 		cf3.setName("entr_cnt_num");*/

--- a/src/main/java/edu/isi/karma/cleaning/features/VarianceFeatureSet.java
+++ b/src/main/java/edu/isi/karma/cleaning/features/VarianceFeatureSet.java
@@ -20,9 +20,10 @@
  ******************************************************************************/
 package edu.isi.karma.cleaning.features;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.Vector;
+import java.util.List;
 class Varfeature implements Feature {
 
 	String name = "";
@@ -51,7 +52,7 @@ public class VarianceFeatureSet implements FeatureSet {
 	}
 	public Collection<Feature> computeFeatures(Collection<String> oldexamples,Collection<String> newexamples) {
 		
-		Vector<Feature> fs = new Vector<Feature>();
+		List<Feature> fs = new ArrayList<Feature>();
 		RegularityFeatureSet rf1 = new RegularityFeatureSet();
 		Collection<Feature> x = rf1.computeFeatures(oldexamples,newexamples);
 		RegularityFeatureSet rf2 = new RegularityFeatureSet();

--- a/src/main/java/edu/isi/karma/controller/command/cleaning/GenerateCleaningRulesCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/cleaning/GenerateCleaningRulesCommand.java
@@ -28,8 +28,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
-import java.util.Vector;
 
 import org.apache.log4j.FileAppender;
 import org.apache.log4j.Logger;
@@ -43,7 +41,6 @@ import edu.isi.karma.cleaning.DataCollection;
 import edu.isi.karma.cleaning.ExampleSelection;
 import edu.isi.karma.cleaning.Ruler;
 import edu.isi.karma.cleaning.TNode;
-import edu.isi.karma.cleaning.UtilTools;
 import edu.isi.karma.controller.command.CommandException;
 import edu.isi.karma.controller.command.WorksheetCommand;
 import edu.isi.karma.controller.update.CleaningResultUpdate;
@@ -58,12 +55,10 @@ import edu.isi.karma.rep.cleaning.RamblerValueCollection;
 import edu.isi.karma.rep.cleaning.TransformationExample;
 import edu.isi.karma.rep.cleaning.ValueCollection;
 import edu.isi.karma.view.VWorkspace;
-import edu.isi.karma.webserver.ServletContextParameterMap;
-import edu.isi.karma.webserver.ServletContextParameterMap.ContextParameter;
 
 public class GenerateCleaningRulesCommand extends WorksheetCommand {
 	final String hNodeId;
-	private Vector<TransformationExample> examples;
+	private List<TransformationExample> examples;
 	private HashSet<String> nodeIds = new HashSet<String>();
 	RamblerTransformationInputs inputs;
 	public String compResultString = "";
@@ -102,8 +97,8 @@ public class GenerateCleaningRulesCommand extends WorksheetCommand {
 		return tSet;
 	}
 
-	public static Vector<TransformationExample> parseExample(String example) {
-		Vector<TransformationExample> x = new Vector<TransformationExample>();
+	public static List<TransformationExample> parseExample(String example) {
+		List<TransformationExample> x = new ArrayList<TransformationExample>();
 		try {
 			JSONArray jsa = new JSONArray(example);
 			for (int i = 0; i < jsa.length(); i++) {
@@ -126,14 +121,14 @@ public class GenerateCleaningRulesCommand extends WorksheetCommand {
 	}
 
 	private String getBestExample(HashMap<String, String[]> xHashMap,
-			HashMap<String, Vector<String[]>> expFeData) {
+			HashMap<String, List<String[]>> expFeData) {
 		String ID = "";
 		ExampleSelection es = new ExampleSelection();
 		es.inite(xHashMap, expFeData);
 		return es.Choose();
 	}
 
-/*	private static Vector<String> getTopK(Set<String> res, int k, String cmpres) {
+/*	private static List<String> getTopK(Set<String> res, int k, String cmpres) {
 		String dirpathString = ServletContextParameterMap
 				.getParameterValue(ContextParameter.USER_DIRECTORY_PATH);
 		if (dirpathString.compareTo("") == 0) {
@@ -144,12 +139,12 @@ public class GenerateCleaningRulesCommand extends WorksheetCommand {
 		//
 		String[] x = (String[]) res.toArray(new String[res.size()]);
 		System.out.println("" + x);
-		// Vector<Double> scores = UtilTools.getScores(x, trainPath);
-		Vector<Double> scores = UtilTools.getScores2(x, cmpres);
+		// List<Double> scores = UtilTools.getScores(x, trainPath);
+		List<Double> scores = UtilTools.getScores2(x, cmpres);
 		System.out.println("Scores: " + scores);
-		Vector<Integer> ins = UtilTools.topKindexs(scores, k);
+		List<Integer> ins = UtilTools.topKindexs(scores, k);
 		System.out.println("Indexs: " + ins);
-		Vector<String> y = new Vector<String>();
+		List<String> y = new ArrayList<String>();
 		for (int i = 0; i < k && i < ins.size(); i++) {
 			y.add(x[ins.get(i)]);
 		}
@@ -180,7 +175,7 @@ public class GenerateCleaningRulesCommand extends WorksheetCommand {
 	public void StringColorCode(String org, String res,
 			HashMap<String, String> dict) {
 		int segmentCnt = 0;
-		Vector<int[]> allUpdates = new Vector<int[]>();
+		List<int[]> allUpdates = new ArrayList<int[]>();
 		String pat = "((?<=\\{_L\\})|(?=\\{_L\\}))";
 		String pat1 = "((?<=\\{_S\\})|(?=\\{_S\\}))";
 		String orgdis = "";
@@ -297,7 +292,7 @@ public class GenerateCleaningRulesCommand extends WorksheetCommand {
 			calAmbScore(id, originalVal, amb);
 		}
 		RamblerValueCollection vc = new RamblerValueCollection(rows);
-		HashMap<String, Vector<String[]>> expFeData = new HashMap<String, Vector<String[]>>();
+		HashMap<String, List<String[]>> expFeData = new HashMap<String, List<String[]>>();
 		inputs = new RamblerTransformationInputs(examples, vc);
 		// generate the program
 		boolean results = false;
@@ -344,7 +339,7 @@ public class GenerateCleaningRulesCommand extends WorksheetCommand {
 				for (TransformationExample exp : examples) {
 					if (exp.getNodeId().compareTo(key) == 0) {
 						if (!expFeData.containsKey(classLabel)) {
-							Vector<String[]> vstr = new Vector<String[]>();
+							List<String[]> vstr = new ArrayList<String[]>();
 							String[] texp = {dict.get("Tar"), pretar};
 							vstr.add(texp);
 							expFeData.put(classLabel, vstr);
@@ -416,7 +411,7 @@ public class GenerateCleaningRulesCommand extends WorksheetCommand {
 	public void calAmbScore(String id, String org, HashMap<String, Integer> amb) {
 		Ruler ruler = new Ruler();
 		ruler.setNewInput(org);
-		Vector<TNode> tNodes = ruler.vec;
+		List<TNode> tNodes = ruler.vec;
 		int tcnt = 1;
 		for (int i = 0; i < tNodes.size(); i++) {
 			if (tNodes.get(i).text.compareTo(" ") == 0)
@@ -510,7 +505,7 @@ public class GenerateCleaningRulesCommand extends WorksheetCommand {
 					int isadded = 0;
 					HashMap<String, String> tx = new HashMap<String, String>();
 					int i = 0;
-					Vector<TransformationExample> vrt = new Vector<TransformationExample>();
+					List<TransformationExample> vrt = new ArrayList<TransformationExample>();
 					while ((pair = cr.readNext()) != null) {
 
 						pair[0] = "<_START>" + pair[0] + "<_END>";
@@ -529,10 +524,10 @@ public class GenerateCleaningRulesCommand extends WorksheetCommand {
 					// generate the program
 					RamblerTransformationOutput rtf = new RamblerTransformationOutput(
 							inputs);
-					HashMap<String, Vector<String>> js2tps = new HashMap<String, Vector<String>>();
+					HashMap<String, List<String>> js2tps = new HashMap<String, List<String>>();
 					Iterator<String> iter = rtf.getTransformations().keySet()
 							.iterator();
-					Vector<ValueCollection> vvc = new Vector<ValueCollection>();
+					List<ValueCollection> vvc = new ArrayList<ValueCollection>();
 					while (iter.hasNext()) {
 						String tpid = iter.next();
 						ValueCollection rvco = rtf.getTransformedValues(tpid);
@@ -542,7 +537,7 @@ public class GenerateCleaningRulesCommand extends WorksheetCommand {
 							js2tps.get(reps).add(tpid); // update the variance
 														// dic
 						} else {
-							Vector<String> tps = new Vector<String>();
+							List<String> tps = new ArrayList<String>();
 							tps.add(tpid);
 							js2tps.put(reps, tps);
 						}

--- a/src/main/java/edu/isi/karma/controller/command/cleaning/SubmitCleaningCommand.java
+++ b/src/main/java/edu/isi/karma/controller/command/cleaning/SubmitCleaningCommand.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Vector;
 
 import org.apache.log4j.FileAppender;
 import org.apache.log4j.Logger;
@@ -66,7 +65,7 @@ public class SubmitCleaningCommand extends Command {
 	private String columnName;
 	
 	private static Logger logger =Logger.getLogger(SubmitCleaningCommand.class);
-	private Vector<TransformationExample> examples = new Vector<TransformationExample>();
+	private List<TransformationExample> examples = new ArrayList<TransformationExample>();
 	
 	public SubmitCleaningCommand(String id, String hNodeId, String vWorkSheetId, String Examples) {
 		super(id);
@@ -211,7 +210,7 @@ public class SubmitCleaningCommand extends Command {
 				
 			}
 			Iterator<String> iter = rtf.getTransformations().keySet().iterator();
-			Vector<ValueCollection> vvc = new Vector<ValueCollection>();
+			List<ValueCollection> vvc = new ArrayList<ValueCollection>();
 			String tpid = iter.next();
 			ValueCollection rvco = rtf.getTransformedValues(tpid);
 			vvc.add(rvco);

--- a/src/main/java/edu/isi/karma/er/helper/OntologyUtil.java
+++ b/src/main/java/edu/isi/karma/er/helper/OntologyUtil.java
@@ -1,7 +1,7 @@
 package edu.isi.karma.er.helper;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Property;
@@ -22,7 +22,7 @@ public class OntologyUtil {
 		Property RDF = ResourceFactory.createProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
 		ResIterator iter = model.listResourcesWithProperty(RDF);
 		
-		List<Ontology> list = new Vector<Ontology>();
+		List<Ontology> list = new ArrayList<Ontology>();
 		while (iter.hasNext()) {
 			Resource res = iter.next();
 			StmtIterator siter = res.listProperties();

--- a/src/main/java/edu/isi/karma/er/helper/ScoreBoardFileUtil.java
+++ b/src/main/java/edu/isi/karma/er/helper/ScoreBoardFileUtil.java
@@ -12,7 +12,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 
 import org.apache.log4j.Logger;
 import org.json.JSONArray;
@@ -257,7 +256,7 @@ public class ScoreBoardFileUtil {
 	}
 	
 	private List<ScoreBoard> sortResultList(Map<String, ScoreBoard> map) {
-		List<ScoreBoard> list = new Vector<ScoreBoard>();
+		List<ScoreBoard> list = new ArrayList<ScoreBoard>();
 		ScoreBoard rec;
 		
 		for (ScoreBoard s : map.values()) {
@@ -326,13 +325,13 @@ public class ScoreBoardFileUtil {
 	 * @param filename of result file
 	 * @return score board data list with ground truth
 	 */
-	public Vector<ScoreBoard> loadScoreBoardFile(String filename) {
+	public List<ScoreBoard> loadScoreBoardFile(String filename) {
 		File file = new File(Constants.PATH_SCORE_BOARD_FILE + filename);
 		if (!file.exists())
 			throw new IllegalArgumentException("file " + file.getAbsolutePath() + " not exists.");
 		
 		RandomAccessFile raf = null;
-		Vector<ScoreBoard> list = new Vector<ScoreBoard>();
+		List<ScoreBoard> list = new ArrayList<ScoreBoard>();
 		
 		try {
 			raf = new RandomAccessFile(file, "r");
@@ -404,7 +403,7 @@ public class ScoreBoardFileUtil {
 	 * @param filename of result file
 	 * @return score board data list without ground truth
 	 */
-	public Vector<ScoreBoard> loadScoreResultFile(String filename) {
+	public List<ScoreBoard> loadScoreResultFile(String filename) {
 		File file = null;
 		if (filename.indexOf(':') > -1 || filename.startsWith("/")) {
 			file = new File(filename);
@@ -415,7 +414,7 @@ public class ScoreBoardFileUtil {
 			throw new IllegalArgumentException("file " + file.getAbsolutePath() + " not exists.");
 		
 		RandomAccessFile raf = null;
-		Vector<ScoreBoard> list = new Vector<ScoreBoard>();
+		List<ScoreBoard> list = new ArrayList<ScoreBoard>();
 		
 		try {
 			raf = new RandomAccessFile(file, "r");
@@ -484,7 +483,7 @@ public class ScoreBoardFileUtil {
 
 	private List<MultiScore> parseRankList(String... strs) {
 		String[] preds = {"http://americanart.si.edu/saam/deathYear", "http://americanart.si.edu/saam/birthYear", "http://americanart.si.edu/saam/fullName"};
-		Vector<MultiScore> list = new Vector<MultiScore> ();
+		List<MultiScore> list = new ArrayList<MultiScore> ();
 		List<Score> scoreList = null;
 		
 		String finalScore, sim, attr;
@@ -492,7 +491,7 @@ public class ScoreBoardFileUtil {
 			if (str.indexOf('{') > -1 && str.indexOf('}') > -1) {
 				MultiScore ms = new MultiScore();
 				
-				scoreList = new Vector<Score>();
+				scoreList = new ArrayList<Score>();
 				finalScore = str.substring(str.indexOf('[')+1, str.indexOf(']'));
 				str = str.substring(str.indexOf(']') + 2);
 				ms.setFinalScore(Double.parseDouble(finalScore));

--- a/src/main/java/edu/isi/karma/er/helper/entity/NYTimes.java
+++ b/src/main/java/edu/isi/karma/er/helper/entity/NYTimes.java
@@ -1,9 +1,9 @@
 package edu.isi.karma.er.helper.entity;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ResIterator;
@@ -61,7 +61,7 @@ public class NYTimes {
 	
 	public List<NYTimes> listAll() {
 		Model model = loadNytimesModel();
-		List<NYTimes> list = new Vector<NYTimes>();
+		List<NYTimes> list = new ArrayList<NYTimes>();
 		ResIterator resList = model.listSubjectsWithProperty(NameSpace.RDF_TYPE);
 		
 		Resource subj;

--- a/src/main/java/edu/isi/karma/er/helper/entity/PersonProperty.java
+++ b/src/main/java/edu/isi/karma/er/helper/entity/PersonProperty.java
@@ -1,15 +1,16 @@
 package edu.isi.karma.er.helper.entity;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public class PersonProperty {
 
 	private String predicate;
 	
-	private Vector<String> value = null;
+	private List<String> value = null;
 	
 	public PersonProperty() {
-		this.value = new Vector<String>();
+		this.value = new ArrayList<String>();
 	}
 
 	public String getPredicate() {
@@ -20,7 +21,7 @@ public class PersonProperty {
 		this.predicate = predicate;
 	}
 
-	public Vector<String> getValue() {
+	public List<String> getValue() {
 		return value;
 	}
 

--- a/src/main/java/edu/isi/karma/er/helper/ontology/MatchOntologyUtil.java
+++ b/src/main/java/edu/isi/karma/er/helper/ontology/MatchOntologyUtil.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -14,7 +15,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeMap;
-import java.util.Vector;
 
 import com.hp.hpl.jena.datatypes.xsd.XSDDateTime;
 import com.hp.hpl.jena.query.QueryExecution;
@@ -542,7 +542,7 @@ public class MatchOntologyUtil {
 	 */
 	public List<Resource> listLatestMatchResultResources() {
 		Model model = this.getModel();
-		List<Resource> list = new Vector<Resource>();
+		List<Resource> list = new ArrayList<Resource>();
 		String sparql = "PREFIX match:<" + NameSpace.PREFIX_MATCH + ">\n" +
 				"PREFIX prov:<" + NameSpace.PREFIX_PROV + ">\n" +
 				"PREFIX rdfs:<" + NameSpace.PREFIX_RDFS + ">" + "\n" +
@@ -594,7 +594,7 @@ public class MatchOntologyUtil {
 	public List<MatchResultOntology> listLatestMatchResultObjects(String sortBy, String creator) {
 		Model model = this.getModel();
 		MatchResultOntology onto = null;
-		List<MatchResultOntology> list = new Vector<MatchResultOntology>();
+		List<MatchResultOntology> list = new ArrayList<MatchResultOntology>();
 		String sparql = "PREFIX match:<" + NameSpace.PREFIX_MATCH + ">\n" +
 				"PREFIX prov:<" + NameSpace.PREFIX_PROV + ">\n" +
 				"PREFIX rdf:<" + NameSpace.PREFIX_RDF + ">" + "\n" +
@@ -823,7 +823,7 @@ public class MatchOntologyUtil {
 	}
 
 	private List<Score> getScoreListFromResource(Resource res) {
-		List<Score> scoreList = new Vector<Score>();
+		List<Score> scoreList = new ArrayList<Score>();
 		Resource actRes = res.listProperties(NameSpace.PROV_WAS_GENERATED_BY).next().getObject().asResource();
 		Resource srcRes = actRes.listProperties(NameSpace.MATCH_HAS_MATCH_SOURCE).next().getObject().asResource();
 		Resource dstRes = actRes.listProperties(NameSpace.MATCH_HAS_MATCH_TARGET).next().getObject().asResource();
@@ -873,7 +873,7 @@ public class MatchOntologyUtil {
 	}
 	
 	public List<MatchResultOntology> listMatchResultObjectWithGiven(String srcUri, String dstUri) {
-		List<MatchResultOntology> list = new Vector<MatchResultOntology>();
+		List<MatchResultOntology> list = new ArrayList<MatchResultOntology>();
 		Model model = this.getModel();
 		MatchResultOntology onto = null;
 		String sparql = "PREFIX match:<" + NameSpace.PREFIX_MATCH + ">\n" +
@@ -1148,7 +1148,7 @@ public class MatchOntologyUtil {
 	}
 	
 	public static List<String> listRepositories() {
-		List<String> list = new Vector<String>();
+		List<String> list = new ArrayList<String>();
 		String repoListFile = Constants.PATH_REPOSITORY + "repository_list.txt";
 		
 		File file = new File(repoListFile);
@@ -1183,7 +1183,7 @@ public class MatchOntologyUtil {
 		
 		RandomAccessFile raf = null;
 		String line = null;
-		List<String> list = new Vector<String>();
+		List<String> list = new ArrayList<String>();
 		try {
 			raf = new RandomAccessFile(file, "rw");
 			while ((line = raf.readLine()) != null) {

--- a/src/main/java/edu/isi/karma/er/linkage/LinkageFinderThread.java
+++ b/src/main/java/edu/isi/karma/er/linkage/LinkageFinderThread.java
@@ -1,7 +1,7 @@
 package edu.isi.karma.er.linkage;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 
 import org.apache.log4j.Logger;
 import org.json.JSONArray;
@@ -16,7 +16,7 @@ public class LinkageFinderThread extends Thread {
 	List<Ontology> dstList = null;
 	Aggregator aver = null;
 	JSONArray confArr = null;
-	List<ResultRecord> resultList = new Vector<ResultRecord>();
+	List<ResultRecord> resultList = new ArrayList<ResultRecord>();
 
 	public LinkageFinderThread(List<Ontology> srcList, List<Ontology> dstList, Aggregator aver, JSONArray confArr) {
 		this.srcList = srcList;

--- a/src/main/java/edu/isi/karma/er/test/old/ConstructPairPropertyMap.java
+++ b/src/main/java/edu/isi/karma/er/test/old/ConstructPairPropertyMap.java
@@ -180,7 +180,7 @@ public class ConstructPairPropertyMap {
 		Property RDF = ResourceFactory.createProperty(RDF_TYPE);
 		ResIterator iter = model.listSubjectsWithProperty(RDF);
 		
-		List<SaamPerson> list = new Vector<SaamPerson>();
+		List<SaamPerson> list = new ArrayList<SaamPerson>();
 		while (iter.hasNext()) {
 			Resource res = iter.next();
 			StmtIterator siter = res.listProperties();

--- a/src/main/java/edu/isi/karma/er/test/old/CreateOntologyRepositoryUsingJena.java
+++ b/src/main/java/edu/isi/karma/er/test/old/CreateOntologyRepositoryUsingJena.java
@@ -8,7 +8,6 @@ import java.io.RandomAccessFile;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.tdb.TDB;
@@ -238,7 +237,7 @@ public class CreateOntologyRepositoryUsingJena {
 		onto.setComment(comment);
 		onto.setCreator(creator);
 		onto.setFinalScore(finalScore);
-		List<Score> list = new Vector<Score>();
+		List<Score> list = new ArrayList<Score>();
 		for (int i= 0; i < srcAttr1.length; i++) {
 			Score s = new Score();
 			s.setPredicate(srcAttr1[i]);
@@ -258,7 +257,7 @@ public class CreateOntologyRepositoryUsingJena {
 	}
 	
 	public static List<MatchResultOntology> loadBuildingOntologyFromCSV() {
-		List<MatchResultOntology> mlist = new Vector<MatchResultOntology>();
+		List<MatchResultOntology> mlist = new ArrayList<MatchResultOntology>();
 		String filename = "BuildingMatchResult.csv";
 		File file = new File(Constants.PATH_SCORE_BOARD_FILE + filename);
 		if (!file.exists())
@@ -291,7 +290,7 @@ public class CreateOntologyRepositoryUsingJena {
 							onto.setComment("Not Match (" + onto.getFinalScore() + ")");
 						}
 						
-						sList = new Vector<Score>();
+						sList = new ArrayList<Score>();
 						s = new Score();
 						s.setPredicate("NAME");
 						s.setSrcObj(arr[1]);

--- a/src/main/java/edu/isi/karma/er/test/old/DrawDiagramFromScoreBoard.java
+++ b/src/main/java/edu/isi/karma/er/test/old/DrawDiagramFromScoreBoard.java
@@ -1,7 +1,7 @@
 package edu.isi.karma.er.test.old;
 
 import java.text.DecimalFormat;
-import java.util.Vector;
+import java.util.List;
 
 import edu.isi.karma.er.helper.ScoreBoardFileUtil;
 import edu.isi.karma.er.helper.entity.ScoreBoard;
@@ -14,13 +14,13 @@ public class DrawDiagramFromScoreBoard {
 	public static void main(String[] args) {
 		String filename = "result2012-10-19-15-29.csv";
 		ScoreBoardFileUtil util = new ScoreBoardFileUtil();
-		Vector<ScoreBoard> list = util.loadScoreBoardFile(filename);
+		List<ScoreBoard> list = util.loadScoreBoardFile(filename);
 		sortByScoreDesc(list);
 		
 		drawGraphData(list);
 	}
 
-	private static void drawGraphData(Vector<ScoreBoard> list) {
+	private static void drawGraphData(List<ScoreBoard> list) {
 		System.out.println("size:" + list.size());
 		DecimalFormat df = new DecimalFormat("#.0000");
 		double found = 0, count  = 0, total = 175, lastResult = -1;
@@ -38,7 +38,7 @@ public class DrawDiagramFromScoreBoard {
 		
 	}
 
-	private static void sortByScoreDesc(Vector<ScoreBoard> list) {
+	private static void sortByScoreDesc(List<ScoreBoard> list) {
 		int i,j, len = list.size();
 		ScoreBoard s1, s2;
 		

--- a/src/main/java/edu/isi/karma/er/test/old/LoadModelIntoObject.java
+++ b/src/main/java/edu/isi/karma/er/test/old/LoadModelIntoObject.java
@@ -1,7 +1,7 @@
 package edu.isi.karma.er.test.old;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Property;
@@ -73,7 +73,7 @@ public class LoadModelIntoObject {
 	}
 
 	private static List<SaamPerson> loadOntologies(ResIterator iter) {
-		List<SaamPerson> list = new Vector<SaamPerson>();
+		List<SaamPerson> list = new ArrayList<SaamPerson>();
 		while (iter.hasNext()) {
 			Resource res = iter.next();
 			StmtIterator siter = res.listProperties();

--- a/src/main/java/edu/isi/karma/er/test/old/TestRandomFrequency.java
+++ b/src/main/java/edu/isi/karma/er/test/old/TestRandomFrequency.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
-import java.util.Vector;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Property;
@@ -343,7 +342,7 @@ public class TestRandomFrequency {
 	
 	private List<String> randomStringList(int num, List<SaamPerson> perList) {
 		
-		List<String> list = new Vector<String>();
+		List<String> list = new ArrayList<String>();
 		
 		
 		int len = perList.size();
@@ -450,7 +449,7 @@ public class TestRandomFrequency {
 	}
 
 	private List<SaamPerson> loadOntologies(Model model) {
-		List<SaamPerson> list = new Vector<SaamPerson>();
+		List<SaamPerson> list = new ArrayList<SaamPerson>();
 		Property RDF = ResourceFactory.createProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
 		ResIterator iter = model.listResourcesWithProperty(RDF);
 		int count = 0;

--- a/src/main/java/edu/isi/karma/er/web/service/ResultService.java
+++ b/src/main/java/edu/isi/karma/er/web/service/ResultService.java
@@ -1,8 +1,8 @@
 package edu.isi.karma.er.web.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 
 import edu.isi.karma.er.helper.ScoreBoardFileUtil;
 import edu.isi.karma.er.helper.entity.MultiScore;
@@ -112,7 +112,7 @@ public class ResultService {
 	}
 
 	public List<String> getPredicateList(List<MatchResultOntology> resultList) {
-		List<String> predList = new Vector<String>();
+		List<String> predList = new ArrayList<String>();
 		if (resultList != null && resultList.size() > 0) {
 			List<Score> scList = resultList.get(0).getMemberList();
 			for (int i = 0; i < scList.size(); i++) {

--- a/src/main/java/edu/isi/karma/geospatial/WorksheetToFeatureCollection.java
+++ b/src/main/java/edu/isi/karma/geospatial/WorksheetToFeatureCollection.java
@@ -77,9 +77,9 @@ import de.micromata.opengis.kml.v_2_2_0.Icon;
 import de.micromata.opengis.kml.v_2_2_0.Kml;
 import de.micromata.opengis.kml.v_2_2_0.KmlFactory;
 import de.micromata.opengis.kml.v_2_2_0.LinearRing;
-import de.micromata.opengis.kml.v_2_2_0.LookAt;
 import de.micromata.opengis.kml.v_2_2_0.Placemark;
 import de.micromata.opengis.kml.v_2_2_0.Style;
+import de.micromata.opengis.kml.v_2_2_0.LookAt;
 import edu.isi.karma.modeling.Namespaces;
 import edu.isi.karma.modeling.ontology.OntologyManager;
 import edu.isi.karma.rep.HNode;
@@ -95,9 +95,9 @@ public class WorksheetToFeatureCollection {
 	private Worksheet worksheet;
 	private OntologyManager om;
 
-	List<SimpleFeature> pointFeatureVector = new ArrayList<SimpleFeature>();
-	List<SimpleFeature> lineFeatureVector = new ArrayList<SimpleFeature>();
-	List<SimpleFeature> polygonFeatureVector = new ArrayList<SimpleFeature>();
+	List<SimpleFeature> pointFeatureList = new ArrayList<SimpleFeature>();
+	List<SimpleFeature> lineFeatureList = new ArrayList<SimpleFeature>();
+	List<SimpleFeature> polygonFeatureList = new ArrayList<SimpleFeature>();
 	List<AttributeDescriptor> featureSchema = new ArrayList<AttributeDescriptor>();
 	List<String> geomHNodeIdList = new ArrayList<String>();
 	List<String> modeledHNodeIds = new ArrayList<String>();
@@ -202,17 +202,17 @@ public class WorksheetToFeatureCollection {
 		prepareFeatureSchema();
 		if (pointFeatureHNodeId != "")
 			populateSimpleFeatures(pointFeatureHNodeId,
-					"", getRows(), pointFeatureVector, Point.class);
+					"", getRows(), pointFeatureList, Point.class);
 		if (pointFeatureLatHNodeId != "" && pointFeatureLonHNodeId != "")
 			populateSimpleFeatures(pointFeatureLonHNodeId,
-					pointFeatureLatHNodeId, getRows(), pointFeatureVector,
+					pointFeatureLatHNodeId, getRows(), pointFeatureList,
 					Point.class);
 		if (lineFeatureHNodeId != "")
 			populateSimpleFeatures(lineFeatureHNodeId, "",
-					getRows(), lineFeatureVector, LineString.class);
+					getRows(), lineFeatureList, LineString.class);
 		if (polygonFeatureHNodeId != "")
 			populateSimpleFeatures(polygonFeatureHNodeId,
-					"", getRows(), polygonFeatureVector, Polygon.class);
+					"", getRows(), polygonFeatureList, Polygon.class);
 	}
 	private void prepareFeatureSchema() {
 		List<String> spatialHNodeIds = new ArrayList<String>();
@@ -409,13 +409,13 @@ public class WorksheetToFeatureCollection {
 		File kml = publishKML(spatialDataFolder, fileName);
 		if (pointFeatureHNodeId != ""
 				|| (pointFeatureLatHNodeId != "" && pointFeatureLonHNodeId != ""))
-			saveShapefile(pointFeatureVector, spatialDataFolder, fileName
+			saveShapefile(pointFeatureList, spatialDataFolder, fileName
 					+ "_point");
 		if (lineFeatureHNodeId != "")
-			saveShapefile(lineFeatureVector, spatialDataFolder, fileName
+			saveShapefile(lineFeatureList, spatialDataFolder, fileName
 					+ "_line");
 		if (polygonFeatureHNodeId != "")
-			saveShapefile(polygonFeatureVector, spatialDataFolder, fileName
+			saveShapefile(polygonFeatureList, spatialDataFolder, fileName
 					+ "_polygon");
 
 		saveSpatialDataToZip(spatialDataFolder, fileName);
@@ -457,13 +457,13 @@ public class WorksheetToFeatureCollection {
 		File kml = publishKML(spatialDataFolder, fileName);
 		if (pointFeatureHNodeId != ""
 				|| (pointFeatureLatHNodeId != "" && pointFeatureLonHNodeId != ""))
-			saveShapefile(pointFeatureVector, spatialDataFolder, fileName
+			saveShapefile(pointFeatureList, spatialDataFolder, fileName
 					+ "_point");
 		if (lineFeatureHNodeId != "")
-			saveShapefile(lineFeatureVector, spatialDataFolder, fileName
+			saveShapefile(lineFeatureList, spatialDataFolder, fileName
 					+ "_line");
 		if (polygonFeatureHNodeId != "")
-			saveShapefile(polygonFeatureVector, spatialDataFolder, fileName
+			saveShapefile(polygonFeatureList, spatialDataFolder, fileName
 					+ "_polygon");
 
 		saveSpatialDataToZip(spatialDataFolder, fileName);
@@ -619,7 +619,7 @@ public class WorksheetToFeatureCollection {
 		 * )); style.createAndSetLineStyle().withColor("501400FF").withWidth(2);
 		 * style.createAndSetPolyStyle().withColor("5014F000");
 		 */
-		for (SimpleFeature pointFeature : pointFeatureVector) {
+		for (SimpleFeature pointFeature : pointFeatureList) {
 
 			CoordinateReferenceSystem sourceCRS = pointFeature.getType()
 					.getCoordinateReferenceSystem();
@@ -660,7 +660,7 @@ public class WorksheetToFeatureCollection {
 			kmlLookAtX += p.getX();
 			kmlLookAtY += p.getY();
 		}
-		for (SimpleFeature lineFeature : lineFeatureVector) {
+		for (SimpleFeature lineFeature : lineFeatureList) {
 			String htmlDescription = getHTMLDescription(lineFeature);
 
 			CoordinateReferenceSystem sourceCRS = lineFeature.getType()
@@ -700,7 +700,7 @@ public class WorksheetToFeatureCollection {
 					.withAltitudeMode(AltitudeMode.CLAMP_TO_GROUND)
 					.setCoordinates(coordsList);
 		}
-		for (SimpleFeature polygonFeature : polygonFeatureVector) {
+		for (SimpleFeature polygonFeature : polygonFeatureList) {
 			
 
 			CoordinateReferenceSystem sourceCRS = polygonFeature.getType()
@@ -896,8 +896,8 @@ public class WorksheetToFeatureCollection {
 	}
 
 	public boolean hasNoGeospatialData() {
-		if (pointFeatureVector.size() == 0 && lineFeatureVector.size() == 0
-				&& polygonFeatureVector.size() == 0)
+		if (pointFeatureList.size() == 0 && lineFeatureList.size() == 0
+				&& polygonFeatureList.size() == 0)
 			return true;
 		return false;
 	}

--- a/src/main/java/edu/isi/karma/geospatial/WorksheetToFeatureCollection.java
+++ b/src/main/java/edu/isi/karma/geospatial/WorksheetToFeatureCollection.java
@@ -77,9 +77,9 @@ import de.micromata.opengis.kml.v_2_2_0.Icon;
 import de.micromata.opengis.kml.v_2_2_0.Kml;
 import de.micromata.opengis.kml.v_2_2_0.KmlFactory;
 import de.micromata.opengis.kml.v_2_2_0.LinearRing;
+import de.micromata.opengis.kml.v_2_2_0.LookAt;
 import de.micromata.opengis.kml.v_2_2_0.Placemark;
 import de.micromata.opengis.kml.v_2_2_0.Style;
-import de.micromata.opengis.kml.v_2_2_0.LookAt;
 import edu.isi.karma.modeling.Namespaces;
 import edu.isi.karma.modeling.ontology.OntologyManager;
 import edu.isi.karma.rep.HNode;
@@ -95,9 +95,9 @@ public class WorksheetToFeatureCollection {
 	private Worksheet worksheet;
 	private OntologyManager om;
 
-	List<SimpleFeature> pointFeatureList = new ArrayList<SimpleFeature>();
-	List<SimpleFeature> lineFeatureList = new ArrayList<SimpleFeature>();
-	List<SimpleFeature> polygonFeatureList = new ArrayList<SimpleFeature>();
+	List<SimpleFeature> pointFeatureVector = new ArrayList<SimpleFeature>();
+	List<SimpleFeature> lineFeatureVector = new ArrayList<SimpleFeature>();
+	List<SimpleFeature> polygonFeatureVector = new ArrayList<SimpleFeature>();
 	List<AttributeDescriptor> featureSchema = new ArrayList<AttributeDescriptor>();
 	List<String> geomHNodeIdList = new ArrayList<String>();
 	List<String> modeledHNodeIds = new ArrayList<String>();
@@ -202,17 +202,17 @@ public class WorksheetToFeatureCollection {
 		prepareFeatureSchema();
 		if (pointFeatureHNodeId != "")
 			populateSimpleFeatures(pointFeatureHNodeId,
-					"", getRows(), pointFeatureList, Point.class);
+					"", getRows(), pointFeatureVector, Point.class);
 		if (pointFeatureLatHNodeId != "" && pointFeatureLonHNodeId != "")
 			populateSimpleFeatures(pointFeatureLonHNodeId,
-					pointFeatureLatHNodeId, getRows(), pointFeatureList,
+					pointFeatureLatHNodeId, getRows(), pointFeatureVector,
 					Point.class);
 		if (lineFeatureHNodeId != "")
 			populateSimpleFeatures(lineFeatureHNodeId, "",
-					getRows(), lineFeatureList, LineString.class);
+					getRows(), lineFeatureVector, LineString.class);
 		if (polygonFeatureHNodeId != "")
 			populateSimpleFeatures(polygonFeatureHNodeId,
-					"", getRows(), polygonFeatureList, Polygon.class);
+					"", getRows(), polygonFeatureVector, Polygon.class);
 	}
 	private void prepareFeatureSchema() {
 		List<String> spatialHNodeIds = new ArrayList<String>();
@@ -409,13 +409,13 @@ public class WorksheetToFeatureCollection {
 		File kml = publishKML(spatialDataFolder, fileName);
 		if (pointFeatureHNodeId != ""
 				|| (pointFeatureLatHNodeId != "" && pointFeatureLonHNodeId != ""))
-			saveShapefile(pointFeatureList, spatialDataFolder, fileName
+			saveShapefile(pointFeatureVector, spatialDataFolder, fileName
 					+ "_point");
 		if (lineFeatureHNodeId != "")
-			saveShapefile(lineFeatureList, spatialDataFolder, fileName
+			saveShapefile(lineFeatureVector, spatialDataFolder, fileName
 					+ "_line");
 		if (polygonFeatureHNodeId != "")
-			saveShapefile(polygonFeatureList, spatialDataFolder, fileName
+			saveShapefile(polygonFeatureVector, spatialDataFolder, fileName
 					+ "_polygon");
 
 		saveSpatialDataToZip(spatialDataFolder, fileName);
@@ -457,13 +457,13 @@ public class WorksheetToFeatureCollection {
 		File kml = publishKML(spatialDataFolder, fileName);
 		if (pointFeatureHNodeId != ""
 				|| (pointFeatureLatHNodeId != "" && pointFeatureLonHNodeId != ""))
-			saveShapefile(pointFeatureList, spatialDataFolder, fileName
+			saveShapefile(pointFeatureVector, spatialDataFolder, fileName
 					+ "_point");
 		if (lineFeatureHNodeId != "")
-			saveShapefile(lineFeatureList, spatialDataFolder, fileName
+			saveShapefile(lineFeatureVector, spatialDataFolder, fileName
 					+ "_line");
 		if (polygonFeatureHNodeId != "")
-			saveShapefile(polygonFeatureList, spatialDataFolder, fileName
+			saveShapefile(polygonFeatureVector, spatialDataFolder, fileName
 					+ "_polygon");
 
 		saveSpatialDataToZip(spatialDataFolder, fileName);
@@ -619,7 +619,7 @@ public class WorksheetToFeatureCollection {
 		 * )); style.createAndSetLineStyle().withColor("501400FF").withWidth(2);
 		 * style.createAndSetPolyStyle().withColor("5014F000");
 		 */
-		for (SimpleFeature pointFeature : pointFeatureList) {
+		for (SimpleFeature pointFeature : pointFeatureVector) {
 
 			CoordinateReferenceSystem sourceCRS = pointFeature.getType()
 					.getCoordinateReferenceSystem();
@@ -660,7 +660,7 @@ public class WorksheetToFeatureCollection {
 			kmlLookAtX += p.getX();
 			kmlLookAtY += p.getY();
 		}
-		for (SimpleFeature lineFeature : lineFeatureList) {
+		for (SimpleFeature lineFeature : lineFeatureVector) {
 			String htmlDescription = getHTMLDescription(lineFeature);
 
 			CoordinateReferenceSystem sourceCRS = lineFeature.getType()
@@ -700,7 +700,7 @@ public class WorksheetToFeatureCollection {
 					.withAltitudeMode(AltitudeMode.CLAMP_TO_GROUND)
 					.setCoordinates(coordsList);
 		}
-		for (SimpleFeature polygonFeature : polygonFeatureList) {
+		for (SimpleFeature polygonFeature : polygonFeatureVector) {
 			
 
 			CoordinateReferenceSystem sourceCRS = polygonFeature.getType()
@@ -896,8 +896,8 @@ public class WorksheetToFeatureCollection {
 	}
 
 	public boolean hasNoGeospatialData() {
-		if (pointFeatureList.size() == 0 && lineFeatureList.size() == 0
-				&& polygonFeatureList.size() == 0)
+		if (pointFeatureVector.size() == 0 && lineFeatureVector.size() == 0
+				&& polygonFeatureVector.size() == 0)
 			return true;
 		return false;
 	}

--- a/src/main/java/edu/isi/karma/modeling/research/graphmatching/nanoxml/XMLElement.java
+++ b/src/main/java/edu/isi/karma/modeling/research/graphmatching/nanoxml/XMLElement.java
@@ -37,9 +37,12 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.Writer;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Hashtable;
-import java.util.Vector;
+import java.util.List;
+
+import edu.isi.karma.util.Iterator2Enumeration;
 
 
 /**
@@ -85,7 +88,7 @@ public class XMLElement
      *     <li>The keys and the values are strings.
      * </ul></dd></dl>
      */
-    private Hashtable attributes;
+    private Hashtable<String, String> attributes;
 
 
     /**
@@ -98,7 +101,7 @@ public class XMLElement
      *         or a subclass of <code>XMLElement</code>.
      * </ul></dd></dl>
      */
-    private Vector children;
+    private List<XMLElement> children;
 
 
     /**
@@ -419,8 +422,8 @@ public class XMLElement
         this.ignoreCase = ignoreCase;
         this.name = null;
         this.contents = "";
-        this.attributes = new Hashtable();
-        this.children = new Vector();
+        this.attributes = new Hashtable<String, String>();
+        this.children = new ArrayList<XMLElement>();
         this.entities = entities;
         this.lineNr = 0;
         Enumeration enume = this.entities.keys();
@@ -468,7 +471,7 @@ public class XMLElement
      */
     public void addChild(XMLElement child)
     {
-        this.children.addElement(child);
+        this.children.add(child);
     }
 
 
@@ -776,27 +779,21 @@ public class XMLElement
      */
     public Enumeration enumerateChildren()
     {
-        return this.children.elements();
+        return new Iterator2Enumeration<XMLElement>(this.children.iterator());
     }
 
 
     /**
-	 * Returns the child elements as a Vector. It is safe to modify this Vector. <dl><dt><b>Postconditions:</b></dt><dd> <ul><li><code>result != null</code> </ul></dd></dl>
+	 * Returns the child elements as a List. It is safe to modify this List. <dl><dt><b>Postconditions:</b></dt><dd> <ul><li><code>result != null</code> </ul></dd></dl>
 	 * @see nanoxml.XMLElement#addChild(nanoxml.XMLElement)   addChild(XMLElement)
 	 * @see nanoxml.XMLElement#countChildren()
 	 * @see nanoxml.XMLElement#enumerateChildren()
 	 * @see nanoxml.XMLElement#removeChild(nanoxml.XMLElement)   removeChild(XMLElement)
 	 * @uml.property   name="children"
 	 */
-    public Vector getChildren()
+    public List<XMLElement> getChildren()
     {
-        try {
-            return (Vector) this.children.clone();
-        } catch (Exception e) {
-            // this never happens, however, some Java compilers are so
-            // braindead that they require this exception clause
-            return null;
-        }
+    	return new ArrayList<XMLElement>(this.children);
     }
 
 
@@ -1887,7 +1884,7 @@ public class XMLElement
      */
     public void removeChild(XMLElement child)
     {
-        this.children.removeElement(child);
+        this.children.remove(child);
     }
 
 

--- a/src/main/java/edu/isi/karma/modeling/research/graphmatching/net/n3/nanoxml/IXMLElement.java
+++ b/src/main/java/edu/isi/karma/modeling/research/graphmatching/net/n3/nanoxml/IXMLElement.java
@@ -29,11 +29,9 @@
 package edu.isi.karma.modeling.research.graphmatching.net.n3.nanoxml;
 
 
-import java.io.Serializable;
 import java.util.Enumeration;
-import java.util.Hashtable;
+import java.util.List;
 import java.util.Properties;
-import java.util.Vector;
 
 
 /**
@@ -178,7 +176,7 @@ public interface IXMLElement
     *
     * @return the non-null enumeration
     */
-   public Enumeration enumerateChildren();
+   public Enumeration<IXMLElement> enumerateChildren();
 
 
    /**
@@ -210,7 +208,7 @@ public interface IXMLElement
     *
     * @return the vector.
     */
-   public Vector getChildren();
+   public List<IXMLElement> getChildren();
 
 
    /**
@@ -256,7 +254,7 @@ public interface IXMLElement
     *
     * @return the non-null vector of child elements.
     */
-   public Vector getChildrenNamed(String name);
+   public List<IXMLElement> getChildrenNamed(String name);
 
 
    /**
@@ -267,7 +265,7 @@ public interface IXMLElement
     *
     * @return the non-null vector of child elements.
     */
-   public Vector getChildrenNamed(String name,
+   public List<IXMLElement> getChildrenNamed(String name,
                                   String namespace);
 
 
@@ -419,7 +417,7 @@ public interface IXMLElement
     *
     * @return the non-null enumeration.
     */
-   public Enumeration enumerateAttributeNames();
+   public Enumeration<String> enumerateAttributeNames();
 
 
    /**

--- a/src/main/java/edu/isi/karma/modeling/research/graphmatching/net/n3/nanoxml/StdXMLParser.java
+++ b/src/main/java/edu/isi/karma/modeling/research/graphmatching/net/n3/nanoxml/StdXMLParser.java
@@ -29,12 +29,11 @@
 package edu.isi.karma.modeling.research.graphmatching.net.n3.nanoxml;
 
 
-import java.io.IOException;
-import java.io.CharArrayReader;
 import java.io.Reader;
+import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Properties;
-import java.util.Vector;
 
 
 /**
@@ -463,9 +462,9 @@ public class StdXMLParser
          name = name.substring(colonIndex + 1);
       }
 
-      Vector attrNames = new Vector();
-      Vector attrValues = new Vector();
-      Vector attrTypes = new Vector();
+      List<String> attrNames = new ArrayList<String>();
+      List<String> attrValues = new ArrayList<String>();
+      List<String> attrTypes = new ArrayList<String>();
 
       this.validator.elementStarted(fullName,
                                     this.reader.getSystemID(),
@@ -494,15 +493,15 @@ public class StdXMLParser
       while (enume.hasMoreElements()) {
          String key = (String) enume.nextElement();
          String value = extraAttributes.getProperty(key);
-         attrNames.addElement(key);
-         attrValues.addElement(value);
-         attrTypes.addElement("CDATA");
+         attrNames.add(key);
+         attrValues.add(value);
+         attrTypes.add("CDATA");
       }
 
       for (int i = 0; i < attrNames.size(); i++) {
-         String key = (String) attrNames.elementAt(i);
-         String value = (String) attrValues.elementAt(i);
-         String type = (String) attrTypes.elementAt(i);
+         String key = attrNames.get(i);
+         String value = attrValues.get(i);
+         String type = attrTypes.get(i);
 
          if (key.equals("xmlns")) {
             defaultNamespace = value;
@@ -523,14 +522,14 @@ public class StdXMLParser
       }
 
       for (int i = 0; i < attrNames.size(); i++) {
-         String key = (String) attrNames.elementAt(i);
+         String key = attrNames.get(i);
 
          if (key.startsWith("xmlns")) {
             continue;
          }
 
-         String value = (String) attrValues.elementAt(i);
-         String type = (String) attrTypes.elementAt(i);
+         String value = attrValues.get(i);
+         String type = attrTypes.get(i);
          colonIndex = key.indexOf(':');
 
          if (colonIndex > 0) {
@@ -658,9 +657,9 @@ public class StdXMLParser
     * @throws java.lang.Exception
     *     if something went wrong
     */
-   protected void processAttribute(Vector attrNames,
-                                   Vector attrValues,
-                                   Vector attrTypes)
+   protected void processAttribute(List<String> attrNames,
+                                   List<String> attrValues,
+                                   List<String> attrTypes)
       throws Exception
    {
       String key = XMLUtil.scanIdentifier(this.reader);
@@ -675,9 +674,9 @@ public class StdXMLParser
       XMLUtil.skipWhitespace(this.reader, null);
       String value = XMLUtil.scanString(this.reader, '&',
                                         this.entityResolver);
-      attrNames.addElement(key);
-      attrValues.addElement(value);
-      attrTypes.addElement("CDATA");
+      attrNames.add(key);
+      attrValues.add(value);
+      attrTypes.add("CDATA");
       this.validator.attributeAdded(key, value,
                                     this.reader.getSystemID(),
                                     this.reader.getLineNr());

--- a/src/main/java/edu/isi/karma/modeling/research/graphmatching/net/n3/nanoxml/StdXMLReader.java
+++ b/src/main/java/edu/isi/karma/modeling/research/graphmatching/net/n3/nanoxml/StdXMLReader.java
@@ -29,15 +29,14 @@
 package edu.isi.karma.modeling.research.graphmatching.net.n3.nanoxml;
 
 
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.IOException;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.LineNumberReader;
-import java.io.PushbackReader;
 import java.io.PushbackInputStream;
+import java.io.PushbackReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
@@ -114,7 +113,7 @@ public class StdXMLReader
       r.setSystemID(filename);
 
       for (int i = 0; i < r.readers.size(); i++) {
-         StackedReader sr = (StackedReader) r.readers.elementAt(i);
+         StackedReader sr = (StackedReader) r.readers.get(i);
          sr.systemId = r.currentReader.systemId;
       }
 

--- a/src/main/java/edu/isi/karma/modeling/research/graphmatching/net/n3/nanoxml/XMLElement.java
+++ b/src/main/java/edu/isi/karma/modeling/research/graphmatching/net/n3/nanoxml/XMLElement.java
@@ -29,12 +29,14 @@
 package edu.isi.karma.modeling.research.graphmatching.net.n3.nanoxml;
 
 
-import java.io.FileReader;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.Hashtable;
+import java.util.List;
 import java.util.Properties;
-import java.util.Vector;
+//import java.util.Vector;
+
+import edu.isi.karma.util.Iterator2Enumeration;
 
 
 /**
@@ -63,13 +65,13 @@ public class XMLElement implements IXMLElement, Serializable {
     /**
      * The attributes of the element.
      */
-    private Vector attributes;
+    private ArrayList<XMLAttribute> attributes;
 
 
     /**
      * The child elements.
      */
-    private Vector children;
+    private ArrayList<IXMLElement> children;
 
 
     /**
@@ -164,8 +166,8 @@ public class XMLElement implements IXMLElement, Serializable {
                       String namespace,
                       String systemID,
                       int    lineNr) {
-        this.attributes = new Vector();
-        this.children = new Vector(8);
+        this.attributes = new ArrayList<XMLAttribute>();
+        this.children = new ArrayList<IXMLElement>(8);
         this.fullName = fullName;
         if (namespace == null) {
             this.name = fullName;
@@ -342,7 +344,7 @@ public class XMLElement implements IXMLElement, Serializable {
             throw new IllegalArgumentException("child must not be null");
         }
         if ((child.getName() == null) && (! this.children.isEmpty())) {
-            IXMLElement lastChild = (IXMLElement) this.children.lastElement();
+            IXMLElement lastChild = (IXMLElement) this.children.get(this.children.size()-1);
 
             if (lastChild.getName() == null) {
                 lastChild.setContent(lastChild.getContent()
@@ -351,7 +353,7 @@ public class XMLElement implements IXMLElement, Serializable {
             }
         }
         ((XMLElement)child).parent = this;
-        this.children.addElement(child);
+        this.children.add(child);
     }
 
 
@@ -367,7 +369,7 @@ public class XMLElement implements IXMLElement, Serializable {
             throw new IllegalArgumentException("child must not be null");
         }
         if ((child.getName() == null) && (! this.children.isEmpty())) {
-            IXMLElement lastChild = (IXMLElement) this.children.lastElement();
+            IXMLElement lastChild = (IXMLElement) this.children.get(this.children.size()-1);
             if (lastChild.getName() == null) {
                 lastChild.setContent(lastChild.getContent()
                                      + child.getContent());
@@ -375,7 +377,7 @@ public class XMLElement implements IXMLElement, Serializable {
             }
         }
         ((XMLElement) child).parent = this;
-        this.children.insertElementAt(child, index);
+        this.children.add(index, child);
     }
 
 
@@ -388,7 +390,7 @@ public class XMLElement implements IXMLElement, Serializable {
         if (child == null) {
             throw new IllegalArgumentException("child must not be null");
         }
-        this.children.removeElement(child);
+        this.children.remove(child);
     }
 
 
@@ -398,7 +400,7 @@ public class XMLElement implements IXMLElement, Serializable {
      * @param index the index of the child, where the first child has index 0.
      */
     public void removeChildAtIndex(int index) {
-        this.children.removeElementAt(index);
+        this.children.remove(index);
     }
 
 
@@ -407,8 +409,8 @@ public class XMLElement implements IXMLElement, Serializable {
      *
      * @return the non-null enumeration
      */
-    public Enumeration enumerateChildren() {
-        return this.children.elements();
+    public Enumeration<IXMLElement> enumerateChildren() {
+        return new Iterator2Enumeration<IXMLElement>(this.children.iterator());
     }
 
 
@@ -443,11 +445,11 @@ public class XMLElement implements IXMLElement, Serializable {
 
 
     /**
-	 * Returns a vector containing all the child elements.
-	 * @return   the vector.
+	 * Returns a Vector containing all the child elements.
+	 * @return   the Vector.
 	 * @uml.property   name="children"
 	 */
-    public Vector getChildren() {
+    public ArrayList<IXMLElement> getChildren() {
         return this.children;
     }
 
@@ -464,7 +466,7 @@ public class XMLElement implements IXMLElement, Serializable {
      */
     public IXMLElement getChildAtIndex(int index)
     throws ArrayIndexOutOfBoundsException {
-        return (IXMLElement) this.children.elementAt(index);
+        return (IXMLElement) this.children.get(index);
     }
     
 
@@ -476,9 +478,7 @@ public class XMLElement implements IXMLElement, Serializable {
      * @return the child element, or null if no such child was found.
      */
     public IXMLElement getFirstChildNamed(String name) {
-        Enumeration enume = this.children.elements();
-        while (enume.hasMoreElements()) {
-            IXMLElement child = (IXMLElement) enume.nextElement();
+        for (IXMLElement child : this.children) {
             String childName = child.getFullName();
             if ((childName != null) && childName.equals(name)) {
                 return child;
@@ -498,9 +498,7 @@ public class XMLElement implements IXMLElement, Serializable {
      */
     public IXMLElement getFirstChildNamed(String name,
                                           String namespace) {
-        Enumeration enume = this.children.elements();
-        while (enume.hasMoreElements()) {
-            IXMLElement child = (IXMLElement) enume.nextElement();
+        for (IXMLElement child : this.children) {
             String str = child.getName();
             boolean found = (str != null) && (str.equals(name));
             str = child.getNamespace();
@@ -518,20 +516,18 @@ public class XMLElement implements IXMLElement, Serializable {
 
 
     /**
-     * Returns a vector of all child elements named <I>name</I>.
+     * Returns a Vector of all child elements named <I>name</I>.
      *
      * @param name the full name of the children to search for.
      *
-     * @return the non-null vector of child elements.
+     * @return the non-null Vector of child elements.
      */
-    public Vector getChildrenNamed(String name) {
-        Vector result = new Vector(this.children.size());
-        Enumeration enume = this.children.elements();
-        while (enume.hasMoreElements()) {
-            IXMLElement child = (IXMLElement) enume.nextElement();
+    public List<IXMLElement> getChildrenNamed(String name) {
+        List<IXMLElement> result = new ArrayList<IXMLElement>(this.children.size());
+        for (IXMLElement child : this.children) {
             String childName = child.getFullName();
             if ((childName != null) && childName.equals(name)) {
-                result.addElement(child);
+                result.add(child);
             }
         }
         return result;
@@ -539,19 +535,17 @@ public class XMLElement implements IXMLElement, Serializable {
 
 
     /**
-     * Returns a vector of all child elements named <I>name</I>.
+     * Returns a Vector of all child elements named <I>name</I>.
      *
      * @param name      the name of the children to search for.
      * @param namespace the namespace, which may be null.
      *
-     * @return the non-null vector of child elements.
+     * @return the non-null Vector of child elements.
      */
-    public Vector getChildrenNamed(String name,
+    public List<IXMLElement> getChildrenNamed(String name,
                                    String namespace) {
-        Vector result = new Vector(this.children.size());
-        Enumeration enume = this.children.elements();
-        while (enume.hasMoreElements()) {
-            IXMLElement child = (IXMLElement) enume.nextElement();
+    	List<IXMLElement> result = new ArrayList<IXMLElement>(this.children.size());
+        for (IXMLElement child : this.children) {
             String str = child.getName();
             boolean found = (str != null) && (str.equals(name));
             str = child.getNamespace();
@@ -562,7 +556,7 @@ public class XMLElement implements IXMLElement, Serializable {
             }
 
             if (found) {
-                result.addElement(child);
+                result.add(child);
             }
         }
         return result;
@@ -577,9 +571,7 @@ public class XMLElement implements IXMLElement, Serializable {
      * @return the attribute, or null if the attribute does not exist.
      */
     private XMLAttribute findAttribute(String fullName) {
-        Enumeration enume = this.attributes.elements();
-        while (enume.hasMoreElements()) {
-            XMLAttribute attr = (XMLAttribute) enume.nextElement();
+        for (XMLAttribute attr : this.attributes) {
             if (attr.getFullName().equals(fullName)) {
                 return attr;
             }
@@ -598,9 +590,7 @@ public class XMLElement implements IXMLElement, Serializable {
      */
     private XMLAttribute findAttribute(String name,
                                        String namespace) {
-        Enumeration enume = this.attributes.elements();
-        while (enume.hasMoreElements()) {
-            XMLAttribute attr = (XMLAttribute) enume.nextElement();
+        for (XMLAttribute attr : this.attributes) {
             boolean found = attr.getName().equals(name);
             if (namespace == null) {
                 found &= (attr.getNamespace() == null);
@@ -775,7 +765,7 @@ public class XMLElement implements IXMLElement, Serializable {
         XMLAttribute attr = this.findAttribute(name);
         if (attr == null) {
             attr = new XMLAttribute(name, name, null, value, "CDATA");
-            this.attributes.addElement(attr);
+            this.attributes.add(attr);
         } else {
             attr.setValue(value);
         }
@@ -797,7 +787,7 @@ public class XMLElement implements IXMLElement, Serializable {
         XMLAttribute attr = this.findAttribute(name, namespace);
         if (attr == null) {
             attr = new XMLAttribute(fullName, name, namespace, value, "CDATA");
-            this.attributes.addElement(attr);
+            this.attributes.add(attr);
         } else {
             attr.setValue(value);
         }
@@ -811,9 +801,9 @@ public class XMLElement implements IXMLElement, Serializable {
      */
     public void removeAttribute(String name) {
         for (int i = 0; i < this.attributes.size(); i++) {
-            XMLAttribute attr = (XMLAttribute) this.attributes.elementAt(i);
+            XMLAttribute attr = (XMLAttribute) this.attributes.get(i);
             if (attr.getFullName().equals(name)) {
-                this.attributes.removeElementAt(i);
+                this.attributes.remove(i);
                 return;
             }
         }
@@ -829,7 +819,7 @@ public class XMLElement implements IXMLElement, Serializable {
     public void removeAttribute(String name,
                                 String namespace) {
         for (int i = 0; i < this.attributes.size(); i++) {
-            XMLAttribute attr = (XMLAttribute) this.attributes.elementAt(i);
+            XMLAttribute attr = (XMLAttribute) this.attributes.get(i);
             boolean found = attr.getName().equals(name);
             if (namespace == null) {
                 found &= (attr.getNamespace() == null);
@@ -838,7 +828,7 @@ public class XMLElement implements IXMLElement, Serializable {
             }
 
             if (found) {
-                this.attributes.removeElementAt(i);
+                this.attributes.remove(i);
                 return;
             }
         }
@@ -850,14 +840,12 @@ public class XMLElement implements IXMLElement, Serializable {
      *
      * @return the non-null enumeration.
      */
-    public Enumeration enumerateAttributeNames() {
-        Vector result = new Vector();
-        Enumeration enume = this.attributes.elements();
-        while (enume.hasMoreElements()) {
-            XMLAttribute attr = (XMLAttribute) enume.nextElement();
-            result.addElement(attr.getFullName());
+    public Enumeration<String> enumerateAttributeNames() {
+    	List<String> result = new ArrayList<String>();
+        for (XMLAttribute attr : this.attributes) {
+            result.add(attr.getFullName());
         }
-        return result.elements();
+        return new Iterator2Enumeration<String>(result.iterator());
     }
 
 
@@ -889,9 +877,7 @@ public class XMLElement implements IXMLElement, Serializable {
 	 */
     public Properties getAttributes() {
         Properties result = new Properties();
-        Enumeration enume = this.attributes.elements();
-        while (enume.hasMoreElements()) {
-            XMLAttribute attr = (XMLAttribute) enume.nextElement();
+        for (XMLAttribute attr : this.attributes) {
             result.put(attr.getFullName(), attr.getValue());
         }
         return result;
@@ -907,9 +893,7 @@ public class XMLElement implements IXMLElement, Serializable {
      */
     public Properties getAttributesInNamespace(String namespace) {
         Properties result = new Properties();
-        Enumeration enume = this.attributes.elements();
-        while (enume.hasMoreElements()) {
-            XMLAttribute attr = (XMLAttribute) enume.nextElement();
+        for (XMLAttribute attr : this.attributes) {
             if (namespace == null) {
                 if (attr.getNamespace() == null) {
                     result.put(attr.getName(), attr.getValue());
@@ -993,9 +977,7 @@ public class XMLElement implements IXMLElement, Serializable {
         if (this.attributes.size() != elt.getAttributeCount()) {
             return false;
         }
-        Enumeration enume = this.attributes.elements();
-        while (enume.hasMoreElements()) {
-            XMLAttribute attr = (XMLAttribute) enume.nextElement();
+        for (XMLAttribute attr : this.attributes) {
             if (! elt.hasAttribute(attr.getName(), attr.getNamespace())) {
                 return false;
             }

--- a/src/main/java/edu/isi/karma/modeling/research/graphmatching/net/n3/nanoxml/XMLWriter.java
+++ b/src/main/java/edu/isi/karma/modeling/research/graphmatching/net/n3/nanoxml/XMLWriter.java
@@ -33,8 +33,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.Vector;
+import java.util.List;
 
 
 /**
@@ -168,7 +169,7 @@ public class XMLWriter
       } else {
          this.writer.print('<');
          this.writer.print(xml.getFullName());
-         Vector nsprefixes = new Vector();
+         List nsprefixes = new ArrayList();
 
          if (xml.getNamespace() != null) {
             if (xml.getName().equals(xml.getFullName())) {
@@ -176,7 +177,7 @@ public class XMLWriter
             } else {
                String prefix = xml.getFullName();
                prefix = prefix.substring(0, prefix.indexOf(':'));
-               nsprefixes.addElement(prefix);
+               nsprefixes.add(prefix);
                this.writer.print(" xmlns:" + prefix);
                this.writer.print("=\"" + xml.getNamespace() + "\"");
             }
@@ -197,7 +198,7 @@ public class XMLWriter
                   if (! nsprefixes.contains(prefix)) {
                      this.writer.print(" xmlns:" + prefix);
                      this.writer.print("=\"" + namespace + '"');
-                     nsprefixes.addElement(prefix);
+                     nsprefixes.add(prefix);
                   }
                }
             }

--- a/src/main/java/edu/isi/karma/modeling/research/graphmatching/xml/XMLParser.java
+++ b/src/main/java/edu/isi/karma/modeling/research/graphmatching/xml/XMLParser.java
@@ -4,7 +4,7 @@ package edu.isi.karma.modeling.research.graphmatching.xml;
 
 import java.io.FileReader;
 import java.util.Enumeration;
-import java.util.Vector;
+import java.util.List;
 
 import edu.isi.karma.modeling.research.graphmatching.nanoxml.XMLElement;
 import edu.isi.karma.modeling.research.graphmatching.util.Edge;
@@ -35,7 +35,7 @@ public class XMLParser {
 		FileReader reader = new FileReader(filename);
 		xml.parseFromReader(reader);
 		GraphSet graphSet = new GraphSet();
-		Vector<XMLElement> children = xml.getChildren();
+		List<XMLElement> children = xml.getChildren();
 		XMLElement root = children.get(0);
 		Enumeration<XMLElement> enumerator = root.enumerateChildren();
 		int i = 1;
@@ -62,7 +62,7 @@ public class XMLParser {
 		xml.parseFromReader(reader);
 		reader.close();
 		Graph graph1 = new Graph();
-		Vector children = xml.getChildren();
+		List children = xml.getChildren();
 		XMLElement root = (XMLElement) children.get(0);
 		String id = (String) root.getAttribute("id", null);
 		String edgemode = (String) root.getAttribute("edgemode", "undirected");
@@ -85,7 +85,7 @@ public class XMLParser {
 					XMLElement child1 = (XMLElement) enum1.nextElement();
 					if (child1.getName().equals("attr")) {
 						String key = (String) child1.getAttribute("name", null);
-						Vector children2 = child1.getChildren();
+						List children2 = child1.getChildren();
 						XMLElement child2 = (XMLElement) children2.get(0);
 						String value = child2.getContent();
 						node.put(key, value);
@@ -115,7 +115,7 @@ public class XMLParser {
 					if (child1.getName().equals("attr")) {
 						String key = (String) child1.getAttribute("name",
 								"key failed!");
-						Vector children2 = child1.getChildren();
+						List children2 = child1.getChildren();
 						XMLElement child2 = (XMLElement) children2.get(0);
 						String value = child2.getContent();
 						edge.put(key, value);
@@ -157,7 +157,7 @@ public class XMLParser {
 		XMLElement xml = new XMLElement();
 		xml.parseString(graph);
 		Graph graph1 = new Graph();
-		Vector children = xml.getChildren();
+		List children = xml.getChildren();
 		XMLElement root = (XMLElement) children.get(0);
 		String id = (String) root.getAttribute("id", null);
 		String edgemode = (String) root.getAttribute("edgemode", "undirected");
@@ -180,7 +180,7 @@ public class XMLParser {
 					XMLElement child1 = (XMLElement) enum1.nextElement();
 					if (child1.getName().equals("attr")) {
 						String key = (String) child1.getAttribute("name", null);
-						Vector children2 = child1.getChildren();
+						List children2 = child1.getChildren();
 						XMLElement child2 = (XMLElement) children2.get(0);
 						String value = child2.getContent();
 						node.put(key, value);
@@ -210,7 +210,7 @@ public class XMLParser {
 					if (child1.getName().equals("attr")) {
 						String key = (String) child1.getAttribute("name",
 								"key failed!");
-						Vector children2 = child1.getChildren();
+						List children2 = child1.getChildren();
 						XMLElement child2 = (XMLElement) children2.get(0);
 						String value = child2.getContent();
 						edge.put(key, value);

--- a/src/main/java/edu/isi/karma/rep/cleaning/RamblerTransformation.java
+++ b/src/main/java/edu/isi/karma/rep/cleaning/RamblerTransformation.java
@@ -20,7 +20,8 @@
  ******************************************************************************/
 package edu.isi.karma.rep.cleaning;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 import edu.isi.karma.cleaning.InterpreterType;
 import edu.isi.karma.cleaning.ProgramRule;
@@ -29,7 +30,7 @@ import edu.isi.karma.cleaning.ProgramRule;
 
 public class RamblerTransformation implements Transformation {
 
-	private Vector<String> rules = new Vector<String>();
+	private List<String> rules = new ArrayList<String>();
 	public String signature = "";
 	private ProgramRule prog;
 	public RamblerTransformation(ProgramRule prog)

--- a/src/main/java/edu/isi/karma/rep/cleaning/RamblerTransformationOutput.java
+++ b/src/main/java/edu/isi/karma/rep/cleaning/RamblerTransformationOutput.java
@@ -20,10 +20,11 @@
  ******************************************************************************/
 package edu.isi.karma.rep.cleaning;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Vector;
+import java.util.List;
 
 import edu.isi.karma.cleaning.ProgSynthesis;
 import edu.isi.karma.cleaning.ProgramRule;
@@ -47,7 +48,7 @@ public class RamblerTransformationOutput implements TransformationOutput {
 	private void learnTransformation() throws Exception
 	{
 		Collection<TransformationExample> exs =  input.getExamples();
-		Vector<String[]> exps = new Vector<String[]>();
+		List<String[]> exps = new ArrayList<String[]>();
 		Iterator<TransformationExample> iter = exs.iterator();
 		while(iter.hasNext())
 		{
@@ -63,7 +64,7 @@ public class RamblerTransformationOutput implements TransformationOutput {
 			ProgramRule r = new ProgramRule(ProgramRule.IDENTITY);
 			r.nullRule = true;
 			this.nullRule = true;
-			rules = new Vector<ProgramRule>();
+			rules = new ArrayList<ProgramRule>();
 			rules.add(r);
 			//return;
 		}

--- a/src/main/java/edu/isi/karma/util/Iterator2Enumeration.java
+++ b/src/main/java/edu/isi/karma/util/Iterator2Enumeration.java
@@ -1,0 +1,23 @@
+package edu.isi.karma.util;
+
+import java.util.Enumeration;
+import java.util.Iterator;
+
+public class Iterator2Enumeration<E> implements Enumeration<E> {
+
+	private Iterator<E> iterator;
+	
+	public Iterator2Enumeration(Iterator<E> iter) {
+		this.iterator = iter;
+	}
+	
+	@Override
+	public boolean hasMoreElements() {
+		return iterator.hasNext();
+	}
+	
+	@Override
+	public E nextElement() {
+		return iterator.next();
+	}
+}

--- a/src/main/java/edu/isi/karma/webserver/helper/CreateGeoBuildingForTable.java
+++ b/src/main/java/edu/isi/karma/webserver/helper/CreateGeoBuildingForTable.java
@@ -5,10 +5,10 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Vector;
 
 import org.dom4j.Attribute;
 import org.dom4j.Document;
@@ -38,14 +38,14 @@ public class CreateGeoBuildingForTable {
 	}
 
 	private <T> List<T> castList(Class<T> clazz, Collection<?> c) {
-		List<T> list = new Vector<T>(c.size());
+		List<T> list = new ArrayList<T>(c.size());
 		for (Object object : c) {
 			list.add(clazz.cast(object));
 		}
 		return list;
 	}
 	private <T> List<T> castIterator(Class<T> clazz, Iterator<?> i) {
-		List<T> list = new Vector<T>();
+		List<T> list = new ArrayList<T>();
 		while(i.hasNext()) {
 			list.add(clazz.cast(i.next()));
 		}

--- a/src/main/java/edu/isi/karma/webserver/helper/CreateGeoStreetForTable.java
+++ b/src/main/java/edu/isi/karma/webserver/helper/CreateGeoStreetForTable.java
@@ -5,10 +5,10 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Vector;
 
 import org.dom4j.Attribute;
 import org.dom4j.Document;
@@ -38,7 +38,7 @@ public class CreateGeoStreetForTable {
 	}
 
 	private <T> List<T> castList(Class<T> clazz, Collection<?> c) {
-		List<T> list = new Vector<T>(c.size());
+		List<T> list = new ArrayList<T>(c.size());
 		for (Object object : c) {
 			list.add(clazz.cast(object));
 		}
@@ -46,7 +46,7 @@ public class CreateGeoStreetForTable {
 	}
 	
 	private <T> List<T> castIterator(Class<T> clazz, Iterator<?> i) {
-		List<T> list = new Vector<T>();
+		List<T> list = new ArrayList<T>();
 		while(i.hasNext()) {
 			list.add(clazz.cast(i.next()));
 		}

--- a/src/main/java/edu/isi/karma/webserver/helper/CreateNodeDataForTable.java
+++ b/src/main/java/edu/isi/karma/webserver/helper/CreateNodeDataForTable.java
@@ -4,10 +4,10 @@ import java.io.File;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Vector;
 
 import org.dom4j.Attribute;
 import org.dom4j.Document;
@@ -34,7 +34,7 @@ public class CreateNodeDataForTable {
 	}
 
 	private <T> List<T> castList(Class<T> clazz, Collection<?> c) {
-		List<T> list = new Vector<T>(c.size());
+		List<T> list = new ArrayList<T>(c.size());
 		for (Object object : c) {
 			list.add(clazz.cast(object));
 		}
@@ -42,7 +42,7 @@ public class CreateNodeDataForTable {
 	}
 
 	private <T> List<T> castIterator(Class<T> clazz, Iterator<?> i) {
-		List<T> list = new Vector<T>();
+		List<T> list = new ArrayList<T>();
 		while (i.hasNext()) {
 			list.add(clazz.cast(i.next()));
 		}

--- a/src/main/java/edu/isi/karma/webserver/helper/CreateWikimapiaInformation.java
+++ b/src/main/java/edu/isi/karma/webserver/helper/CreateWikimapiaInformation.java
@@ -35,7 +35,7 @@ public class CreateWikimapiaInformation {
 	}
 
 //	private <T> List<T> castList(Class<T> clazz, Collection<?> c) {
-//		List<T> list = new Vector<T>(c.size());
+//		List<T> list = new ArrayList<T>(c.size());
 //		for (Object object : c) {
 //			list.add(clazz.cast(object));
 //		}
@@ -43,7 +43,7 @@ public class CreateWikimapiaInformation {
 //	}
 //
 //	private <T> List<T> castIterator(Class<T> clazz, Iterator<?> i) {
-//		List<T> list = new Vector<T>();
+//		List<T> list = new ArrayList<T>();
 //		while (i.hasNext()) {
 //			list.add(clazz.cast(i.next()));
 //		}
@@ -86,7 +86,7 @@ public class CreateWikimapiaInformation {
 			Document document = saxReadering.read(new File(this.osmFile_path));
 			// Document document=saxReadering.read(new
 			// File("/Users/yzhang/Downloads/USC_wikimapia.xml"));
-			 List list = document.selectNodes("//folder/place");
+			List list = document.selectNodes("//folder/place");
 			Iterator iter = list.iterator();
 			System.out.println("begin");
 			// String backid=null;


### PR DESCRIPTION
Vector is a Java 1.0 legacy class which is no longer recommended for use because it is synchronized, causing lower performance, and because it doesn't fit with the rest of the more modern Collections classes.

This pull request changes everything to use List in the API and ArrayList in the implementations.

Not done as part of this, but useful for as a next step would be to switch from using Enumerations (also no longer recommended) to Iterators.  For this piece, to preserve API compatibility, I've introduced an adapter to class to convert iterators to enumerations where needed by the API.
